### PR TITLE
feat(bin): conservative git-reap-gone worktree/branch reaper

### DIFF
--- a/bin/git-prune-branch
+++ b/bin/git-prune-branch
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-git branch | \
-    awk -F ' ' '{ if( $1 != "\*" && $1 != "main" ) print $1 }' | \
-    xargs git branch -d

--- a/bin/git-reap-gone
+++ b/bin/git-reap-gone
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# git-reap-gone [--no-fetch] [<branch>...] -- conservatively reap [gone] branches
+# (and their worktrees) left behind by merged, delegated work.
+#
+# A local branch becomes [gone] when its tracked upstream is deleted on the
+# remote (typically the remote branch is removed on merge, then `git fetch
+# --prune` marks the local copy [gone]). That is the authoritative "this work is
+# done" signal we trigger on -- completion is never inferred, only observed.
+#
+# For each [gone] branch (optionally filtered to the names given as arguments):
+#   * guard: no unintegrated commits. The integration base is origin/HEAD (e.g.
+#     origin/main). If `git rev-list --count <base>..<branch>` is non-zero the
+#     branch carries local-only commits and is SKIPPED (never lost).
+#   * if a worktree is checked out on the branch: it must be clean
+#     (`git status --porcelain` empty), and it must not be the worktree this
+#     script runs in. Then `git worktree remove` (NO --force) + `git branch -d`.
+#   * if no worktree is attached (bare branch): just `git branch -d` after the
+#     guard.
+#
+# Anything that fails a check is SKIPPED and reported with the blocking reason.
+# Deletion is ALWAYS the safe form (`git worktree remove` without --force,
+# `git branch -d` not -D); this script never escalates to a force delete. If git
+# itself refuses a deletion, that branch is reported skipped, not forced.
+#
+# Manual, best-effort: exits 0 even when branches are skipped. It sweeps every
+# [gone] branch by default so it can later be dropped into cron/loop unchanged.
+#
+# Usage:
+#   git-reap-gone [--no-fetch] [<branch>...]
+#
+#   --no-fetch   skip the leading `git fetch --prune` (assume [gone] state is
+#                already current, e.g. the caller fetched)
+#   <branch>...  restrict reaping to these branch names (still fully gated)
+
+usage() {
+  awk '/^#!/ {next} /^#/ {sub(/^# ?/, ""); print; seen=1; next} seen {exit}' "$0"
+  exit "${1:-1}"
+}
+
+do_fetch=1
+declare -a filters=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage 0 ;;
+    --no-fetch) do_fetch=0; shift ;;
+    --) shift; while [ $# -gt 0 ]; do filters+=("$1"); shift; done ;;
+    -*) echo "git-reap-gone: unknown flag: $1" >&2; usage 1 ;;
+    *) filters+=("$1"); shift ;;
+  esac
+done
+
+# Report accumulators. Each entry is "<branch>\t<detail>".
+declare -a reaped=()
+declare -a skipped=()
+
+reap_ok()  { reaped+=("$1"$'\t'"$2"); }
+reap_skip() { skipped+=("$1"$'\t'"$2"); }
+
+if [ "$do_fetch" = 1 ]; then
+  echo "git-reap-gone: fetching (git fetch --prune)..." >&2
+  git fetch --prune
+fi
+
+# Integration base: the branch merged work lands on. Prefer the remote's default
+# (origin/HEAD, e.g. origin/main); fall back to origin/main then main. Empty if
+# none can be resolved -- then every branch is skipped rather than guessed.
+base=""
+if b="$(git rev-parse --abbrev-ref origin/HEAD 2>/dev/null)" && [ "$b" != "origin/HEAD" ]; then
+  base="$b"
+elif git rev-parse --verify --quiet origin/main >/dev/null; then
+  base="origin/main"
+elif git rev-parse --verify --quiet main >/dev/null; then
+  base="main"
+fi
+
+# Map branch name -> worktree path from `git worktree list --porcelain`. Blocks
+# are separated by blank lines; a "branch refs/heads/<name>" line ties the
+# preceding "worktree <path>" line to a branch (detached worktrees have none).
+declare -A wt_of=()
+cur_wt=""
+while IFS= read -r line; do
+  case "$line" in
+    "worktree "*) cur_wt="${line#worktree }" ;;
+    "branch refs/heads/"*) wt_of["${line#branch refs/heads/}"]="$cur_wt" ;;
+    "") cur_wt="" ;;
+  esac
+done < <(git worktree list --porcelain)
+
+# The worktree this script is invoked from -- never remove it.
+self_wt="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+
+# Collect [gone] local branches. `%(upstream:track)` is literally "[gone]" when
+# the tracked upstream was pruned.
+declare -a gone=()
+while IFS=' ' read -r branch track; do
+  [ "$track" = "[gone]" ] || continue
+  [ "$branch" = "main" ] && continue   # never touch main
+  gone+=("$branch")
+done < <(git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads/)
+
+# If explicit branches were requested, intersect (skip-report the ones asked for
+# that are not actually [gone], so the caller learns why nothing happened).
+in_list() { local x="$1"; shift; for e in "$@"; do [ "$e" = "$x" ] && return 0; done; return 1; }
+
+if [ "${#filters[@]}" -gt 0 ]; then
+  for f in "${filters[@]}"; do
+    if ! in_list "$f" "${gone[@]}"; then
+      reap_skip "$f" "not a [gone] branch (skipped)"
+    fi
+  done
+fi
+
+for branch in "${gone[@]}"; do
+  if [ "${#filters[@]}" -gt 0 ] && ! in_list "$branch" "${filters[@]}"; then
+    continue
+  fi
+
+  # Guard: no unintegrated (local-only) commits relative to the integration base.
+  if [ -z "$base" ]; then
+    reap_skip "$branch" "cannot resolve integration base (origin/HEAD, origin/main, main)"
+    continue
+  fi
+  ahead="$(git rev-list --count "$base..$branch" 2>/dev/null || echo unknown)"
+  if [ "$ahead" != 0 ]; then
+    reap_skip "$branch" "$ahead unintegrated commit(s) ahead of $base"
+    continue
+  fi
+
+  wt="${wt_of[$branch]:-}"
+  if [ -n "$wt" ]; then
+    if [ "$wt" = "$self_wt" ]; then
+      reap_skip "$branch" "checked out in the current worktree ($wt)"
+      continue
+    fi
+    if [ -n "$(git -C "$wt" status --porcelain)" ]; then
+      reap_skip "$branch" "worktree not clean ($wt)"
+      continue
+    fi
+    if ! git worktree remove "$wt"; then
+      reap_skip "$branch" "git worktree remove refused ($wt)"
+      continue
+    fi
+  fi
+
+  if ! git branch -d "$branch"; then
+    reap_skip "$branch" "git branch -d refused (not fully merged?)"
+    continue
+  fi
+  reap_ok "$branch" "${wt:+worktree removed; }branch deleted"
+done
+
+echo
+if [ "${#reaped[@]}" -gt 0 ]; then
+  echo "reaped (${#reaped[@]}):"
+  for e in "${reaped[@]}"; do printf '  %s\n' "${e/$'\t'/  -- }"; done
+else
+  echo "reaped (0): nothing"
+fi
+if [ "${#skipped[@]}" -gt 0 ]; then
+  echo "skipped (${#skipped[@]}):"
+  for e in "${skipped[@]}"; do printf '  %s\n' "${e/$'\t'/  -- }"; done
+fi

--- a/dot/claude/rules/worktree-scope.md
+++ b/dot/claude/rules/worktree-scope.md
@@ -77,3 +77,18 @@ claude-worktree <name> [-b <branch>] [-- <prompt...>]
 分岐先は `acceptEdits` で自律的に編集を進める。タスクが自然に独立した複数ラインへ割れるときに、現在 worktree を汚さず並行で進める選択肢として使う。乱用は避け、分岐の必要性が薄いときは現在 worktree 内で進める。
 
 連携の全体像（git worktree → tmux セッション → claude-queue の 3 層と `claude-worktree` の位置づけ）は `docs/design/claude-tmux-worktree.md` を参照。
+
+### 6. 委譲 worktree の後片付け（`git-reap-gone`）
+
+§5 で分岐・委譲した作業が merge され終わったら、その worktree とブランチの後始末を頼まれることがある。「後片付けして」「委譲先を片付けて」等で依頼されたら、手作業で `git worktree remove` / `git branch -d` を撃たず、`git-reap-gone`（`bin/`）を保守的 predicate で回す。
+
+```
+git-reap-gone [--no-fetch] [<branch>...]
+```
+
+- **トリガーは推論せず `[gone]` 状態**。リモートが merge 時にブランチを削除 → `git fetch --prune`（スクリプト冒頭で自動実行）で local が `[gone]` 化する、という権威ある外部イベントだけを完了の合図にする。`--no-fetch` で冒頭 fetch を抑制できる（呼び出し側／cron が fetch を制御する場合）。
+- **reap してよい条件（全通過のみ削除）**: ①統合先（`origin/HEAD` = 通常 `origin/main`）に対し未統合コミットが無い、②worktree が紐づくならそれが clean、③その worktree が今いる worktree でない。裸ブランチ（worktree 無し）は①のみで判定。
+- **削除は安全形だけ**: `git worktree remove`（**`--force` 無し**）＋ `git branch -d`（**`-D` ではない**）。条件を欠くもの・git が拒否したものは **skip し、何が blocking か report** する。決して force にエスカレートしない。これにより dirty／別ブランチへ切替済み（→ `[gone]` ブランチに worktree が紐づかない）等で spawn 中の worktree は自動的に対象外になる。
+- 引数でブランチ名を指定するとその対象だけを（同じゲートを通して）reap する。無指定なら全 `[gone]` を sweep。
+- **manual 運用**。cron/janitor の常駐は当面作らない。ただし全 `[gone]` を sweep できる形なので、将来そのまま cron/loop に挿せる。
+- settings.json で allow 済み（`git-reap-gone` / `git-reap-gone *`）なので承認なしで実行できる。

--- a/dot/claude/settings.json
+++ b/dot/claude/settings.json
@@ -77,6 +77,8 @@
       "Bash(git worktree list *)",
       "Bash(claude-worktree)",
       "Bash(claude-worktree *)",
+      "Bash(git-reap-gone)",
+      "Bash(git-reap-gone *)",
       "Bash(gh pr view *)",
       "Bash(gh pr diff *)",
       "Bash(gh pr create *)",

--- a/dot/claude/skills/harness-from-feedback/SKILL.md
+++ b/dot/claude/skills/harness-from-feedback/SKILL.md
@@ -87,4 +87,5 @@ allowed-tools: Bash(claude-worktree *), Bash(git rev-parse *), Bash(git worktree
    - 置いた場所（rules / CLAUDE.md / lint / test / hook）と対象 repo
    - ロードされる条件（paths と想定シナリオ。rule の場合）
    - branch 名とマージ方法（委譲先が pr-review-merge まで自走。マージは保護ゲート依存）
-   - マージ後の後始末（ガイダンス）: `git worktree remove <path>` / `git-prune-branch`
+   - マージ後の後始末（ガイダンス）: `git-reap-gone`（`[gone]` 化した委譲ブランチ／worktree を
+     保守的に reap。詳細は worktree-scope.md §6）


### PR DESCRIPTION
## What

委譲 worktree の後片付け用に、保守的な `[gone]` ブランチ reaper `bin/git-reap-gone` を新規追加。雑だった `bin/git-prune-branch` を置き換えて削除する。

## Why

`delegate-to-worktree` で別 worktree に委譲した作業が merge され終わった後、worktree 削除を都度手作業でやっていた。完了を推論せず、権威ある外部イベント = ブランチの `[gone]` 状態（リモートが merge 時に削除 → `git fetch --prune` で local が `[gone]` 化）だけをトリガーにする再利用可能な reaper にまとめた。曖昧なものは触らず残す。

## 動作 — `git-reap-gone [--no-fetch] [<branch>...]`

- 冒頭で `git fetch --prune`（`--no-fetch` で抑制可）して `[gone]` 状態を最新化。
- 各 `[gone]` ブランチを保守的 predicate でゲート:
  - 統合先（`origin/HEAD` = 通常 `origin/main`）に対し**未統合コミットが無い**こと。
  - worktree が紐づくならそれが **clean**、かつ**今いる worktree でない**こと。
  - 裸ブランチ（worktree 無し）は未統合コミットのガードのみで判定。
- 全通過のみ削除。削除は**安全形だけ**: `git worktree remove`（`--force` 無し）＋ `git branch -d`（`-D` ではない）。
- 欠けたもの・git が拒否したものは **skip し、何が blocking か report**。決して force にエスカレートしない。
- 無指定なら全 `[gone]` sweep（将来そのまま cron/loop に挿せる形）、引数指定でピンポイントも可（ゲートは常に通す）。

これにより dirty／別ブランチへ切替済み等で spawn 中の worktree は自動的に対象外になる。セッションガード（tmux）は入れていない。

## 変更点

- `bin/git-reap-gone` 新規（`set -euo pipefail`、既存 `gh-*` ラッパー流儀）。
- `bin/git-prune-branch` 削除（`[gone]` ゲートも worktree 処理も無く force delete していた）。
- `dot/claude/settings.json` に `Bash(git-reap-gone)` / `Bash(git-reap-gone *)` を allowlist。
- `dot/claude/rules/worktree-scope.md` §6（後片付け）新設。
- `harness-from-feedback/SKILL.md` の後片付けガイダンス参照を `git-reap-gone` に差し替え。

## テスト

隔離した scratch git リポジトリで検証: merged-bare / clean-worktree → reap、unintegrated-commit / dirty-worktree → skip&report、not-gone → 不干渉、ブランチ引数フィルタ、非 gone 指定の skip-report、self-worktree ガード（自分が居る worktree は消さない）を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)