### PR TITLE
feat(claude-queue): picker の worktree 名を truncate せずカラム順を整理

### DIFF
--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -13,10 +13,7 @@ import (
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/multiplexer"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/summary"
-	"github.com/mattn/go-runewidth"
 )
-
-const cwdWidth = 20
 
 var emoji = map[string]string{
 	"awaiting_approval": "⏳",
@@ -33,7 +30,10 @@ var ascii = map[string]string{
 }
 
 // FormatLine renders one queue row as a tab-delimited line for fzf.
-// Visible columns (--with-nth=1,2,3,4): icon, summary, cwd-basename, age.
+// Visible columns (--with-nth=1,2,3,4): icon, cwd-basename, summary, age.
+// cwd-basename (the worktree dir name) comes right after the icon so it
+// starts at a fixed position and stays scannable; the variable-width summary
+// is demoted behind it and left untruncated.
 // Hidden columns: session_id (5), tmux_pane (6).
 func FormatLine(row db.Row, nowSec int64, asciiMode bool) string {
 	icons := emoji
@@ -51,7 +51,6 @@ func FormatLine(row db.Row, nowSec int64, asciiMode bool) string {
 	cwdBase := ""
 	if row.Cwd.Valid {
 		cwdBase = filepath.Base(row.Cwd.String)
-		cwdBase = runewidth.Truncate(cwdBase, cwdWidth, "")
 	}
 
 	age := formatAge(nowSec - row.CreatedAt)
@@ -61,7 +60,7 @@ func FormatLine(row db.Row, nowSec int64, asciiMode bool) string {
 		pane = row.TmuxPane.String
 	}
 
-	return strings.Join([]string{icon, sum, cwdBase, age, row.SessionID, pane}, "\t")
+	return strings.Join([]string{icon, cwdBase, sum, age, row.SessionID, pane}, "\t")
 }
 
 func formatAge(sec int64) string {

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -28,11 +28,11 @@ func TestFormatLine_AwaitingApproval(t *testing.T) {
 	if fields[0] != "⏳" {
 		t.Errorf("icon = %q, want ⏳", fields[0])
 	}
-	if !strings.Contains(fields[1], "Bash: pnpm prisma migrate") {
-		t.Errorf("summary = %q", fields[1])
+	if fields[1] != "everysteel-api" {
+		t.Errorf("cwd basename = %q, want everysteel-api", fields[1])
 	}
-	if fields[2] != "everysteel-api" {
-		t.Errorf("cwd basename = %q, want everysteel-api", fields[2])
+	if !strings.Contains(fields[2], "Bash: pnpm prisma migrate") {
+		t.Errorf("summary = %q", fields[2])
 	}
 	if fields[3] != "2m" {
 		t.Errorf("age = %q, want 2m", fields[3])


### PR DESCRIPTION
## Summary

`claude-queue` picker (Ctrl-Q → q/Q) の表示を変更した。

- cwd basename（worktree ディレクトリ名）の 20 セル truncate を撤廃し、フルで表示する
- カラム順を `icon → summary → cwd → age` から `icon → cwd → summary → age` に変更。worktree 名を icon 直後の固定位置に置き、可変幅の summary をその後ろへ降ろした
- 本パッケージで未使用になった `go-runewidth` 依存を削除

## Why

picker で session を選ぶ際、cwd が 20 文字で切られ、かつ可変幅の summary の後ろに置かれていたため worktree 名の開始位置が行ごとにズレて見分けづらかった。ユーザーは選択時に icon と worktree 名で識別しており summary はほぼ見ていないため、worktree 名を全表示かつ固定位置に出し、summary は残しつつ後方へ降格した。