### PR TITLE
feat(pr-judge): 仕分けを coverage-first にし severity/confidence を添える

### DIFF
--- a/dot/claude/agents/pr-judge.md
+++ b/dot/claude/agents/pr-judge.md
@@ -19,13 +19,31 @@ model: opus
    重複の観点でレビューする。`/code-review` skill が使えるなら土台に使ってよい。
 4. **未解決 thread の取得**: `gh-list-threads <PR>` を実行し、`isResolved == false` の thread のみを
    対象にする。raw な `gh api graphql` は使わない。
-5. **仕分け**: findings と未解決 thread を「直す（fix 役へ渡す）」と「gate に残す（人間の議論待ち・
+5. **仕分け**: **まず見つけたものを全部いずれかのバケットに載せる。** 軽微だから・確信が持てない
+   からという理由で、バケットに載せずに落とすことはしない。妥当でないと判断したものは
+   `findings_gated` に `blocker: false` で載せ、`reason_gated` に却下理由を書く。仕分けは
+   「載せた後」に行う。理由: 報告の取捨選択をこの工程でやると、実際には妥当だった指摘が記録に
+   残らないまま消える。取捨選択は orchestrator と人間が gate を見て行える。
+
+   そのうえで findings と未解決 thread を「直す（fix 役へ渡す）」と「gate に残す（人間の議論待ち・
    コード修正で片付かないもの・そもそも妥当でないもの）」に分ける。gate は merge を止めるべきものだけ
    `blocker: true` にし、妥当でないと却下しただけのものは `blocker: false` にする（orchestrator が
-   `blocker` でループ継続を決めるため）。**resolve も push も commit もしない。**
+   `blocker` でループ継続を決めるため）。`findings_to_fix` / `findings_gated` の各要素には
+   `severity`（`high` / `medium` / `low`）と `confidence`（`high` / `medium` / `low`）を添え、
+   下流（orchestrator / 人間）がランク付けできるようにする。**resolve も push も commit もしない。**
    **PR コメント（reply も含め）は投稿しない。**
 6. **verdict 出力**: verdict JSON だけを出力する（説明文は付けない）。スキーマは
    `pr-review-automerge` skill の「判定 subagent prompt」節に示されたものに従う。
+
+<!-- 由来: 手順 5 の coverage-first（まず全件バケットに載せる）と `severity` / `confidence` は、
+     Claude Opus 5 が「保守的に報告せよ」「重大なものだけ報告せよ」といった severity フィルタ指示を
+     前世代より literal に守り、バグ発見能力は向上しているのに報告件数が減って recall が落ちたように
+     見える、という Anthropic 公式の Opus 5 移行ガイドの指摘に合わせたもの。公式の推奨パターンは
+     「見つけたものは確信度・重大度を添えて全部挙げさせ、フィルタは別工程でやる」。この repo では
+     orchestrator（`pr-review-automerge`）と人間が別工程として既に存在するので、判定役側は
+     coverage-first に寄せ、取捨選択を下流へ渡す。
+     同じ手順が `pr-review-automerge` skill の「判定 subagent prompt」にもあるので、片方だけ
+     変えない。 -->
 
 <!-- 決定済み（再指摘防止のため理由を残す）: 「コードを変更しない」を frontmatter の `tools:`
      allowlist で機械的に縛るかを検討し、**入れない**と決めた。理由:

--- a/dot/claude/agents/pr-judge.md
+++ b/dot/claude/agents/pr-judge.md
@@ -28,9 +28,14 @@ model: opus
    そのうえで findings と未解決 thread を「直す（fix 役へ渡す）」と「gate に残す（人間の議論待ち・
    コード修正で片付かないもの・そもそも妥当でないもの）」に分ける。gate は merge を止めるべきものだけ
    `blocker: true` にし、妥当でないと却下しただけのものは `blocker: false` にする（orchestrator が
-   `blocker` でループ継続を決めるため）。`findings_to_fix` / `findings_gated` の各要素には
+   `blocker` でループ継続を決めるため）。coverage-first は「載せるか落とすか」の話であって
+   「どのバケットに載せるか」ではない。修正の価値が薄い低 severity / 低 confidence の指摘は、
+   `findings_to_fix` ではなく `findings_gated`（`blocker: false`）に寄せてよい（`findings_to_fix`
+   が非空だと必ず次イテレーションが走るため、瑣末な指摘を積むと 5 回の上限を使い切ってしまう）。
+   `findings_to_fix` / `findings_gated` の各要素には
    `severity`（`high` / `medium` / `low`）と `confidence`（`high` / `medium` / `low`）を添え、
-   下流（orchestrator / 人間）がランク付けできるようにする。**resolve も push も commit もしない。**
+   下流（orchestrator / 人間）がランク付けできるようにする（`threads_pending` には添えない —
+   人間の議論待ちが主で意味が薄いため）。**resolve も push も commit もしない。**
    **PR コメント（reply も含め）は投稿しない。**
 6. **verdict 出力**: verdict JSON だけを出力する（説明文は付けない）。スキーマは
    `pr-review-automerge` skill の「判定 subagent prompt」節に示されたものに従う。

--- a/dot/claude/skills/pr-review-automerge/SKILL.md
+++ b/dot/claude/skills/pr-review-automerge/SKILL.md
@@ -123,6 +123,10 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
 >      片付かない・そもそも妥当でない（＝直さない理由がある）もの。merge を止めるべきものは
 >      `blocker: true` にする（人間の判断を待つべきもの）。妥当でないと判断して却下しただけの
 >      ものは `blocker: false` — 理由は残るが merge は止めない。
+>    - coverage-first は「載せるか落とすか」の話であって「どのバケットに載せるか」ではない。
+>      修正の価値が薄い低 severity / 低 confidence の指摘は、`findings_to_fix` ではなく
+>      `findings_gated`（`blocker: false`）に寄せてよい（`findings_to_fix` が非空だと必ず次
+>      イテレーションが走るため、瑣末な指摘を積むと 5 回の上限を使い切ってしまう）。
 >    - `findings_to_fix` / `findings_gated` の各要素には `severity`（`high` / `medium` / `low`）と
 >      `confidence`（`high` / `medium` / `low`）を添え、下流（orchestrator / 人間）がランク付け
 >      できるようにする。`threads_pending` には添えない（thread は人間の議論待ちが主で
@@ -202,3 +206,8 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
 `findings_gated` / `threads_pending` に `blocker: true` 無し && `mergeable==true`** を満たしたときのみ
 手順 3（遅着 review の再確認 → CI 確認 → auto-merge 有効化）に進む。gate の**非空**そのものは
 終端条件にしない（理由は手順 2.c）。
+
+`severity` / `confidence` は**継続判定（手順 2.c）には使わない**。終端条件は上記のとおり
+`blocker` の有無と `findings_to_fix` / `made_changes` / `mergeable` だけで決まり、この 2 フィールドは
+関与しない。用途は**報告専用**で、手順 3.e / 4 の最終サマリで findings を `severity` 降順
+（`high` → `medium` → `low`）に並べて出力し、orchestrator と人間が優先度を把握できるようにする。

--- a/dot/claude/skills/pr-review-automerge/SKILL.md
+++ b/dot/claude/skills/pr-review-automerge/SKILL.md
@@ -162,6 +162,10 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
 >   （例: `"copilot-pull-request-reviewer"`）。orchestrator が AI の指摘を握り潰していないか判定するために使う。
 > - `ci_status`: 把握できる範囲で `pending` / `pass` / `fail`。不明なら `pending`。
 > - `mergeable`: レビュー観点で merge して良いと判断したか。**ただし `ci_status` が `fail` の場合は必ず `false` にする**（orchestrator が再イテレーションするため）。
+>   `blocker: false` の gate（却下した指摘・低 severity / 低 confidence で `findings_gated` に寄せたもの）が
+>   残っているだけの状態は `mergeable: true` にしてよい。gate の非空は merge を止める理由にしない
+>   （手順 2.c と同じ理由）。ここを厳しく取ると、coverage-first で `findings_gated` が常時非空になった
+>   場合に `mergeable` 経由で手順 2.c が潰したはずの無限ループが復活する。
 
 ## 修正 subagent prompt（`<PR>` と `findings_to_fix` を埋めて `pr-fix` に渡す）
 

--- a/dot/claude/skills/pr-review-automerge/SKILL.md
+++ b/dot/claude/skills/pr-review-automerge/SKILL.md
@@ -110,13 +110,23 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
 > 4. **未解決 thread の取得**: `gh-list-threads <PR>` を実行する（reviewThreads の JSON が返る）。
 >    `isResolved == false` の thread（`id` / `comments` 等）のみ対象にする。raw な
 >    `gh api graphql` は使わない。
-> 5. **仕分け**: findings と未解決 thread を 2 つに分ける。
+> 5. **仕分け**: **まず見つけたものを全部いずれかのバケットに載せる。** 軽微だから・確信が持てない
+>    からという理由で、バケットに載せずに落とすことはしない。妥当でないと判断したものは
+>    `findings_gated` に `blocker: false` で載せ、`reason_gated` に却下理由を書く。仕分けは
+>    「載せた後」に行う。理由: 報告の取捨選択をこの工程でやると、実際には妥当だった指摘が記録に
+>    残らないまま消える。取捨選択は orchestrator と人間が gate を見て行える。
+>
+>    そのうえで findings と未解決 thread を 2 つに分ける。
 >    - **直す** → `findings_to_fix`。コード修正で対応できるもの。修正役が実装できるだけの具体性
 >      （対象ファイル・何をどう直すか）を書く。thread 由来なら `thread_id` を添える。
 >    - **gate に残す** → `findings_gated` / `threads_pending`。人間の議論が必要・コード修正で
 >      片付かない・そもそも妥当でない（＝直さない理由がある）もの。merge を止めるべきものは
 >      `blocker: true` にする（人間の判断を待つべきもの）。妥当でないと判断して却下しただけの
 >      ものは `blocker: false` — 理由は残るが merge は止めない。
+>    - `findings_to_fix` / `findings_gated` の各要素には `severity`（`high` / `medium` / `low`）と
+>      `confidence`（`high` / `medium` / `low`）を添え、下流（orchestrator / 人間）がランク付け
+>      できるようにする。`threads_pending` には添えない（thread は人間の議論待ちが主で
+>      severity / confidence の意味が薄いため）。
 >    - **あなたは commit / push / `gh-resolve-thread` を実行しない。** これらは修正役の担当。
 >    - **PR コメント（reply も含め）は投稿しない。**
 >    - standalone コメント（`gh-pr-comments` が返すもの）は **resolve できない**。コード修正で対応させるなら
@@ -125,8 +135,8 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
 >
 > ```json
 > {
->   "findings_to_fix": [{"summary": "...", "detail": "...", "thread_id": null, "source": "self"}],
->   "findings_gated": [{"summary": "...", "reason_gated": "...", "blocker": false, "source": "self"}],
+>   "findings_to_fix": [{"summary": "...", "detail": "...", "thread_id": null, "source": "self", "severity": "medium", "confidence": "high"}],
+>   "findings_gated": [{"summary": "...", "reason_gated": "...", "blocker": false, "source": "self", "severity": "low", "confidence": "low"}],
 >   "threads_pending": [{"thread_id": "...", "summary": "...", "blocker": true, "source": "copilot"}],
 >   "ci_status": "pending",
 >   "mergeable": false,
@@ -139,6 +149,11 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
 > - `findings_gated`: 直さないと判断した findings（無ければ空配列）。`reason_gated` に理由を書く。
 >   `blocker` は merge を止めるべきか（人間の判断待ち = `true`、妥当でないと却下しただけ = `false`）。
 > - `threads_pending`: resolve せず残す thread（無ければ空配列）。`blocker` は merge を止めるべきか。
+>   `severity` / `confidence` は付けない（thread は人間の議論待ちが主で意味が薄いため）。
+> - `severity` / `confidence`: `findings_to_fix` / `findings_gated` の各要素に付ける。ともに
+>   `high` / `medium` / `low`。`severity` は指摘の重大度、`confidence` はその指摘が妥当だと
+>   どれだけ確信しているか。手順 5 のとおり**この 2 つを理由に findings を落とさない** — 低い値を
+>   添えて載せる。下流（orchestrator / 人間）がランク付けに使う。
 > - `source`: その指摘の出所。`"self"`（あなた自身のレビュー）または指摘した bot / 人間の login
 >   （例: `"copilot-pull-request-reviewer"`）。orchestrator が AI の指摘を握り潰していないか判定するために使う。
 > - `ci_status`: 把握できる範囲で `pending` / `pass` / `fail`。不明なら `pending`。


### PR DESCRIPTION
## 背景

Anthropic 公式の Claude Opus 5 移行ガイドによれば、Opus 5 は「保守的に報告せよ」「重大なものだけ報告せよ」といった severity フィルタ指示を前世代より literal に守る。その結果、バグ発見能力自体は向上しているのに **報告される件数が減って recall が落ちたように見える**。公式の推奨パターンは「見つけたものは確信度・重大度を添えて全部挙げさせ、フィルタは別工程でやる」。

判定役（`pr-judge`）の手順 5 は findings を `findings_to_fix` / `findings_gated` / `threads_pending` の 3 バケットへ仕分ける良い構造になっているが、「そもそも妥当でない」と判断したものをバケットに載せずに落とす余地があり、軽微・低確信の指摘が黙って消える。この repo では orchestrator（`pr-review-automerge`）が別工程として既に存在するので、判定役側に coverage-first を明示するだけで公式パターンに乗る。

## 変更

1. **coverage-first の明示**（両ファイルの手順 5 冒頭）
   まず見つけたものを全部いずれかのバケットに載せる。軽微・低確信を理由にバケットに載せずに落とさない。妥当でないと判断したものは `findings_gated` に `blocker: false` で載せ、`reason_gated` に却下理由を書く。仕分けは「載せた後」に行う。理由も併記（`rule-authoring.md` に従う）。

2. **`severity` / `confidence` の追加**
   `findings_to_fix` / `findings_gated` の各要素に `severity`（high/medium/low）と `confidence`（high/medium/low）を追加。下流（orchestrator / 人間）がランク付けできるようにするため。SKILL.md の JSON スキーマ例とフィールド説明リストの両方を更新。`threads_pending` には追加しない（thread は人間の議論待ちが主で意味が薄いため）。

3. **由来コメント**（`pr-judge.md`）
   Opus 5 移行ガイドに由来する変更である旨と、同じ手順が SKILL.md にも二重にあるので片方だけ変えない旨を残した。

## 不変条件（変えていないこと）

- 3 バケットの構造、`blocker` の意味（人間の判断待ち = `true` / 却下しただけ = `false`）
- 判定役は commit / push / resolve しない、PR コメントを投稿しない
- orchestrator のループ継続判定（`blocker: false` の gate はループを止めない）

`pr-fix` に渡る `findings_to_fix` にフィールドが増えるが、修正役は `summary` / `detail` / `thread_id` しか読まないので互換性の問題は無い。

## 検証

`test/*.test.sh`（3 本）全て PASS。markdown 側の lint は repo に無し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)