### PR TITLE
docs(implement-and-review): plan 内の事実主張は書き写す前に裏を取る

### DIFF
--- a/dot/claude/skills/implement-and-review/SKILL.md
+++ b/dot/claude/skills/implement-and-review/SKILL.md
@@ -36,6 +36,18 @@ description: worktree に委譲されたタスクを実装→merge で完遂す�
    自分で直接書くのは、軽微・逐次的で dispatch のオーバーヘッドが見合わないものに留める
    （ハイブリッド）。`superpowers:test-driven-development` 等、repo の規約に従う。
    コミットは論理単位で小さく。
+
+   **plan 内の事実主張は書き写す前に裏を取る**: どの artifact を選ぶか・どこに置くか等の
+   設計判断には従う。一方 plan 本文が repo 内の実装・ツール挙動に言及していたら（「`bin/X`
+   はこう動く」「既存 skill Y はこう書いてある」等）、書き写す前に該当ファイルを Read して
+   確かめる。事実の誤りを黙って commit するほうが、確認してから書くより後戻りが大きいため。
+   設計をやり直すのとは別物なので、不変条件「HOW を勝手に作り直さない」と矛盾しない。
+   常時ロードの `dot/claude/rules/evidence-over-guesswork.md` §1（一次情報を確認しきる前に
+   着手しない）と同根で、plan 経由でそれが迂回されるのを塞ぐ位置づけ。
+   由来: plan に埋め込まれた SKILL.md 全文の「headless 起動では claude-review が出力を
+   ログ化する」を無検証で書き写し、レビューで差し戻された実例（実際の `bin/claude-review` は
+   自身が起こす headless pane の stdout を tee するだけで、委譲先の interactive セッションから
+   呼ばれた skill の出力は載らない）。
 3. **verification**: PR を出す前に、テスト・ビルド・lint が通ることだけを確認する
    （`superpowers:verification-before-completion`）。**重い self-review はしない** —
    レビュー本体は独立した文脈を持つ次の手順に委ねる。自分が書いたコードを同じ文脈で


### PR DESCRIPTION
## 背景

`implement-and-review` は「HOW を勝手に作り直さない」を不変条件に持つため、確定済み実装計画の内容を verbatim で書き写す運用になる。その結果「plan に書いてあるから」が事実検証の免罪符になり、**plan 本文に含まれる repo 内実装・ツール挙動への事実主張が無検証のまま commit される穴**があった。

実例: plan に埋め込まれた SKILL.md 全文に「headless 起動では claude-review が出力をログ化する」という記述があったが、`bin/claude-review` は自身が起こす headless pane（`claude -p '/pr-review-automerge'`）の stdout を tee するだけで、委譲先の interactive セッションから呼ばれた skill の出力は載らない。誤りのまま commit され、レビューで差し戻された。

根本原因は、**設計判断（従うべき HOW）と事実主張（一次情報で裏を取るべきもの）の線引きが skill に明文化されていない**こと。

## 変更

`dot/claude/skills/implement-and-review/SKILL.md` の手順 2（実装）末尾に、理由付きソフト指針を 1 ブロック追加。

- どの artifact を選ぶか・どこに置くか等の**設計判断には従う**
- plan 本文が repo 内の実装・ツール挙動に言及していたら、**書き写す前に該当ファイルを Read** して確かめる
- 理由: 事実の誤りを黙って commit するほうが、確認してから書くより後戻りが大きい。設計をやり直すのとは別物なので不変条件「HOW を勝手に作り直さない」と矛盾しない
- 常時ロードの `dot/claude/rules/evidence-over-guesswork.md` §1（一次情報を確認しきる前に着手しない）と同根で、**plan 経由での迂回を塞ぐ**位置づけ
- 由来（上記の実例）を短く併記

既存の構成・見出しは変更していない。

## 確認

- 委譲ランで plan が `bin/` や既存 skill の挙動に言及しているときに、該当ファイルを Read してから書く判断ができる文面になっている
- 設計選択（どの artifact を選ぶか等）はこの検証の対象外（従う）と読み取れる
- `test/*.test.sh` 3 本 PASS（本変更は docs のみで無関係だが回帰確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)