### PR TITLE
feat(claude): デフォルトの permission mode を acceptEdits にする

### DIFF
--- a/dot/claude/settings.json
+++ b/dot/claude/settings.json
@@ -1,5 +1,6 @@
 {
   "permissions": {
+    "defaultMode": "acceptEdits",
     "allow": [
       "Bash(cd *)",
       "Bash(find *)",


### PR DESCRIPTION
## Summary

- `dot/claude/settings.json` の `permissions` に `"defaultMode": "acceptEdits"` を追加し、Claude Code 起動時のデフォルト権限モードを `acceptEdits` にする。

## Why

ファイル編集を都度承認せずに進める運用を既定にする。`claude-worktree` で分岐した作業は既に `acceptEdits` で自律実行しているため（`bin/claude-worktree` は `claude --permission-mode acceptEdits` で起動）、通常セッションのデフォルトもこれに揃えて挙動を一貫させる。