### PR TITLE
fix(gh-await-reviews): PR 作成直後の expected 空を settled と判定しない

### DIFF
--- a/bin/gh-await-reviews
+++ b/bin/gh-await-reviews
@@ -20,10 +20,10 @@ set -euo pipefail
 # when this script started, so an already-reviewed PR returns immediately.
 #
 # An empty `expected` is ambiguous: it can mean "no review bot on this repo" or
-# "the review request has not been registered yet". Settling on it right after
-# PR creation is therefore unsound (see $expected_floor_s), and the report
-# carries `expected_unknown` so callers do not read `expected: []` as proof that
-# no bot will review.
+# "a bot is present but hasn't posted anything yet (an unpredictable reviewer
+# may still be booting)". Settling on it right after PR creation is therefore
+# unsound (see $expected_floor_s), and the report carries `expected_unknown` so
+# callers do not read `expected: []` as proof that no bot will review.
 #
 # Wrapped so the reviewer agent needs no `sleep` grant. Allowlist as
 # `Bash(gh-await-reviews *)`. Requires jq (see bin/list-install.sh).
@@ -125,11 +125,8 @@ emit() {  # $1 = settled|timed_out
 # top of this file). Resolving to a variable first lets us `return 0` (fail
 # open) on a bad parse instead of crashing.
 #
-# The same inline-date trap applies to the quiet-window check in the main
-# loop below (the `$(( now - $(date ... "$last_ts") ))` comparison): it
-# resolves last_ts to last_epoch first for the identical reason, fails open
-# (quiet window treated as elapsed) on a bad parse so the JSON report still
-# gets emitted.
+# (The same inline-date trap applies to the quiet-window check in the main
+# loop below -- see the comment there instead of duplicating it here.)
 expected_settled() {
   [ "$expect_copilot" -eq 0 ] || return 0
   [ -n "$created_at" ] || return 0

--- a/bin/gh-await-reviews
+++ b/bin/gh-await-reviews
@@ -45,12 +45,20 @@ quiet_s=${GH_AWAIT_REVIEWS_QUIET:-30}        # silence after the last activity
 grace_s=${GH_AWAIT_REVIEWS_GRACE:-60}        # floor when nothing is expected and nothing posted
 poll_s=${GH_AWAIT_REVIEWS_POLL:-15}
 # Floor, measured from PR creation, below which an empty `expected` may not be
-# settled on. GitHub registers review requests asynchronously after the PR is
-# created, so right after creation "no reviewer requested" is indistinguishable
-# from "not registered yet". Measured on a PR in another repo (not this one --
-# dotrc's own PR numbers don't reach this yet): settled at 63s with an empty
-# expected/observed, yet a Copilot review landed shortly after and a re-run of
-# this script then reported copilot in both expected and observed.
+# settled on. As the header comment says, Copilot's pending review never
+# surfaces in reviewRequests in this repo, so an empty `expected` never means
+# "registration hasn't finished" -- it means nothing has been observed *yet*.
+# The floor exists so the script doesn't conclude "no automated review" before
+# an unpredictable reviewer has had a realistic chance to actually post; it
+# does not guarantee `expected` fills in by the time it elapses (Copilot may
+# still stay silent), and once it elapses an empty `expected` is accepted as
+# the best available signal, not proof the ambiguity was resolved.
+#
+# Measured on a PR in another repo (dotrc's own PR history hasn't yet produced
+# one slow enough to exercise this floor): settled at 63s with an empty
+# expected/observed, yet a Copilot review landed shortly after -- i.e. 63s was
+# too short for Copilot to have posted, not evidence reviewRequests was still
+# registering.
 expected_floor_s=${GH_AWAIT_REVIEWS_EXPECTED_FLOOR:-90}
 
 # One gh call per poll. Emits, per line:

--- a/bin/gh-await-reviews
+++ b/bin/gh-await-reviews
@@ -47,7 +47,8 @@ poll_s=${GH_AWAIT_REVIEWS_POLL:-15}
 # Floor, measured from PR creation, below which an empty `expected` may not be
 # settled on. GitHub registers review requests asynchronously after the PR is
 # created, so right after creation "no reviewer requested" is indistinguishable
-# from "not registered yet". Measured on PR #537: settled at 63s with an empty
+# from "not registered yet". Measured on a PR in another repo (not this one --
+# dotrc's own PR numbers don't reach this yet): settled at 63s with an empty
 # expected/observed, yet a Copilot review landed shortly after and a re-run of
 # this script then reported copilot in both expected and observed.
 expected_floor_s=${GH_AWAIT_REVIEWS_EXPECTED_FLOOR:-90}
@@ -115,6 +116,12 @@ emit() {  # $1 = settled|timed_out
 # (violates the "prints and exits 0 even on timeout/error" contract at the
 # top of this file). Resolving to a variable first lets us `return 0` (fail
 # open) on a bad parse instead of crashing.
+#
+# The same inline-date trap applies to the quiet-window check in the main
+# loop below (the `$(( now - $(date ... "$last_ts") ))` comparison): it
+# resolves last_ts to last_epoch first for the identical reason, fails open
+# (quiet window treated as elapsed) on a bad parse so the JSON report still
+# gets emitted.
 expected_settled() {
   [ "$expect_copilot" -eq 0 ] || return 0
   [ -n "$created_at" ] || return 0
@@ -152,7 +159,14 @@ while :; do
   elif [ "$expect_copilot" -eq 0 ] || [ -n "$copilot_at" ]; then
     # Everything we can wait for has arrived; wait out the quiet window so a
     # reviewer that posts a summary first and inline comments second is caught.
-    if [ $(( now - $(date -u -d "$last_ts" +%s) )) -ge "$quiet_s" ] && expected_settled; then
+    #
+    # last_ts is resolved to last_epoch first, not inlined in `$(( ))` -- see
+    # the comment above expected_settled() for why inlining `date` here would
+    # be fatal under `set -euo pipefail` on a bad parse. Fails open (quiet
+    # window treated as elapsed) so an unparseable timestamp still reaches
+    # `emit` instead of crashing before any JSON is printed.
+    last_epoch=$(date -u -d "$last_ts" +%s 2>/dev/null) || last_epoch=""
+    if { [ -z "$last_epoch" ] || [ $(( now - last_epoch )) -ge "$quiet_s" ]; } && expected_settled; then
       emit settled; exit 0
     fi
   fi

--- a/bin/gh-await-reviews
+++ b/bin/gh-await-reviews
@@ -19,6 +19,12 @@ set -euo pipefail
 # Quiet is measured from real submittedAt/createdAt timestamps rather than from
 # when this script started, so an already-reviewed PR returns immediately.
 #
+# An empty `expected` is ambiguous: it can mean "no review bot on this repo" or
+# "the review request has not been registered yet". Settling on it right after
+# PR creation is therefore unsound (see $expected_floor_s), and the report
+# carries `expected_unknown` so callers do not read `expected: []` as proof that
+# no bot will review.
+#
 # Wrapped so the reviewer agent needs no `sleep` grant. Allowlist as
 # `Bash(gh-await-reviews *)`. Requires jq (see bin/list-install.sh).
 #
@@ -38,14 +44,23 @@ timeout_s=${GH_AWAIT_REVIEWS_TIMEOUT:-600}   # overall ceiling
 quiet_s=${GH_AWAIT_REVIEWS_QUIET:-30}        # silence after the last activity
 grace_s=${GH_AWAIT_REVIEWS_GRACE:-60}        # floor when nothing is expected and nothing posted
 poll_s=${GH_AWAIT_REVIEWS_POLL:-15}
+# Floor, measured from PR creation, below which an empty `expected` may not be
+# settled on. GitHub registers review requests asynchronously after the PR is
+# created, so right after creation "no reviewer requested" is indistinguishable
+# from "not registered yet". Measured on PR #537: settled at 63s with an empty
+# expected/observed, yet a Copilot review landed shortly after and a re-run of
+# this script then reported copilot in both expected and observed.
+expected_floor_s=${GH_AWAIT_REVIEWS_EXPECTED_FLOOR:-90}
 
 # One gh call per poll. Emits, per line:
+#   CRT<TAB><iso8601>            when the PR was created
 #   REQ<TAB><login>              a pending review request (pre-arrival signal)
 #   ACT<TAB><login><TAB><iso8601> a review or comment by someone other than the author
 snapshot() {
-  gh pr view "$pr" --json author,reviewRequests,reviews,comments --jq '
+  gh pr view "$pr" --json author,createdAt,reviewRequests,reviews,comments --jq '
     .author.login as $a
-    | ([.reviewRequests[]?.login // empty] | .[] | "REQ\t" + .),
+    | "CRT\t" + (.createdAt // ""),
+      ([.reviewRequests[]?.login // empty] | .[] | "REQ\t" + .),
       (([.reviews[]?  | {l: .author.login, t: .submittedAt}]
       + [.comments[]? | {l: .author.login, t: .createdAt}])
        | .[] | select(.l != $a) | "ACT\t" + .l + "\t" + (.t // ""))
@@ -55,6 +70,7 @@ snapshot() {
 started=$(date -u +%s)
 expect_copilot=0
 copilot_at=""
+created_at=""
 last_ts=""
 observed=""   # "<login><TAB><ts>" per line, may repeat a login
 
@@ -79,16 +95,27 @@ emit() {  # $1 = settled|timed_out
        timed_out: ($status == "timed_out"),
        waited_seconds: $waited,
        expected: $expected,
+       expected_unknown: (($expected | length) == 0),
        observed: $observed,
        missing: [$expected[] | select(.arrived | not) | .name],
        last_activity_at: (($observed | map(.at) | max) // null)}
   '
 }
 
+# False while an empty `expected` is still too fresh to be believed. Fails open
+# (settle allowed) when the PR age is unknown, so a parse failure cannot hang
+# the caller.
+expected_settled() {
+  [ "$expect_copilot" -eq 0 ] || return 0
+  [ -n "$created_at" ] || return 0
+  [ $(( now - $(date -u -d "$created_at" +%s) )) -ge "$expected_floor_s" ]
+}
+
 while :; do
   observed=""
   while IFS=$'\t' read -r kind login ts; do
     case "$kind" in
+      CRT) created_at="$login" ;;
       REQ) case "$login" in *[Cc]opilot*) expect_copilot=1 ;; esac ;;
       ACT) observed+="$login"$'\t'"$ts"$'\n' ;;
     esac
@@ -108,11 +135,13 @@ while :; do
   if [ "$expect_copilot" -eq 0 ] && [ -z "$last_ts" ]; then
     # Nothing predicted and nobody has spoken. Don't conclude "no automated
     # review" instantly -- an unpredictable reviewer may still be booting.
-    if [ "$waited" -ge "$grace_s" ]; then emit settled; exit 0; fi
+    if [ "$waited" -ge "$grace_s" ] && expected_settled; then emit settled; exit 0; fi
   elif [ "$expect_copilot" -eq 0 ] || [ -n "$copilot_at" ]; then
     # Everything we can wait for has arrived; wait out the quiet window so a
     # reviewer that posts a summary first and inline comments second is caught.
-    if [ $(( now - $(date -u -d "$last_ts" +%s) )) -ge "$quiet_s" ]; then emit settled; exit 0; fi
+    if [ $(( now - $(date -u -d "$last_ts" +%s) )) -ge "$quiet_s" ] && expected_settled; then
+      emit settled; exit 0
+    fi
   fi
 
   if [ "$waited" -ge "$timeout_s" ]; then emit timed_out; exit 0; fi

--- a/bin/gh-await-reviews
+++ b/bin/gh-await-reviews
@@ -105,10 +105,23 @@ emit() {  # $1 = settled|timed_out
 # False while an empty `expected` is still too fresh to be believed. Fails open
 # (settle allowed) when the PR age is unknown, so a parse failure cannot hang
 # the caller.
+#
+# created_epoch is resolved into a plain variable *before* the arithmetic
+# comparison below. Inlining `$(date ... "$created_at" +%s)` directly inside
+# `$(( ))` is a trap: under `set -euo pipefail`, an unparseable created_at
+# makes `date` fail and print nothing, so the arithmetic expression becomes
+# `now - ` -- a bash *expansion* error, which is fatal even in a subshell-free
+# context and kills the whole script before it ever prints the JSON report
+# (violates the "prints and exits 0 even on timeout/error" contract at the
+# top of this file). Resolving to a variable first lets us `return 0` (fail
+# open) on a bad parse instead of crashing.
 expected_settled() {
   [ "$expect_copilot" -eq 0 ] || return 0
   [ -n "$created_at" ] || return 0
-  [ $(( now - $(date -u -d "$created_at" +%s) )) -ge "$expected_floor_s" ]
+  local created_epoch
+  created_epoch=$(date -u -d "$created_at" +%s 2>/dev/null) || return 0
+  [ -n "$created_epoch" ] || return 0
+  [ $(( now - created_epoch )) -ge "$expected_floor_s" ]
 }
 
 while :; do

--- a/dot/claude/skills/pr-review-automerge/SKILL.md
+++ b/dot/claude/skills/pr-review-automerge/SKILL.md
@@ -38,6 +38,9 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
    返る JSON の `expected` / `observed` / `missing` / `last_activity_at` を保持する。`last_activity_at` を
    `LAST_SEEN` として記録する。`missing` が非空でも **merge をブロックしない**（bot が無効化されている repo で
    永久に止まるため）。報告に使うだけ。
+   `expected` が空（= `expected_unknown: true`）でも **「レビュー bot 無し」と断定しない**。review 要求の登録は
+   PR 作成に対して遅延しうるため、bot が無効化されているのか登録が遅れているのかを区別できないという意味しか
+   持たない。実際に届いた review は判定役が `gh-pr-comments` で読む（判定 subagent prompt の手順 2）前提を維持する。
 1. `owner` / `repo` を取得: `gh repo view --json owner,name --jq '.owner.login + " " + .name'`。
 2. イテレーション `i` を 1..5 で回す:
 

--- a/dot/claude/skills/pr-review-automerge/SKILL.md
+++ b/dot/claude/skills/pr-review-automerge/SKILL.md
@@ -38,9 +38,10 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
    返る JSON の `expected` / `observed` / `missing` / `last_activity_at` を保持する。`last_activity_at` を
    `LAST_SEEN` として記録する。`missing` が非空でも **merge をブロックしない**（bot が無効化されている repo で
    永久に止まるため）。報告に使うだけ。
-   `expected` が空（= `expected_unknown: true`）でも **「レビュー bot 無し」と断定しない**。review 要求の登録は
-   PR 作成に対して遅延しうるため、bot が無効化されているのか登録が遅れているのかを区別できないという意味しか
-   持たない。実際に届いた review は判定役が `gh-pr-comments` で読む（判定 subagent prompt の手順 2）前提を維持する。
+   `expected` が空（= `expected_unknown: true`）でも **「レビュー bot 無し」と断定しない**。Copilot 等の
+   pending review はこの repo の reviewRequests に一切現れないため、`expected` が空でも「bot が無効化
+   されている」のか「bot は居るがまだ何も投稿していないだけ」なのかを区別できないという意味しか持たない。
+   実際に届いた review は判定役が `gh-pr-comments` で読む（判定 subagent prompt の手順 2）前提を維持する。
 1. `owner` / `repo` を取得: `gh repo view --json owner,name --jq '.owner.login + " " + .name'`。
 2. イテレーション `i` を 1..5 で回す:
 

--- a/test/gh-wrappers.test.sh
+++ b/test/gh-wrappers.test.sh
@@ -218,6 +218,19 @@ if [ "$rc" -eq 0 ] \
   echo "ok: gh-await-reviews settles once a short floor has elapsed"
 else echo "FAIL: gh-await-reviews short-floor rc=$rc out=$out"; fail=1; fi
 
+# Case H: an ACT timestamp that fails to parse (`date -u -d` rejects it) must
+# not crash the script before it emits JSON -- regression test for the inline
+# `$(( now - $(date ...) ))` trap described above expected_settled(). CRT is
+# old so only the quiet-window `date` call (not the floor) is exercised.
+fx="$awaitstub/h"; mkdir -p "$fx"
+printf 'CRT\t%s\nACT\tcoderabbitai\tgarbage\n' "$old" >"$fx/1"
+out=$(awaitenv "$fx" 42 2>/dev/null); rc=$?
+if [ "$rc" -eq 0 ] \
+  && printf '%s' "$out" | grep -q '"pr":42' \
+  && printf '%s' "$out" | grep -q '"login":"coderabbitai"'; then
+  echo "ok: gh-await-reviews emits JSON instead of crashing on an unparseable ACT timestamp"
+else echo "FAIL: gh-await-reviews unparseable timestamp rc=$rc out=$out"; fail=1; fi
+
 # gh-await-reviews: missing / non-numeric / extra-flag arg fail (no flag passthrough).
 PATH="$awaitstub:$PATH" "$bindir/gh-await-reviews" >/dev/null 2>&1; [ $? -ne 0 ] \
   && echo "ok: gh-await-reviews missing arg fails" || { echo "FAIL: gh-await-reviews missing arg"; fail=1; }

--- a/test/gh-wrappers.test.sh
+++ b/test/gh-wrappers.test.sh
@@ -111,9 +111,11 @@ awaitenv() { env GH_AWAIT_REVIEWS_TIMEOUT=3 GH_AWAIT_REVIEWS_QUIET=1 \
 old='2020-01-01T00:00:00Z'
 
 # Case A: an already-reviewed, quiet PR settles immediately (quiet is measured
-# from the real timestamp, not from when we started polling).
+# from the real timestamp, not from when we started polling). CRT is old so
+# the $expected_floor_s gate (default 90s, irrelevant here since copilot
+# already arrived) can never be the reason this settles.
 fx="$awaitstub/a"; mkdir -p "$fx"
-printf 'ACT\tcopilot-pull-request-reviewer\t%s\n' "$old" >"$fx/1"
+printf 'CRT\t%s\nACT\tcopilot-pull-request-reviewer\t%s\n' "$old" "$old" >"$fx/1"
 out=$(awaitenv "$fx" 42 2>/dev/null); rc=$?
 if [ "$rc" -eq 0 ] \
   && printf '%s' "$out" | grep -q '"settled":true' \
@@ -131,7 +133,8 @@ if [ "$rc" -eq 0 ] \
   && printf '%s' "$out" | grep -q '"timed_out":true' \
   && printf '%s' "$out" | grep -q '"settled":false' \
   && printf '%s' "$out" | grep -q '"missing":\["copilot"\]' \
-  && printf '%s' "$out" | grep -q '"arrived":false'; then
+  && printf '%s' "$out" | grep -q '"arrived":false' \
+  && printf '%s' "$out" | grep -q '"expected_unknown":false'; then
   echo "ok: gh-await-reviews times out with missing=[copilot] when copilot never posts"
 else echo "FAIL: gh-await-reviews missing copilot rc=$rc out=$out"; fail=1; fi
 
@@ -144,35 +147,76 @@ if [ "$rc" -eq 0 ] \
   && printf '%s' "$out" | grep -q '"settled":true' \
   && printf '%s' "$out" | grep -q '"name":"copilot"' \
   && printf '%s' "$out" | grep -q '"arrived":true' \
-  && printf '%s' "$out" | grep -q '"missing":\[\]'; then
+  && printf '%s' "$out" | grep -q '"missing":\[\]' \
+  && printf '%s' "$out" | grep -q '"expected_unknown":false'; then
   echo "ok: gh-await-reviews settles once the requested copilot review arrives"
 else echo "FAIL: gh-await-reviews copilot arrival rc=$rc out=$out"; fail=1; fi
 
-# Case D: no expected reviewer and nobody posted -> settle after GRACE, empty report.
+# Case D: no expected reviewer and nobody posted -> settle after GRACE, empty
+# report. CRT is old so the $expected_floor_s gate is already satisfied and
+# GRACE (not the floor) is what this case is exercising.
 fx="$awaitstub/d"; mkdir -p "$fx"
-: >"$fx/1"
+printf 'CRT\t%s\n' "$old" >"$fx/1"
 out=$(awaitenv "$fx" 42 2>/dev/null); rc=$?
 if [ "$rc" -eq 0 ] \
   && printf '%s' "$out" | grep -q '"settled":true' \
   && printf '%s' "$out" | grep -q '"timed_out":false' \
   && printf '%s' "$out" | grep -q '"expected":\[\]' \
   && printf '%s' "$out" | grep -q '"observed":\[\]' \
-  && printf '%s' "$out" | grep -q '"last_activity_at":null'; then
+  && printf '%s' "$out" | grep -q '"last_activity_at":null' \
+  && printf '%s' "$out" | grep -q '"expected_unknown":true'; then
   echo "ok: gh-await-reviews settles after GRACE when no automated review runs"
 else echo "FAIL: gh-await-reviews grace rc=$rc out=$out"; fail=1; fi
 
 # Case E: a non-copilot participant (e.g. coderabbit) is tracked without any
 # pre-arrival signal, and the PR author's own comment is not tracked. The
 # wrapper's --jq already drops the author, so the fixture only carries others.
+# CRT is old for the same reason as case D.
 fx="$awaitstub/e"; mkdir -p "$fx"
-printf 'ACT\tcoderabbitai\t%s\n' "$old" >"$fx/1"
+printf 'CRT\t%s\nACT\tcoderabbitai\t%s\n' "$old" "$old" >"$fx/1"
 out=$(awaitenv "$fx" 42 2>/dev/null); rc=$?
 if [ "$rc" -eq 0 ] \
   && printf '%s' "$out" | grep -q '"login":"coderabbitai"' \
   && printf '%s' "$out" | grep -q '"expected":\[\]' \
+  && printf '%s' "$out" | grep -q '"expected_unknown":true' \
   && printf '%s' "$out" | grep -q '"settled":true'; then
   echo "ok: gh-await-reviews tracks a non-copilot participant with no pre-arrival signal"
 else echo "FAIL: gh-await-reviews tracks coderabbit rc=$rc out=$out"; fail=1; fi
+
+# Case F: PR just created (CRT ~= now), nothing posted, no reviewer requested.
+# The floor (EXPECTED_FLOOR=90) outlives TIMEOUT=3, so an empty `expected`
+# must not be believed within either the GRACE or the timeout window -- the
+# floor keeps this timed_out rather than settling early, and does not itself
+# stretch the overall timeout past TIMEOUT.
+fx="$awaitstub/f"; mkdir -p "$fx"
+printf 'CRT\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$fx/1"
+out=$(env GH_AWAIT_REVIEWS_TIMEOUT=3 GH_AWAIT_REVIEWS_QUIET=1 GH_AWAIT_REVIEWS_GRACE=1 \
+  GH_AWAIT_REVIEWS_POLL=1 GH_AWAIT_REVIEWS_EXPECTED_FLOOR=90 \
+  GH_STUB_DIR="$fx" GH_STUB_COUNT="$fx/.count" PATH="$awaitstub:$PATH" \
+  "$bindir/gh-await-reviews" 42 2>/dev/null); rc=$?
+if [ "$rc" -eq 0 ] \
+  && printf '%s' "$out" | grep -q '"settled":false' \
+  && printf '%s' "$out" | grep -q '"timed_out":true' \
+  && printf '%s' "$out" | grep -Eq '"waited_seconds":[34]' \
+  && printf '%s' "$out" | grep -q '"expected_unknown":true'; then
+  echo "ok: gh-await-reviews floor outlasting TIMEOUT times out instead of settling early, without stretching TIMEOUT"
+else echo "FAIL: gh-await-reviews floor-outlives-timeout rc=$rc out=$out"; fail=1; fi
+
+# Case G: same fresh-PR fixture as F, but with a floor (1s) shorter than
+# TIMEOUT (3s) -- once the floor age is reached, an empty `expected` may be
+# believed and the PR settles instead of timing out.
+fx="$awaitstub/g"; mkdir -p "$fx"
+printf 'CRT\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$fx/1"
+out=$(env GH_AWAIT_REVIEWS_TIMEOUT=3 GH_AWAIT_REVIEWS_QUIET=1 GH_AWAIT_REVIEWS_GRACE=1 \
+  GH_AWAIT_REVIEWS_POLL=1 GH_AWAIT_REVIEWS_EXPECTED_FLOOR=1 \
+  GH_STUB_DIR="$fx" GH_STUB_COUNT="$fx/.count" PATH="$awaitstub:$PATH" \
+  "$bindir/gh-await-reviews" 42 2>/dev/null); rc=$?
+if [ "$rc" -eq 0 ] \
+  && printf '%s' "$out" | grep -q '"settled":true' \
+  && printf '%s' "$out" | grep -q '"timed_out":false' \
+  && printf '%s' "$out" | grep -q '"expected_unknown":true'; then
+  echo "ok: gh-await-reviews settles once a short floor has elapsed"
+else echo "FAIL: gh-await-reviews short-floor rc=$rc out=$out"; fail=1; fi
 
 # gh-await-reviews: missing / non-numeric / extra-flag arg fail (no flag passthrough).
 PATH="$awaitstub:$PATH" "$bindir/gh-await-reviews" >/dev/null 2>&1; [ $? -ne 0 ] \


### PR DESCRIPTION
## Summary

- `expected` が空のまま settle しようとするとき、PR の `createdAt` からの経過が `expected_floor_s`（既定 90 秒、`GH_AWAIT_REVIEWS_EXPECTED_FLOOR` で上書き可）未満なら settle せず polling を継続する。判定は `expected_settled()` に切り出し、grace 経路（何も予期せず誰も発言していない）と quiet 経路の両方に適用する。timeout チェックは従来どおり後段にあるので、この floor が全体 timeout を延長することはない。
- `createdAt` は既存の per-poll `gh pr view` に畳み込み、`CRT<TAB><iso8601>` 行として渡す（「1 poll = 1 gh call」を維持）。PR 作成時刻が取れない場合は fail-open（settle 許可）で、パース失敗が呼び出し側を吊らせない。
- 返す JSON に `expected_unknown` を追加。`expected` が空なら true、非空なら false。既存フィールド（`pr` / `settled` / `timed_out` / `waited_seconds` / `expected` / `observed` / `missing` / `last_activity_at`）は名前・意味とも不変。
- `pr-review-automerge` の手順 0 に、`expected` が空でも「レビュー bot 無し」と断定せず、実際に届いた review は判定役が `gh-pr-comments` で読む前提を維持する旨を追記。

## Why

review 要求の GitHub 側への登録は PR 作成に対して遅延しうるため、作成直後の `expected` 空は「期待する reviewer が居ない」証拠にならない。実観測（PR #537）:

- PR 作成直後に `gh-await-reviews 537` を実行 → 63 秒で settled、`expected` / `observed` / `missing` すべて空、`last_activity_at` は null。
- しかし実際には Copilot の review が `2026-07-27T08:46:57Z` に着いており、有効な指摘を 1 件含んでいた。
- 数分後に同じコマンドを再実行すると `expected` に copilot、`observed` に `copilot-pull-request-reviewer` が入った。

呼び出し側が `expected: []` を「bot 無し」と解釈すると AI レビューの指摘を丸ごと読み飛ばす経路になる。今回は判定役が `gh-pr-comments` を必ず読む設計と手順 3.a の遅着 review 再確認で救われたが、仕組みとしては穴が開いていた。`expected_unknown` は「bot が無効化されているのか登録が遅延しているのか区別できない」ことを呼び出し側に明示する。

## Verification

`bash -n` OK（shellcheck は既存の SC2016 のみ）。`gh` を stub して 4 ケース実測:

| ケース | 結果 |
|---|---|
| 古い PR・`expected` 空 | grace どおり 2s で settled、`expected_unknown: true` |
| 作成直後・floor 90s / timeout 8s | settle せず 8s ちょうどで `timed_out`（floor が timeout を延ばさない） |
| 作成直後・floor 6s / grace 2s | 2s ではなく 6s で settled（floor が効いている） |
| copilot が `reviewRequests` にいる | `expected_unknown: false`、floor 600s は無関係に従来動作 |

実 PR（#24）に対しても実行し、JSON が壊れていないことを確認済み。
