### PR TITLE
docs(gh-commands): point PR comment reading at gh-pr-comments

### DIFF
--- a/dot/claude/rules/gh-commands.md
+++ b/dot/claude/rules/gh-commands.md
@@ -8,8 +8,8 @@ GitHub CLI (`gh`) を使うときの方針。permission rule との整合性の�
 
 | やりたいこと | 使うべきコマンド | `gh api` を避ける理由 |
 |---|---|---|
-| PR の概要・本文を読む | `gh pr view <N>` | 高位コマンドの方が安全・読みやすい。ただし `gh pr view <N>` も内部クエリに statusCheckRollup を含むため、check runs が付いた PR では fine-grained PAT で失敗しうる（次行と同根）。その場合は `--json title,body` のように必要フィールドだけ指定すると rollup を引かない |
-| PR のコメント一覧を読む | `gh-pr-comments <N>`（§5 参照） | `gh pr view <N> --comments` は内部クエリに statusCheckRollup を含むため、check runs が付いた PR では fine-grained PAT で失敗し、コメント本文が一切返らない（§5 と同根の権限不足。commit status のみの PR は §5 のとおり通るのでここでは失敗要因に含めない）。`gh-pr-comments` は read-only な `gh pr view --json reviews,comments` の薄いラッパーで、`gh api` は使わない。この行は `gh api` 回避の話ではなく、高位コマンドの表示形が fine-grained PAT の権限不足で使えないための代替である。`--json comments` は standalone comments のみで review body（Copilot の review サマリ等）を落とすため代替にならない（`gh-pr-comments` を使う） |
+| PR の概要・本文を読む | `gh pr view <N>` | 高位コマンドの方が安全・読みやすい。ただし `gh pr view <N>` も内部クエリに statusCheckRollup を含むため、token に check runs の読み取り権限が無い場合は fine-grained PAT で失敗しうる（次行と同根）。その場合は `--json title,body` のように必要フィールドだけ指定すると rollup を引かない |
+| PR のコメント一覧を読む | `gh-pr-comments <N>`（§5 参照） | `gh pr view <N> --comments` は内部クエリに statusCheckRollup を含むため、token に check runs の読み取り権限が無い場合は fine-grained PAT で失敗し、コメント本文が一切返らないことがある（実測は別 repo・別 token での事例）。`gh-pr-comments` は read-only な `gh pr view --json reviews,comments` の薄いラッパーで、`gh api` は使わない。`--json comments` は standalone comments のみで review body（Copilot の review サマリ等）を落とすため代替にならない（`gh-pr-comments` を使う） |
 | PR の diff を読む | `gh pr diff <N>` | 同上 |
 | PR の CI 状態を見る | `gh-pr-checks <N>`（§5 参照） | `gh pr checks` は fine-grained PAT では**必ず失敗する**（statusCheckRollup が check runs 権限を要求するが、fine-grained token にはその権限自体が存在しない）。`gh-pr-checks` は読み取り専用の `gh api`（`actions/runs` と `commits/<sha>/status`）2 本を合成する薄いラッパーで、高位コマンドが使えない代替であって「`gh api` を避けている」わけではない |
 | PR にコメントを投げる | `gh pr comment <N> -b "..."` | 後述の reply ポリシーを守りつつ簡潔 |

--- a/dot/claude/rules/gh-commands.md
+++ b/dot/claude/rules/gh-commands.md
@@ -9,7 +9,7 @@ GitHub CLI (`gh`) を使うときの方針。permission rule との整合性の�
 | やりたいこと | 使うべきコマンド | `gh api` を避ける理由 |
 |---|---|---|
 | PR の概要・本文を読む | `gh pr view <N>` | 高位コマンドの方が安全・読みやすい |
-| PR のコメント一覧を読む | `gh pr view <N> --comments` | 同上 |
+| PR のコメント一覧を読む | `gh-pr-comments <N>`（§5 参照） | `gh pr view <N> --comments` は内部クエリに statusCheckRollup を含むため、check runs / commit status が付いた PR では fine-grained PAT で失敗し、コメント本文が一切返らない（§5 と同根の権限不足）。`gh-pr-comments` は read-only な `gh pr view --json reviews,comments` の薄いラッパーで、高位コマンドの表示形が使えないときの代替であって「`gh api` を避けている」わけではない（`gh api` は使わない）。低レイヤでよければ `gh pr view <N> --json comments` も同じ token で通る |
 | PR の diff を読む | `gh pr diff <N>` | 同上 |
 | PR の CI 状態を見る | `gh-pr-checks <N>`（§5 参照） | `gh pr checks` は fine-grained PAT では**必ず失敗する**（statusCheckRollup が check runs 権限を要求するが、fine-grained token にはその権限自体が存在しない）。`gh-pr-checks` は読み取り専用の `gh api`（`actions/runs` と `commits/<sha>/status`）2 本を合成する薄いラッパーで、高位コマンドが使えない代替であって「`gh api` を避けている」わけではない |
 | PR にコメントを投げる | `gh pr comment <N> -b "..."` | 後述の reply ポリシーを守りつつ簡潔 |
@@ -77,6 +77,7 @@ PR review・コメント確認を依頼されたとき、**reply コメントの
 
 - **allow:** read 系の高位コマンド（`gh pr view *`, `gh pr diff *`, `gh run view *`, `gh repo view *`）と PR 作成（`gh pr create *`）
   - CI 状態の確認は `gh pr checks *` を allow しない。pattern 自体は正しくマッチするが、fine-grained PAT では実行すれば必ず失敗する（§1 / §5 の理由）ので、allow しておいても許可する意味が無い（`claude-settings.md` が定義する「pattern がマッチしない dead rule」とは別物）。代わりに §5 の `gh-pr-checks *` を allow する
+  - コメント取得の `gh pr view <N> --comments` も `gh pr view *` の pattern にはマッチするが、fine-grained PAT では失敗しうる（§1）。ただし `gh pr view *` は他の read 用途で必要なので allow は維持し、コメント取得には §5 の `gh-pr-comments *` を使う
 - **allow しない:** `gh api *`, `gh pr comment *`, `gh pr review *`, `gh pr merge *` 等の書き込み・低レイヤ
   - allow に無いので呼び出し時に prompt が出る → ユーザー確認経由で実行可
 - **deny:** 不要（hard-block は明示指示時の運用を阻害する）

--- a/dot/claude/rules/gh-commands.md
+++ b/dot/claude/rules/gh-commands.md
@@ -9,7 +9,7 @@ GitHub CLI (`gh`) を使うときの方針。permission rule との整合性の�
 | やりたいこと | 使うべきコマンド | `gh api` を避ける理由 |
 |---|---|---|
 | PR の概要・本文を読む | `gh pr view <N>` | 高位コマンドの方が安全・読みやすい |
-| PR のコメント一覧を読む | `gh-pr-comments <N>`（§5 参照） | `gh pr view <N> --comments` は内部クエリに statusCheckRollup を含むため、check runs / commit status が付いた PR では fine-grained PAT で失敗し、コメント本文が一切返らない（§5 と同根の権限不足）。`gh-pr-comments` は read-only な `gh pr view --json reviews,comments` の薄いラッパーで、高位コマンドの表示形が使えないときの代替であって「`gh api` を避けている」わけではない（`gh api` は使わない）。低レイヤでよければ `gh pr view <N> --json comments` も同じ token で通る |
+| PR のコメント一覧を読む | `gh-pr-comments <N>`（§5 参照） | `gh pr view <N> --comments` は内部クエリに statusCheckRollup を含むため、check runs が付いた PR では fine-grained PAT で失敗し、コメント本文が一切返らない（§5 と同根の権限不足。commit status のみの PR は §5 のとおり通るのでここでは失敗要因に含めない）。`gh-pr-comments` は read-only な `gh pr view --json reviews,comments` の薄いラッパーで、高位コマンドの表示形が使えないときの代替であって「`gh api` を避けている」わけではない（`gh api` は使わない）。`--json comments` は standalone comments のみで review body（Copilot の review サマリ等）を落とすため代替にならない（`gh-pr-comments` を使う） |
 | PR の diff を読む | `gh pr diff <N>` | 同上 |
 | PR の CI 状態を見る | `gh-pr-checks <N>`（§5 参照） | `gh pr checks` は fine-grained PAT では**必ず失敗する**（statusCheckRollup が check runs 権限を要求するが、fine-grained token にはその権限自体が存在しない）。`gh-pr-checks` は読み取り専用の `gh api`（`actions/runs` と `commits/<sha>/status`）2 本を合成する薄いラッパーで、高位コマンドが使えない代替であって「`gh api` を避けている」わけではない |
 | PR にコメントを投げる | `gh pr comment <N> -b "..."` | 後述の reply ポリシーを守りつつ簡潔 |

--- a/dot/claude/rules/gh-commands.md
+++ b/dot/claude/rules/gh-commands.md
@@ -8,8 +8,8 @@ GitHub CLI (`gh`) を使うときの方針。permission rule との整合性の�
 
 | やりたいこと | 使うべきコマンド | `gh api` を避ける理由 |
 |---|---|---|
-| PR の概要・本文を読む | `gh pr view <N>` | 高位コマンドの方が安全・読みやすい |
-| PR のコメント一覧を読む | `gh-pr-comments <N>`（§5 参照） | `gh pr view <N> --comments` は内部クエリに statusCheckRollup を含むため、check runs が付いた PR では fine-grained PAT で失敗し、コメント本文が一切返らない（§5 と同根の権限不足。commit status のみの PR は §5 のとおり通るのでここでは失敗要因に含めない）。`gh-pr-comments` は read-only な `gh pr view --json reviews,comments` の薄いラッパーで、高位コマンドの表示形が使えないときの代替であって「`gh api` を避けている」わけではない（`gh api` は使わない）。`--json comments` は standalone comments のみで review body（Copilot の review サマリ等）を落とすため代替にならない（`gh-pr-comments` を使う） |
+| PR の概要・本文を読む | `gh pr view <N>` | 高位コマンドの方が安全・読みやすい。ただし `gh pr view <N>` も内部クエリに statusCheckRollup を含むため、check runs が付いた PR では fine-grained PAT で失敗しうる（次行と同根）。その場合は `--json title,body` のように必要フィールドだけ指定すると rollup を引かない |
+| PR のコメント一覧を読む | `gh-pr-comments <N>`（§5 参照） | `gh pr view <N> --comments` は内部クエリに statusCheckRollup を含むため、check runs が付いた PR では fine-grained PAT で失敗し、コメント本文が一切返らない（§5 と同根の権限不足。commit status のみの PR は §5 のとおり通るのでここでは失敗要因に含めない）。`gh-pr-comments` は read-only な `gh pr view --json reviews,comments` の薄いラッパーで、`gh api` は使わない。この行は `gh api` 回避の話ではなく、高位コマンドの表示形が fine-grained PAT の権限不足で使えないための代替である。`--json comments` は standalone comments のみで review body（Copilot の review サマリ等）を落とすため代替にならない（`gh-pr-comments` を使う） |
 | PR の diff を読む | `gh pr diff <N>` | 同上 |
 | PR の CI 状態を見る | `gh-pr-checks <N>`（§5 参照） | `gh pr checks` は fine-grained PAT では**必ず失敗する**（statusCheckRollup が check runs 権限を要求するが、fine-grained token にはその権限自体が存在しない）。`gh-pr-checks` は読み取り専用の `gh api`（`actions/runs` と `commits/<sha>/status`）2 本を合成する薄いラッパーで、高位コマンドが使えない代替であって「`gh api` を避けている」わけではない |
 | PR にコメントを投げる | `gh pr comment <N> -b "..."` | 後述の reply ポリシーを守りつつ簡潔 |


### PR DESCRIPTION
## 問題

`dot/claude/rules/gh-commands.md` §1 の表（高位サブコマンド優先の指針）が、「PR のコメント一覧を読む」に `gh pr view <N> --comments` を挙げていた。このコマンドは内部クエリに statusCheckRollup を含むため、check runs / commit status が付いた PR では fine-grained PAT で失敗する。

実測（eversteel/tetsunavi-monorepo PR #6269 に対する `gh pr view 6269 --comments`）ではコメント本文が一切返らず、以下の形のエラーが 100 件返って終了した。

```
GraphQL: Resource not accessible by personal access token
(repository.pullRequest.statusCheckRollup.nodes.0.commit.statusCheckRollup.contexts.nodes.0),
... (nodes.99 まで)
```

エラーパスが statusCheckRollup 配下である点が根拠で、同じ §1 の `gh pr checks` 行と §5 が既に説明している「fine-grained token には check runs を読む権限がそもそも存在しない」と同根。なお `gh pr view <N> --json comments` は同じ token で成功する。

§1 は agent が初手のコマンドを選ぶ表なので、空振りする指示を残すと PR コメントを読む作業のたびに 1 往復を無駄にする（実際にこの誤指示を踏んで停止した）。

## 変更

- §1 の該当行の「使うべきコマンド」を、既存の read-only ラッパー `gh-pr-comments <N>`（§5 で定義済み・`Bash(gh-pr-comments *)` で allowlist 済み）へ差し替え
- 同行の理由列を実態に合わせて書き直し。低レイヤの代替として `gh pr view <N> --json comments` にも言及
- §4 に 1 行補足。`gh pr view *` の pattern は `--comments` にもマッチするが、`gh pr checks *` と違い `gh pr view *` 自体は他の read 用途で必要なので allow は維持し、コメント取得だけ `gh-pr-comments *` に寄せる旨

断定の強さには注意した。`gh pr checks` は statusCheckRollup そのものを読むので「必ず失敗する」と書けるが、`gh pr view --comments` は rollup が空の PR では成功しうるため「check runs / commit status が付いた PR では失敗する」相当に留めている。

## スコープ

変更は `dot/claude/rules/gh-commands.md` のみ。§5 のラッパー表と `bin/` 配下の実装、`.claude/settings.json` の allowlist、§2 §3 §5 の内容は変更していない。

## 検証

- Markdown の表崩れ無し（§1 表の全行が 3 カラムのままであることを確認）
- `test/gh-wrappers.test.sh` 全 pass（shell は未変更だが回帰が無いことの確認）
- repo に markdown lint / CI workflow は無し（root に Makefile 無し、`.github/workflows` 無し、`src/claude-queue/Makefile` は Go 用で無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
