### PR TITLE
fix(claude-worktree): check out remote-only branches instead of forking HEAD

### DIFF
--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -43,7 +43,9 @@ set -euo pipefail
 #                  uncommitted notes). Must live inside cwd's checkout.
 #   name           worktree label (suffix after the underscore); also the new
 #                  branch name when -b is omitted
-#   -b <branch>    branch to check out / create (default: <name>)
+#   -b <branch>    branch to check out / create (default: <name>). Resolved as:
+#                  local branch, else origin/<branch> (tracked, no fetch), else
+#                  created fresh from the current HEAD.
 #   -- <prompt>    everything after `--` is the initial prompt; when given, an
 #                  interactive claude (acceptEdits) is started in a detached tmux
 #                  session in the worktree. Attach with the printed command.
@@ -131,7 +133,19 @@ fi
 if [ -d "$wt_path" ]; then
   echo "claude-worktree: worktree dir already exists, reusing: $wt_path" >&2
 elif git -C "$repo_dir" show-ref --verify --quiet "refs/heads/${branch}"; then
-  git -C "$repo_dir" worktree add "$wt_path" "$branch" >&2    # existing branch
+  git -C "$repo_dir" worktree add "$wt_path" "$branch" >&2               # existing local branch
+elif git -C "$repo_dir" show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
+  # Branch has no local tracking branch but exists on origin: check it out
+  # explicitly from origin/<branch> rather than relying on `git worktree add`'s
+  # DWIM resolution. git-worktree(1) says a bare <branch> with no local match
+  # behaves like `--track -b` only when it "uniquely" identifies a remote-tracking
+  # branch across ALL remotes; with more than one remote (or none) the outcome
+  # depends on checkout.defaultRemote. Naming `origin` explicitly makes this
+  # deterministic regardless of remote configuration -- and matches this repo's
+  # other origin-assuming script, git-reap-gone. No fetch happens here: if the
+  # branch was never fetched, this check simply misses and falls through to the
+  # "new branch" case below, same as before this case existed.
+  git -C "$repo_dir" worktree add --track -b "$branch" "$wt_path" "origin/${branch}" >&2 # remote-only branch
 else
   git -C "$repo_dir" worktree add -b "$branch" "$wt_path" >&2 # new branch
 fi

--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -81,7 +81,8 @@ claude-worktree <name> [-b <branch>] [-- <prompt...>]
 
 - worktree を `<メインリポジトリ toplevel>_<name>` に作成
 - `name` は `[A-Za-z0-9_-]+` のみ許可（`.`/`:` は tmux ターゲット構文と衝突するため拒否）
-- `-b` 省略時はブランチ名 = `<name>`（既存なら check out、無ければ新規）
+- `-b` 省略時はブランチ名 = `<name>`。解決順はローカルブランチ → `origin/<branch>` を追跡 checkout →
+  どちらにも無ければ新規作成（fetch はしない）
 - プロンプト無し: worktree 追加のみ。stdout にパスのみ出力（`git wa` の置き換え）
 - プロンプト有り: **detached tmux session（名前 = worktree basename）を作り、その pane の中で
   interactive claude（`acceptEdits`）を起動**

--- a/dot/claude/rules/worktree-scope.md
+++ b/dot/claude/rules/worktree-scope.md
@@ -103,7 +103,7 @@ claude-worktree [--self] [--model <alias>] [--seed <path>]... <name> [-b <branch
 ```
 
 - worktree は `<メインリポジトリ toplevel>_<name>` に作られる（メイン基準なので worktree 内から切ってもパスがネストしない。区切りは tmux 安全な `_`。`.` は `tmux -t` の `window.pane` 構文と衝突するため不可）
-- `-b` 省略時はブランチ名 = `<name>`。既存ブランチ名なら check out、無ければ新規作成
+- `-b` 省略時はブランチ名 = `<name>`。解決順はローカルブランチ優先 → 無ければ `origin/<branch>` を追跡 checkout → どちらにも無ければ新規作成。fetch はしない（未 fetch なら新規作成に落ちる）
 - `--` の後ろにプロンプトを渡すと、**新規の detached tmux セッション（名前 = worktree basename）を worktree dir に作り、その pane の中で interactive claude（`acceptEdits`）を起動**する。pane が独立するので `$TMUX_PANE` も独立し、claude-queue が起動元 pane と衝突せず正しく追跡する。interactive なので初期プロンプト処理後も REPL に留まり、`gts <session>` / `tmux attach -t <session>` で**いつでも attach して続行できる（`claude --resume` 不要）**
 - プロンプト無しなら worktree 追加のみ（stdout にパスのみ出力。`git wa` の置き換え）
 - `--self` は worktree の基準 repo を、cwd の repo ではなく **`claude-worktree` 自身が置かれている repo**（symlink 解決後。= dotrc）にする。無関係な project で作業中に dotrc のグローバル harness（rules / skills / bin）を切りたいときに使う。`--seed` のコピー元は `--self` の有無に関わらず cwd の checkout のまま

--- a/test/claude-worktree.test.sh
+++ b/test/claude-worktree.test.sh
@@ -240,4 +240,98 @@ if [ "$rc" -ne 0 ] && [ ! -d "${cwdrepo}_emptymodel" ]; then
   echo "ok: empty --model value is rejected before the worktree is created"
 else echo "FAIL: empty --model accepted rc=$rc"; fail=1; fi
 
+# --- remote-only branch resolution --------------------------------------------
+# `-b <branch>` must resolve against LOCAL branches, then origin's remote-tracking
+# branches, before falling back to "create new from current HEAD". A dedicated
+# bare origin + clone (not cwdrepo/scriptrepo, to avoid interfering with the
+# tests above) lets us push branches that never get a local tracking branch.
+
+remotesrc="$tmp/remotesrc"
+mkdir -p "$remotesrc"
+git -C "$remotesrc" init -q
+git -C "$remotesrc" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+
+originbare="$tmp/origin.git"
+git init -q --bare "$originbare"
+# Push the initial commit to an explicit "main" ref, then point the bare repo's
+# HEAD at it directly -- `git init --bare`'s HEAD follows init.defaultBranch,
+# which varies by environment, so this is what makes `git clone` below check out
+# the branch we actually intend ("main") rather than whatever the default was.
+git -C "$remotesrc" push -q "$originbare" HEAD:refs/heads/main
+git -C "$originbare" symbolic-ref HEAD refs/heads/main
+
+# origin-only branch: pushed to origin, then deleted locally, so nothing but the
+# remote-tracking ref (refs/remotes/origin/remoteonly) will exist in the clone.
+git -C "$remotesrc" checkout -q -b remoteonly
+echo "remote content" >"$remotesrc/remote.txt"
+git -C "$remotesrc" add remote.txt
+git -C "$remotesrc" -c user.email=t@t -c user.name=t commit -q -m "remote-only commit"
+git -C "$remotesrc" push -q "$originbare" remoteonly
+remote_only_sha="$(git -C "$remotesrc" rev-parse remoteonly)"
+git -C "$remotesrc" checkout -q main
+git -C "$remotesrc" branch -q -D remoteonly
+
+# a branch that will exist BOTH locally (in the clone, below) and on origin, at
+# DIFFERENT commits -- proves local takes precedence over same-named remote.
+git -C "$remotesrc" checkout -q -b localdiff
+echo "origin's localdiff content" >"$remotesrc/localdiff.txt"
+git -C "$remotesrc" add localdiff.txt
+git -C "$remotesrc" -c user.email=t@t -c user.name=t commit -q -m "origin's localdiff commit"
+git -C "$remotesrc" push -q "$originbare" localdiff
+git -C "$remotesrc" checkout -q main
+git -C "$remotesrc" branch -q -D localdiff
+
+clone2="$tmp/clone2"
+git clone -q "$originbare" "$clone2"
+clone_head_sha="$(git -C "$clone2" rev-parse HEAD)"
+
+# Give the clone its OWN local "localdiff" branch, at a commit that differs from
+# origin/localdiff (sanity-checked below so this can't pass vacuously).
+git -C "$clone2" checkout -q -b localdiff main
+echo "local's localdiff content" >"$clone2/localdiff.txt"
+git -C "$clone2" add localdiff.txt
+git -C "$clone2" -c user.email=t@t -c user.name=t commit -q -m "local's localdiff commit"
+local_localdiff_sha="$(git -C "$clone2" rev-parse localdiff)"
+origin_localdiff_sha="$(git -C "$clone2" rev-parse origin/localdiff)"
+git -C "$clone2" checkout -q main
+
+if [ "$local_localdiff_sha" = "$origin_localdiff_sha" ] || [ "$remote_only_sha" = "$clone_head_sha" ]; then
+  echo "FAIL: test setup produced colliding shas, the assertions below would be vacuous"; fail=1
+fi
+
+# Case 1: branch absent locally but present on origin -> checked out at origin's
+# commit (NOT built fresh from the clone's current HEAD, which is the bug) and
+# tracking origin/<branch>.
+out="$(cd "$clone2" && "$wt" remoteonlytest -b remoteonly 2>/dev/null)"; rc=$?
+wt_sha="$(git -C "$out" rev-parse HEAD 2>/dev/null)"
+wt_upstream="$(git -C "$out" rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null)"
+if [ "$rc" -eq 0 ] && [ "$wt_sha" = "$remote_only_sha" ] && [ "$wt_upstream" = "origin/remoteonly" ]; then
+  echo "ok: remote-only branch checks out origin's commit and tracks origin/<branch>"
+else
+  echo "FAIL: remote-only branch rc=$rc sha=$wt_sha want=$remote_only_sha upstream=$wt_upstream want=origin/remoteonly"
+  fail=1
+fi
+
+# Case 2: branch exists both locally and on origin, at different commits -> the
+# LOCAL branch wins (must not be pulled from origin just because origin also
+# has it).
+out="$(cd "$clone2" && "$wt" localdifftest -b localdiff 2>/dev/null)"; rc=$?
+wt_sha="$(git -C "$out" rev-parse HEAD 2>/dev/null)"
+if [ "$rc" -eq 0 ] && [ "$wt_sha" = "$local_localdiff_sha" ]; then
+  echo "ok: local branch takes precedence over a same-named branch on origin"
+else
+  echo "FAIL: local-branch precedence rc=$rc sha=$wt_sha want=$local_localdiff_sha (origin has $origin_localdiff_sha)"
+  fail=1
+fi
+
+# Case 3: branch absent from both local and origin -> unchanged behavior, a new
+# branch created from the clone's current HEAD.
+out="$(cd "$clone2" && "$wt" newbranchtest -b brandnew 2>/dev/null)"; rc=$?
+wt_sha="$(git -C "$out" rev-parse HEAD 2>/dev/null)"
+if [ "$rc" -eq 0 ] && [ "$wt_sha" = "$clone_head_sha" ]; then
+  echo "ok: branch absent from both local and origin is created fresh from current HEAD"
+else
+  echo "FAIL: new-branch fallback rc=$rc sha=$wt_sha want=$clone_head_sha"; fail=1
+fi
+
 exit "$fail"

--- a/test/claude-worktree.test.sh
+++ b/test/claude-worktree.test.sh
@@ -250,6 +250,10 @@ remotesrc="$tmp/remotesrc"
 mkdir -p "$remotesrc"
 git -C "$remotesrc" init -q
 git -C "$remotesrc" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+# `git init`'s initial branch follows init.defaultBranch, which varies by
+# environment (e.g. "master" instead of "main") -- pin it explicitly so the
+# `checkout -q main` calls below don't fail on non-"main"-default setups.
+git -C "$remotesrc" branch -q -M main
 
 originbare="$tmp/origin.git"
 git init -q --bare "$originbare"


### PR DESCRIPTION
## 問題

`bin/claude-worktree` の worktree 作成部が `refs/heads/` しか見ておらず、**origin にはあるがローカル追跡ブランチが無いブランチ名を `-b` に渡すと、そのブランチを check out せず現在の HEAD から同名の新規ブランチを作ってしまう**。

他人の PR を引き継ごうと `claude-worktree ... -b feature/xxx` を実行すると、PR の head ではなく当時の作業ブランチを土台にした worktree ができる。委譲先は detached で人間が不在なので、この取り違えは気付かれないまま誤ったベースの上に実装が積まれる。

## 修正

`refs/heads/` の分岐と `else`（新規作成）の**間に** `refs/remotes/origin/<branch>` の分岐を挿入し、`git worktree add --track -b "$branch" "$wt_path" "origin/${branch}"` で明示的に check out する。

- **DWIM に任せず明示形にする理由**: `git-worktree(1)` は「branch が見つからず `-b`/`-B`/`--detach` も無く、**ちょうど 1 つの remote** に一致する追跡ブランチがあれば `--track -b` 相当」と定める。remote が複数あると `checkout.defaultRemote` 次第で挙動が変わるため、明示形にして remote 構成に依存しない決定的な形にした。
- **`origin` 決め打ち**: 同じ `bin/` の `git-reap-gone` が既に `origin/HEAD` 前提。揃えた。
- **ローカル優先の順序は維持**: 両方にある場合は従来どおりローカルを check out（分岐を `refs/heads/` の後ろに置いた）。
- **fetch はしない**: 未 fetch で `refs/remotes/origin/<branch>` が無ければ従来どおり新規作成に落ちる。暗黙 fetch は起動を遅くし副作用があるため入れない。

`dot/claude/rules/worktree-scope.md` §6 の `-b` の解決順の記述も実態に合わせて更新した。

## テスト

`test/claude-worktree.test.sh` の末尾に、専用の bare origin + clone を組んだ 3 ケースを追加（既存テストの `$cwdrepo` / `$scriptrepo` には触れず干渉を避けている）。

1. **remote-only**: HEAD が origin 側の commit と一致し、upstream が `origin/<branch>` になること
2. **ローカル既存**（origin にも同名で別 sha がある）: ローカル側 sha が check out されること
3. **どちらにも無い**: 従来どおり clone の現在 HEAD から新規作成されること

setup の sha が衝突していたら assertion が vacuous になるので、その sanity check も入れてある。

修正前（新テストが期待どおり落ちる）:

```
ok: empty --model value is rejected before the worktree is created
FAIL: remote-only branch rc=0 sha=36e183a6f5504ac1293d3e20f8378ada799a1407 want=06df80b4ede348104e188208aa0d0ea45b1094df upstream= want=origin/remoteonly
ok: local branch takes precedence over a same-named branch on origin
ok: branch absent from both local and origin is created fresh from current HEAD
EXIT=1
```

修正後（21 件すべて ok）:

```
...
ok: remote-only branch checks out origin's commit and tracks origin/<branch>
ok: local branch takes precedence over a same-named branch on origin
ok: branch absent from both local and origin is created fresh from current HEAD
EXIT=0
```

`test/gh-wrappers.test.sh` / `test/claude-review.test.sh` も EXIT=0。`bash -n` 通過。`shellcheck bin/claude-worktree test/claude-worktree.test.sh` の残指摘はすべて既存行（今回追加した行にはゼロ）。

## スコープ

`--self` / `--seed` / `--model` の挙動は変えていない。変更は上記 3 ファイルのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
