### PR TITLE
feat(claude): claude-review を headless 化し reviewer の最終レビュー結果を PR に1本投稿する

### DIFF
--- a/bin/claude-review
+++ b/bin/claude-review
@@ -8,6 +8,13 @@ set -euo pipefail
 # the /pr-review-merge skill against the given PR. A new window means a new
 # $TMUX_PANE, so claude-queue tracks the reviewer as its own entry and the
 # author session is untouched -- "1 worktree = 1 tmux session" is preserved.
+#
+# The reviewer runs headless (claude -p): it executes /pr-review-merge to
+# completion and then exits, so tmux closes the window automatically (no
+# remain-on-exit). The review outcome is not kept on screen -- pr-review-merge
+# posts a single standalone report comment to the PR (via gh-pr-report), so the
+# record lives on the PR rather than in a left-open pane.
+#
 # The PR branch is already checked out in this worktree, so no second checkout
 # (and no branch conflict) occurs; the author must hand off (stop editing this
 # branch) once the reviewer is launched.
@@ -31,4 +38,4 @@ if [ -z "${TMUX:-}" ]; then
 fi
 
 tmux new-window -c "$PWD" -n "review-pr${pr}" \
-  claude --permission-mode acceptEdits "/pr-review-merge ${pr}"
+  claude -p --permission-mode acceptEdits "/pr-review-merge ${pr}"

--- a/bin/gh-pr-report
+++ b/bin/gh-pr-report
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gh-pr-report <PR> -- post the reviewer's final report as ONE standalone PR
+# comment. The body is read from stdin (gh --body-file -). This wrapper exists so
+# the pr-review-merge reviewer can leave a single review log without granting raw
+# `gh pr comment`: it takes only a numeric PR number and passes NO other flags
+# (no reply targeting, no --edit-last), so it cannot be coerced into editing or
+# replying to arbitrary comments. Thread replies remain forbidden (see
+# dot/claude/rules/gh-commands.md §3).
+#
+# Usage: gh-pr-report <PR-number>   (comment body on stdin)
+
+usage() { echo "usage: gh-pr-report <PR-number> (body on stdin)" >&2; exit "${1:-1}"; }
+
+[ $# -eq 1 ] || usage 1
+case "$1" in -h|--help) usage 0 ;; esac
+if [[ ! "$1" =~ ^[0-9]+$ ]]; then
+  echo "gh-pr-report: PR number must be numeric (got: $1)" >&2
+  exit 1
+fi
+
+exec gh pr comment "$1" --body-file -

--- a/dot/claude/rules/gh-commands.md
+++ b/dot/claude/rules/gh-commands.md
@@ -92,6 +92,7 @@ PR review・コメント確認を依頼されたとき、**reply コメントの
 | 未解決 thread の取得 | `gh-list-threads <PR>` | read-only reviewThreads query | `Bash(gh-list-threads *)` |
 | thread の resolve | `gh-resolve-thread <id>` | `resolveReviewThread` mutation のみ | `Bash(gh-resolve-thread *)` |
 | merge | `gh-automerge <PR>` | `gh pr merge --auto --merge <PR>` のみ | `Bash(gh-automerge *)` |
+| 最終レポート投稿 | `gh-pr-report <PR>` | `gh pr comment <PR> --body-file -`（stdin 本文）のみ | `Bash(gh-pr-report *)` |
 
 - ラッパーはフラグ素通しをしない。特に `gh-automerge` は `--admin` 等の protection バイパス
   フラグを付けられない。merge 前に skill 自身が `gh pr checks` で required checks の green を
@@ -101,3 +102,7 @@ PR review・コメント確認を依頼されたとき、**reply コメントの
   残してサマリで報告する。
 - ラッパーは **repo 単位**で、特定 PR に固定されない（`gh-automerge <別PR>` も allowlist 上は通る）。`--auto` は branch protection / required checks を尊重するため未通過 PR を強制 merge はできないが、「PR 限定ではない」点は把握しておく。
 - `gh-automerge`（= `gh pr merge --auto`）は **repo で auto-merge が有効**である必要がある。無効な repo では失敗するため、`pr-review-merge` の merge ステップが完了しない（skill は report して停止する）。
+- `gh-pr-report` は **reviewer の最終レポートを1本だけ** standalone コメントとして投稿するための
+  ラッパー。§3 の reply ポリシー（thread への reply 禁止）は維持しつつ、レビュー結果の記録だけを
+  許可する。引数は PR 番号のみで本文は stdin。フラグ素通しが無いため、既存コメントの編集や特定
+  コメントへの reply には使えない。raw `gh pr comment` は引き続き allow しない。

--- a/dot/claude/settings.json
+++ b/dot/claude/settings.json
@@ -86,6 +86,7 @@
       "Bash(gh-list-threads *)",
       "Bash(gh-resolve-thread *)",
       "Bash(gh-automerge *)",
+      "Bash(gh-pr-report *)",
       "Bash(node --version)",
       "Bash(yarn --version)",
       "Bash(uv run ruff format)",

--- a/dot/claude/skills/pr-review-merge/SKILL.md
+++ b/dot/claude/skills/pr-review-merge/SKILL.md
@@ -17,7 +17,7 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
 ## 不変条件（厳守）
 
 - **review thread への reply は投稿しない**（raw `gh pr comment` / thread への reply 禁止）。人間の議論待ち thread は resolve せず残す。
-- ただし**ループ終了後に1回だけ**、reviewer の作業ログ（各イテレーションの 指摘→対応、最終 verdict）を **`gh-pr-report <PR>`** で PR に standalone コメントとして残す（`@mention` は付けない。raw `gh pr comment` は使わない）。
+- ただし**ループ終了後に1回だけ**、reviewer の作業ログ（各イテレーションの 指摘→対応、最終 verdict）を **`gh-pr-report <PR>`** で PR に standalone コメントとして残す（`@mention` は付けない。raw `gh pr comment` は使わない）。本文の先頭行は固定マーカー `pr-review-merge report` を置く（後から grep で識別できるよう）。本文は heredoc 形式 `gh-pr-report <PR> <<'EOF' … EOF` で渡す（`printf | gh-pr-report` は `-p` 実行環境で allowlist 外となりサイレント失敗するため禁止）。
 - merge は **`gh-automerge <PR>`** ラッパーのみ（内部で `gh pr merge --auto --merge`）。事前に required CI の green を確認する。raw `gh pr merge` は使わない。
 - 未解決 thread の取得は **`gh-list-threads <PR>`**、resolve は **`gh-resolve-thread <id>`** ラッパーのみ。raw `gh api graphql` は使わない。
 - 最大 **5 イテレーション**。未収束・CI 連続 fail なら **merge せず停止・報告**。PR は閉じない。
@@ -42,11 +42,11 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
       なので、fail を findings として扱い 2 に戻ってもよいが、合計 5 イテレーションの上限は超えない）。
    c. required が全て pass なら `gh-automerge <PR>` を実行する（内部で `gh pr merge --auto --merge`）。
    d. `gh pr view <PR> --json state,merged --jq '.state, .merged'` で merge を確認し、完了を報告。
-   e. **最終レポート投稿**: 全イテレーションの「指摘→対応」と最終結果（merge 済み）を本文に composing し、`gh-pr-report <PR>` に stdin で渡して PR に1本投稿する。`@mention` は付けない。
+   e. **最終レポート投稿**: 全イテレーションの「指摘→対応」と最終結果（merge 済み。required checks 未確定なら auto-merge 予約済み）を本文に composing し、heredoc 形式 `gh-pr-report <PR> <<'EOF' … EOF` で PR に1本投稿する（`printf |` 禁止）。`@mention` は付けない。
 4. **停止・報告**（merge しなかった場合）: 残った findings / 議論待ち thread / CI 状態を箇条書きで
    要約して出力する。PR は開いたまま、thread への reply は投稿しない（人間が引き取る）。最後に同じ
-   要約（各イテレーションの 指摘→対応 と、停止理由・残課題）を `gh-pr-report <PR>` に stdin で渡して
-   PR に1本投稿する。`@mention` は付けない。
+   要約（各イテレーションの 指摘→対応 と、停止理由・残課題）を heredoc 形式 `gh-pr-report <PR> <<'EOF' … EOF` で
+   PR に1本投稿する（`printf |` 禁止）。`@mention` は付けない。
 
 ## subagent prompt（`<PR>`/`<owner>`/`<repo>` を埋めて Task に渡す）
 

--- a/dot/claude/skills/pr-review-merge/SKILL.md
+++ b/dot/claude/skills/pr-review-merge/SKILL.md
@@ -16,7 +16,8 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
 
 ## 不変条件（厳守）
 
-- reply コメントは**一切投稿しない**（`gh pr comment` / thread への reply 禁止）。
+- **review thread への reply は投稿しない**（raw `gh pr comment` / thread への reply 禁止）。人間の議論待ち thread は resolve せず残す。
+- ただし**ループ終了後に1回だけ**、reviewer の作業ログ（各イテレーションの 指摘→対応、最終 verdict）を **`gh-pr-report <PR>`** で PR に standalone コメントとして残す（`@mention` は付けない。raw `gh pr comment` は使わない）。
 - merge は **`gh-automerge <PR>`** ラッパーのみ（内部で `gh pr merge --auto --merge`）。事前に required CI の green を確認する。raw `gh pr merge` は使わない。
 - 未解決 thread の取得は **`gh-list-threads <PR>`**、resolve は **`gh-resolve-thread <id>`** ラッパーのみ。raw `gh api graphql` は使わない。
 - 最大 **5 イテレーション**。未収束・CI 連続 fail なら **merge せず停止・報告**。PR は閉じない。
@@ -41,8 +42,11 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
       なので、fail を findings として扱い 2 に戻ってもよいが、合計 5 イテレーションの上限は超えない）。
    c. required が全て pass なら `gh-automerge <PR>` を実行する（内部で `gh pr merge --auto --merge`）。
    d. `gh pr view <PR> --json state,merged --jq '.state, .merged'` で merge を確認し、完了を報告。
+   e. **最終レポート投稿**: 全イテレーションの「指摘→対応」と最終結果（merge 済み）を本文に composing し、`gh-pr-report <PR>` に stdin で渡して PR に1本投稿する。`@mention` は付けない。
 4. **停止・報告**（merge しなかった場合）: 残った findings / 議論待ち thread / CI 状態を箇条書きで
-   要約して出力する。PR は開いたまま、reply も投稿しない（人間が引き取る）。
+   要約して出力する。PR は開いたまま、thread への reply は投稿しない（人間が引き取る）。最後に同じ
+   要約（各イテレーションの 指摘→対応 と、停止理由・残課題）を `gh-pr-report <PR>` に stdin で渡して
+   PR に1本投稿する。`@mention` は付けない。
 
 ## subagent prompt（`<PR>`/`<owner>`/`<repo>` を埋めて Task に渡す）
 
@@ -62,8 +66,9 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
 >    - 意図的にそうしている箇所は、再指摘されないよう **ソースコードにコメントで理由を残す**。
 >    - 対応した thread は **`gh-resolve-thread <THREAD_NODE_ID>`** で resolve する（`<THREAD_NODE_ID>`
 >      は手順 3 の `id`）。raw な `gh api graphql` は使わない。
->    - **reply コメントは投稿しない。** 人間の「議論が必要 / コード修正で片付かない」thread は
->      resolve せず残し、verdict の `threads_pending` に `blocker: true` で記録する。
+>    - **PR コメント（reply も含め）は投稿しない。** 人間の「議論が必要 / コード修正で片付かない」
+>      thread は resolve せず残し、verdict の `threads_pending` に `blocker: true` で記録する。
+>      （最終レポートの投稿は orchestrator が行う。subagent は verdict JSON を返すだけ。）
 > 5. **verdict 出力**: 下記スキーマの JSON **だけ**を出力する。
 >
 > ```json

--- a/test/claude-review.test.sh
+++ b/test/claude-review.test.sh
@@ -24,6 +24,7 @@ if [ "$rc" -eq 0 ] \
   && grep -qxF '[new-window]' "$stubdir/args" \
   && grep -qxF '[review-pr42]' "$stubdir/args" \
   && grep -qxF '[claude]' "$stubdir/args" \
+  && grep -qxF '[-p]' "$stubdir/args" \
   && grep -qxF '[--permission-mode]' "$stubdir/args" \
   && grep -qxF '[acceptEdits]' "$stubdir/args" \
   && grep -qxF '[/pr-review-merge 42]' "$stubdir/args"; then

--- a/test/gh-wrappers.test.sh
+++ b/test/gh-wrappers.test.sh
@@ -66,4 +66,21 @@ PATH="$stubdir:$PATH" "$bindir/gh-list-threads" >/dev/null 2>&1; [ $? -ne 0 ] \
 PATH="$stubdir:$PATH" "$bindir/gh-list-threads" x9 >/dev/null 2>&1; [ $? -ne 0 ] \
   && echo "ok: gh-list-threads non-numeric fails" || { echo "FAIL: gh-list-threads non-numeric"; fail=1; }
 
+# gh-pr-report: numeric PR + stdin body issues `gh pr comment <PR> --body-file -`.
+printf 'report body' | GH_ARGS_FILE="$stubdir/args" PATH="$stubdir:$PATH" "$bindir/gh-pr-report" 42 >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ] \
+  && grep -qxF '[pr]' "$stubdir/args" && grep -qxF '[comment]' "$stubdir/args" \
+  && grep -qxF '[42]' "$stubdir/args" \
+  && grep -qxF '[--body-file]' "$stubdir/args" && grep -qxF '[-]' "$stubdir/args"; then
+  echo "ok: gh-pr-report issues gh pr comment <PR> --body-file -"
+else echo "FAIL: gh-pr-report rc=$rc args=$(cat "$stubdir/args" 2>/dev/null)"; fail=1; fi
+
+# gh-pr-report: missing / non-numeric / extra-flag arg fail (no flag passthrough).
+printf x | PATH="$stubdir:$PATH" "$bindir/gh-pr-report" >/dev/null 2>&1; [ $? -ne 0 ] \
+  && echo "ok: gh-pr-report missing arg fails" || { echo "FAIL: gh-pr-report missing arg"; fail=1; }
+printf x | PATH="$stubdir:$PATH" "$bindir/gh-pr-report" 9z >/dev/null 2>&1; [ $? -ne 0 ] \
+  && echo "ok: gh-pr-report non-numeric fails" || { echo "FAIL: gh-pr-report non-numeric"; fail=1; }
+printf x | PATH="$stubdir:$PATH" "$bindir/gh-pr-report" 42 --edit-last >/dev/null 2>&1; [ $? -ne 0 ] \
+  && echo "ok: gh-pr-report rejects extra flag arg" || { echo "FAIL: gh-pr-report extra flag"; fail=1; }
+
 exit "$fail"


### PR DESCRIPTION
## Summary

`pr-review-merge` の自律レビュー reviewer を headless 化し、レビュー結果を PR コメントとして残せるようにする。

- **`bin/gh-pr-report`（新規）**: PR 番号のみを受け取り、本文を stdin から `gh pr comment <PR> --body-file -` で投稿する薄いラッパー。引数は固定1個でフラグ素通しが無く、既存コメントの編集や特定コメントへの reply には使えない。
- **`bin/claude-review`**: reviewer の claude を `claude -p`（headless）で起動。`/pr-review-merge` 完了で claude が exit し、`remain-on-exit` 未設定の tmux window が自動で閉じる。window 生成（`new-window -n review-pr<PR>`）は不変。
- **`dot/claude/skills/pr-review-merge/SKILL.md`**: 不変条件を精密化。review thread への reply 禁止は維持しつつ、**ループ終了後に1回だけ** reviewer の作業ログ（各イテレーションの指摘→対応・最終 verdict）を `gh-pr-report` で standalone コメントとして投稿する。merge 成功・停止の両出口でレポートを投稿し、本文は heredoc で `-p` セーフに渡す（先頭行に `pr-review-merge report` マーカー、`@mention` 無し）。投稿は orchestrator のみで subagent は verdict JSON を返すだけ。
- **`dot/claude/settings.json`**: `Bash(gh-pr-report *)` を allowlist に追加（headless で prompt 無しに呼べるように）。raw `gh pr comment` は追加しない。
- **`dot/claude/rules/gh-commands.md` §5**: `gh-pr-report` ラッパーを文書化。
- **tests**: `test/gh-wrappers.test.sh` に gh-pr-report のケース（コマンド形 + missing/非数値/余計なフラグ拒否）、`test/claude-review.test.sh` に `-p` の assert を追加。

## Why

- 対話モードの claude はレビュー完了後も exit せず window が残り、結果（merge 可否・残課題）は画面でしか読めず後から追えなかった。headless 化で完了時に window を畳み、レビュー結果は PR コメントとして永続化して後追いできるようにした。
- 投稿に raw `gh pr comment` を解禁せず専用ラッパーへ絞ったのは、reviewer が信頼できない PR コメントを読んで自律実行するため。フラグ素通し（`--edit-last` 等）を塞ぐことで権限バイパスや thread reply 化を防ぎ、`gh-commands.md` §5 の wrapper 方針（merge / thread 操作と同じく操作を最小化）と揃えた。thread への reply 禁止（§3）は維持し、standalone な作業ログのみ解禁する。
- heredoc を必須化したのは、`printf | gh-pr-report` だと `printf` が allowlist 外となり `-p` 実行下で prompt できずサイレント失敗し、レポートが黙って欠落するため。
