### PR TITLE
docs(implement-and-review): PR 作成前の base 進行確認と my-create-pr 経路を明示

### DIFF
--- a/dot/claude/skills/implement-and-review/SKILL.md
+++ b/dot/claude/skills/implement-and-review/SKILL.md
@@ -66,7 +66,36 @@ description: worktree に委譲されたタスクを実装→merge で完遂す�
    （`superpowers:verification-before-completion`）。**重い self-review はしない** —
    レビュー本体は独立した文脈を持つ次の手順に委ねる。自分が書いたコードを同じ文脈で
    レビューしても、実装時の思い込みごと追認するだけになるため。
-4. **review→merge**: PR を出したら `pr-review-automerge` を呼び、author とは独立した立場での
+
+   **base の進行も確認する**: テストが通ることは、走行中に base 側が進んでいないことを
+   意味しない。PR を出す前に base の現在地を見る。
+
+   ```
+   git fetch origin
+   git log --oneline HEAD..origin/<base>      # base がどれだけ進んだか
+   git diff --name-only HEAD...origin/<base>  # base 側で変わったファイル
+   ```
+
+   自分が触ったファイルが base 側でも変更されていれば、PR を出す前に取り込む（merge
+   / rebase）。base が進んでいなければ追加コストはこの 2〜3 コマンドだけで済むので、
+   毎回確認して構わない。
+
+   複数の委譲が並行して merge される運用では、base が走行中に進むのは例外ではなく常態。
+   conflict したまま PR を出すと GitHub 側は `mergeStateStatus: DIRTY` になり、手順 4 の
+   レビュー段で判定役が発見 → 修正役が直す、で 1 イテレーションをまるごと消費する。
+   さらに修正役は他人の変更を conflict 解決越しに扱うことになり、内容欠落のリスクが乗る。
+   自分の文脈が生きているここで取り込むほうが安く確実。
+   由来: knagiri/dotrc#26（Opus 5 の委譲上限を追記した PR）で、実装中に base が 40 コミット
+   以上進み、そのうち 1 つが自分と同一ファイルの同一段落を変更していたのに気づかず conflict
+   したまま PR を出し、レビュー段の判定役が発見して 1 イテレーションを消費した実例。
+4. **review→merge**: **PR は `my-create-pr` skill で作る**（生の `gh pr create` を直接叩かない）。
+   base の決定（`gh repo view` で既定ブランチを取得し、ブランチ名を決め打ちにしない）・
+   diff の基準（ローカル追跡ブランチでなく remote ref を 3 点表記で使う）・`--base` の常時明示
+   といった非自明な作法が `my-create-pr` 側に集約されており、生の `gh pr create` はそれを
+   丸ごと迂回するため。由来: 上と同じ委譲ランで、repo に `my-create-pr` があり settings.json で
+   allow までされているのに素通りし、生の `gh pr create` を使っていた。
+
+   PR を出したら `pr-review-automerge` を呼び、author とは独立した立場での
    レビュー・required CI 確認を経て自律 merge する。
 5. **自己内省（末尾ハーネス）**: `pr-review-automerge` から戻ったら（auto-merge 有効化に至らず
    5 イテレーション未収束や CI fail で停止・報告して終わった場合も含む）、委譲プロンプトに


### PR DESCRIPTION
## Summary

`dot/claude/skills/implement-and-review/SKILL.md` の手順 3〜4 に、PR 作成前後の経路を追記する。

- **手順 3（verification）に base 進行の確認を追加**: `git fetch origin` →
  `git log --oneline HEAD..origin/<base>` / `git diff --name-only HEAD...origin/<base>` で
  base の現在地を見て、自分が触ったファイルが base 側でも変更されていれば PR を出す前に取り込む。
- **手順 4 冒頭に PR 作成経路を明示**: PR は `my-create-pr` skill 経由で作る
  （生の `gh pr create` を直接叩かない）。

いずれも断定的なハード禁止ではなく理由付きのソフト指針として書き、`dot/claude/rules/rule-authoring.md`
に従って由来を併記した。base 確認は `my-create-pr` 側に重複させず `implement-and-review` 側にのみ置いている。

## Why

委譲ランで 2 つの漏れが同時に起きた。手順 3 の verification が「テスト・ビルド・lint が通ること」に
限定されていて base 側の進行がスコープ外だったこと、および PR 作成手順そのものが未指定だったことが
根本原因で、個別の不注意ではなく手順の欠落。

- **base 進行**: 複数の委譲が並行して merge される運用では、base が走行中に進むのは例外ではなく常態。
  conflict したまま PR を出すと `mergeStateStatus: DIRTY` になり、レビュー段で判定役が発見 →
  修正役が直す、で 1 イテレーションをまるごと消費する。さらに修正役は他人の変更を conflict 解決越しに
  扱うことになり、内容欠落のリスクが乗る。base が進んでいなければ追加コストは 2〜3 コマンドで済む。
- **PR 作成経路**: base の決定（`gh repo view` で既定ブランチを取得し決め打ちにしない）・diff の基準
  （ローカル追跡ブランチでなく remote ref を 3 点表記で使う）・`--base` の常時明示 といった非自明な作法が
  `my-create-pr` 側に集約されており、生の `gh pr create` はそれを丸ごと迂回する。

## Refs

- knagiri/dotrc#26 — 実装中に base が 40 コミット以上進み、うち 1 つが同一ファイルの同一段落を
  変更していたのに気づかず conflict したまま PR を出し、レビュー段で 1 イテレーションを消費した実例