### PR TITLE
feat(claude): claude-worktree 委譲スキル（delegate-to-worktree / implement-and-review）を追加

### DIFF
--- a/dot/claude/skills/delegate-to-worktree/SKILL.md
+++ b/dot/claude/skills/delegate-to-worktree/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: delegate-to-worktree
 description: WHAT が固まった作業を別 workspace の自律 agent に委譲する。claude-worktree を session 起動形式（-- 付き）で呼び、detached tmux session 内に acceptEdits の claude を起こして implement-and-review skill に着手させる。「claude-worktree で作業して」「claude-worktree で worktree 作成から」「別 worktree / workspace でやらせて」「これを別 agent に任せて」「delegate して」系の依頼で使う。worktree を作るだけ（初期タスクを伴わない）の要求のときだけ add-only で呼ぶ。
-allowed-tools: Bash(claude-worktree *), Bash(claude-worktree), Bash(git worktree list), Bash(git rev-parse *), Read, Glob, Grep
+allowed-tools: Bash(claude-worktree *), Bash(git worktree list), Bash(git rev-parse *), Read, Glob, Grep
 ---
 
 # delegate-to-worktree

--- a/dot/claude/skills/delegate-to-worktree/SKILL.md
+++ b/dot/claude/skills/delegate-to-worktree/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: delegate-to-worktree
+description: WHAT が固まった作業を別 workspace の自律 agent に委譲する。claude-worktree を session 起動形式（-- 付き）で呼び、detached tmux session 内に acceptEdits の claude を起こして implement-and-review skill に着手させる。「claude-worktree で作業して」「claude-worktree で worktree 作成から」「別 worktree / workspace でやらせて」「これを別 agent に任せて」「delegate して」系の依頼で使う。worktree を作るだけ（初期タスクを伴わない）の要求のときだけ add-only で呼ぶ。
+allowed-tools: Bash(claude-worktree *), Bash(claude-worktree), Bash(git worktree list), Bash(git rev-parse *), Read, Glob, Grep
+---
+
+# delegate-to-worktree
+
+固まった作業（WHAT）を、別 workspace の自律 claude に委譲する。`bin/claude-worktree` を
+**session 起動形式**（`--` 付き）で呼び、detached tmux session の中に acceptEdits の
+claude を起こす。起動先は `implement-and-review` skill で HOW を詰め、実装し、merge する。
+
+運用ポリシー（いつ分岐するか・スコープを worktree に閉じるか）は
+`dot/claude/rules/worktree-scope.md` §5 を参照。この skill はその「明示指示パス」の手順を担う。
+
+## Pre-fetched context
+
+!`git worktree list`
+!`git rev-parse --abbrev-ref HEAD`
+
+## 不変条件（厳守）
+
+- **既定は session 起動形式**。必ず `claude-worktree <name> -b <branch> -- "<prompt>"` の
+  `--` 付きで呼ぶ。`--` 無しの add-only モード（path を stdout に出すだけ）は使わない。
+- **add-only 例外**: 「worktree だけ作って」など、明示的に初期タスクを伴わない要求の
+  ときに限り `--` 無しで呼ぶ。判断に迷ったら session 起動を選ぶ。
+- 起動後は fire-and-forget。起動成否の二重検証はしない（重複 session・dir 既存・name 検証は
+  `bin/claude-worktree` 本体が行う）。
+
+## 手順
+
+1. **WHAT が固まっているか確認**。未確定なら、この skill に入る前に
+   `superpowers:brainstorming` で WHAT を詰めること。この skill は WHAT 確定後の委譲を担う。
+2. **自己完結プロンプトを組む**。起動先 claude は会話履歴を持たない。追加質問なしに
+   着手できるよう、目的・背景・制約・関連ファイル・期待成果物を畳み込む。先頭に
+   `implement-and-review` の明示起動命令を置く。フォーマット:
+
+   ```
+   implement-and-review を使って以下のタスクを進めてください。
+
+   ## やること（WHAT）
+   <目的 / 背景 / 制約 / 関連ファイル / 期待成果物 を自己完結で>
+
+   ## 進め方
+   1. まず HOW をユーザーと brainstorm（最初の質問を出して attach を待つ）
+   2. 実装
+   3. pr-review-merge で merge
+   ```
+
+3. **name / branch を決める**。
+   - `<name>`: 依頼内容から簡潔な kebab-case で推論（`[A-Za-z0-9_-]+` のみ）。
+     ユーザーが名を明示していたら最優先。pre-fetch した worktree 一覧と衝突しない名にする。
+   - `-b <branch>`: repo の branch 命名規約に合わせる（例: `feat/<name>`）。
+4. **起動する**: `claude-worktree <name> -b <branch> -- "<prompt>"`.
+5. **報告して終了**: スクリプト出力（worktree / branch / session / attach コマンド）を
+   そのままユーザーに伝える。ユーザーは `gts <session>` で attach して HOW を詰める。

--- a/dot/claude/skills/implement-and-review/SKILL.md
+++ b/dot/claude/skills/implement-and-review/SKILL.md
@@ -10,7 +10,7 @@ HOW の brainstorm → 実装 → merge まで完遂する。`delegate-to-worktr
 プロンプト先頭の明示命令でこの skill に入る。
 
 作業スコープは起動された worktree ディレクトリ内に閉じる
-（`dot/claude/rules/worktree-scope.md` 参照）。
+（`dot/claude/rules/worktree-scope.md` §5 参照）。
 
 ## 入力
 

--- a/dot/claude/skills/implement-and-review/SKILL.md
+++ b/dot/claude/skills/implement-and-review/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: implement-and-review
+description: worktree に委譲されたタスクを brainstorm→実装→merge で完遂する。HOW をユーザーと brainstorm し（detached session のため最初の質問を出して attach を待つ）、実装し、pr-review-merge で自律 merge する。delegate-to-worktree から渡されたプロンプト先頭の明示命令で起動される。
+---
+
+# implement-and-review
+
+別 workspace（detached tmux session, acceptEdits）に委譲されたタスクを、
+HOW の brainstorm → 実装 → merge まで完遂する。`delegate-to-worktree` が渡した
+プロンプト先頭の明示命令でこの skill に入る。
+
+作業スコープは起動された worktree ディレクトリ内に閉じる
+（`dot/claude/rules/worktree-scope.md` 参照）。
+
+## 入力
+
+プロンプトの `## やること（WHAT）` に目的・背景・制約・関連ファイル・期待成果物が
+自己完結で渡される。会話履歴は無い。WHAT はこのプロンプトが唯一の出所。
+
+## 手順
+
+1. **HOW を brainstorm**: `superpowers:brainstorming` を使い、WHAT を「どう実装するか」に
+   落とす。この session は detached で起動直後ユーザーは attach していないため、
+   brainstorming の最初の質問を出した時点で REPL で待機する。ユーザーが
+   `gts <session>` / `tmux attach -t <session>` で attach して HOW を詰める。
+2. **実装**: 設計が固まったら実装する。`superpowers:test-driven-development` 等、
+   repo の規約に従う。コミットは論理単位で小さく。
+3. **review→merge**: 実装が一段落し PR を出したら `pr-review-merge` を呼び、
+   author とは独立した立場でのレビュー・required CI 確認を経て自律 merge する。
+
+## 不変条件
+
+- WHAT を勝手に広げない。委譲されたタスクの範囲で完遂する。
+- worktree ディレクトリ外への書き込みはしない（read-only 参照は可）。


### PR DESCRIPTION
## Summary

`claude-worktree` を使った 2 エージェント・委譲パイプラインを skill 化する。新規 skill は薄いオーケストレータ 2 つで、`superpowers:brainstorming` / `pr-review-merge` は再実装せず呼ぶだけ。

- **`dot/claude/skills/delegate-to-worktree/SKILL.md`**（Agent 1 / launcher）: 固まった作業（WHAT）を自己完結プロンプトに再構成し、`claude-worktree <name> -b <branch> -- "<prompt>"` の **session 起動形式**（detached tmux + acceptEdits の自律 claude）で起動する。既定は session 起動で、「worktree だけ作って」など初期タスクを伴わない要求のときのみ add-only。name/branch は依頼内容から推論（pre-fetch した `git worktree list` / 現在ブランチを衝突回避・規約推論に使用）。起動後は fire-and-forget で worktree/branch/session/attach を報告。
- **`dot/claude/skills/implement-and-review/SKILL.md`**（Agent 2 / worker）: launcher が渡すプロンプト先頭の明示命令で発火し、`superpowers:brainstorming`（HOW、detached なので最初の質問で attach 待ち）→ 実装（`superpowers:test-driven-development`）→ `pr-review-merge` を順に実行する。

## Why

`claude-worktree` を依頼したとき、agent が `--` プロンプト無しの add-only モード（worktree を作り path を stdout に出すだけで tmux session も自律 claude も起動しない）で呼んでしまい、意図した「session を起こして中の claude にやらせる」挙動が得られない失敗があった。launcher の description と本文の両方で session 起動を既定として明記し、この誤用を構造的に防ぐ。運用ポリシーは既存 rule に委ね、skill は手順のみを持つ。

## Refs

- `dot/claude/rules/worktree-scope.md` §5（claude-worktree の運用ポリシー。skill は重複コピーせず参照）
- `bin/claude-worktree`（起動スクリプト本体。`--` 有無で session / add-only が分岐）
- `docs/design/claude-tmux-worktree.md`（git worktree → tmux → claude-queue の 3 層連携）