### PR TITLE
feat(claude-worktree): session claude 終了時に呼び出し元 pane へ復帰

### DIFF
--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -17,6 +17,11 @@ set -euo pipefail
 # (`gts <session>` / `tmux attach -t <session>`); it is interactive, so it keeps
 # running at the REPL after the initial prompt -- no `claude --resume` needed.
 #
+# When invoked from inside tmux, the launch is wrapped so that when claude exits
+# the attached client is switched back to the pane it was called from (not just
+# the origin session's currently-active pane). Nobody attached / origin pane gone
+# both degrade to a silent no-op.
+#
 # Usage:
 #   claude-worktree [--self] <name> [-b <branch>] [-- <prompt...>]
 #
@@ -102,8 +107,23 @@ fi
 # Start claude INSIDE a fresh detached tmux session in the worktree. Passing the
 # prompt as a separate argv element keeps spaces/quotes intact (tmux preserves
 # argv). Interactive (no -p) so it stays at the REPL after the first prompt.
-tmux new-session -d -s "$session" -c "$wt_path" \
-  claude --permission-mode acceptEdits "$prompt"
+#
+# When launched from inside tmux, wrap the launch in `bash -c` so that when
+# claude exits we chain `switch-client -t <origin_pane>`, returning the attached
+# client to the exact pane we were called from (session-level auto-return only
+# lands on the origin session's active pane, not this one). The prompt and pane
+# id ride in as positional args ($1/$2) -- never folded into the command string
+# -- so quotes in the prompt can't break the chain. If nobody is attached, or
+# the origin pane is already gone, switch-client is a graceful no-op (2>/dev/null)
+# and the single-pane session just dies quietly when the inner bash exits.
+if [ -n "${TMUX:-}" ]; then
+  tmux new-session -d -s "$session" -c "$wt_path" \
+    bash -c 'claude --permission-mode acceptEdits "$1"; tmux switch-client -t "$2" 2>/dev/null' \
+    bash "$prompt" "$TMUX_PANE"
+else
+  tmux new-session -d -s "$session" -c "$wt_path" \
+    claude --permission-mode acceptEdits "$prompt"
+fi
 
 attach="gts $session"
 [ -n "${TMUX:-}" ] || attach="tmux attach -t $session"

--- a/test/claude-worktree.test.sh
+++ b/test/claude-worktree.test.sh
@@ -50,4 +50,59 @@ else echo "FAIL: --self with -b rc=$rc out=$out want=${scriptrepo}_glob2"; fail=
 (cd "$cwdrepo" && "$wt" --bogus name) >/dev/null 2>&1; [ $? -ne 0 ] \
   && echo "ok: unknown flag still rejected" || { echo "FAIL: unknown flag accepted"; fail=1; }
 
+# --- session-launch mode (with a prompt) --------------------------------------
+# We can't reproduce real tmux/claude behavior, so we stub `tmux` on PATH: it
+# fails `has-session` (so the script proceeds) and records `new-session`'s argv
+# (one element per line) to $TMUX_STUB_LOG. This lets us assert exactly how the
+# launch command is built -- including the pane-return chain -- without spawning
+# anything. `git` stays real (stub only shadows tmux).
+stubbin="$tmp/stubbin"
+mkdir -p "$stubbin"
+cat >"$stubbin/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  has-session) exit 1 ;;                        # pretend no session exists yet
+  new-session) printf '%s\n' "$@" >"$TMUX_STUB_LOG"; exit 0 ;;
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$stubbin/tmux"
+
+# Prompt carrying a space plus both quote kinds -- must survive as ONE argv
+# element (the whole point of passing it separately, not folded into a string).
+prompt='say "hi" it'\''s here'
+
+# Inside tmux ($TMUX set): launch is wrapped in `bash -c` so claude's exit is
+# chained to `switch-client -t <origin_pane>`, returning the client to the pane
+# we launched from. Assert the chain is wired and quoting is intact.
+log="$tmp/ns-in"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" TMUX_STUB_LOG="$log" TMUX=fake TMUX_PANE=%9
+  "$wt" insess -- "$prompt"; } 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] \
+   && grep -q 'switch-client' "$log" \
+   && grep -Fxq '%9' "$log" \
+   && grep -Fxq "$prompt" "$log" \
+   && grep -q 'attach   : gts' <<<"$out"; then
+  echo "ok: \$TMUX set wires switch-client back to origin pane, prompt intact"
+else
+  echo "FAIL: in-tmux launch rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; fail=1
+fi
+
+# Outside tmux ($TMUX unset): no client to return, so claude runs directly (no
+# wrapper, no switch-client) and the attach hint falls back to `tmux attach`.
+log="$tmp/ns-out"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" TMUX_STUB_LOG="$log"
+  "$wt" nosess -- "$prompt"; } 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] \
+   && ! grep -q 'switch-client' "$log" \
+   && grep -Fxq 'claude' "$log" \
+   && grep -Fxq "$prompt" "$log" \
+   && grep -q 'attach   : tmux attach -t' <<<"$out"; then
+  echo "ok: no \$TMUX launches claude directly, no pane-return chain"
+else
+  echo "FAIL: out-of-tmux launch rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; fail=1
+fi
+
 exit "$fail"


### PR DESCRIPTION
## Summary

`claude-worktree` を session 起動形式（`-- <prompt>` 付き）で使うと detached tmux session 内で claude が走るが、claude 終了時の復帰先は tmux 既定の session レベル自動復帰任せで、呼び出し元 session の「現在アクティブな pane」に着地するだけで、起動した pane にはピン留めされなかった。

tmux 内から起動されたとき、起動を `bash -c` でラップし、claude の exit に `switch-client -t <origin_pane>`（`$TMUX_PANE`）をチェーンする。これで attach 中のクライアントを**起動した pane まで厳密復帰**させる。

- prompt と pane id は positional 引数（`$1`/`$2`）として渡し、コマンド文字列に畳み込まない。prompt 内の `'`/`"`/空白があってもチェーンが壊れない。
- 誰も attach していない／呼び出し元 pane が既に閉じている場合はいずれも `2>/dev/null` で静かな no-op に劣化し、単一 pane の session は inner bash 終了で自然消滅する。
- tmux 外（`$TMUX` 未設定）では戻すべきクライアントが無いため、従来どおり直 exec で挙動不変。

## Why

session レベルの自動復帰は「呼び出し元 session」までは概ね効くが、着地 pane は起動元 pane に固定されない。委譲した claude を抜けたときに元の作業 pane へ正確に戻したいという運用上の要求に対応する。

終了フックを prompt 込みの生文字列チェーンに直書きすると prompt 内クォートでチェーンが壊れやすいため、tmux `set-hook` 案ではなく、prompt を argv のまま保てる `bash -c` positional 渡し方式を採った。

## Test

`test/claude-worktree.test.sh` に PATH 上の `tmux` stub（`has-session` を非0、`new-session` の argv を記録）を用いた検証を追加:

- `$TMUX` あり → `new-session` argv に `switch-client` と `$TMUX_PANE`（`%9`）が配線され、空白・両クォートを含む prompt が単一 argv 要素として保持される。attach ヒントは `gts`。
- `$TMUX` なし → `switch-client` 無しで直 `claude` 起動、attach ヒントは `tmux attach`。
- 既存の add-only 回帰4件は据え置きで PASS。

🤖 Generated with [Claude Code](https://claude.com/claude-code)