### PR TITLE
docs(rules): SKILL.md / agent 定義の description は「いつ使うか」に絞る rule を追加

### DIFF
--- a/dot/claude/rules/skill-description-scope.md
+++ b/dot/claude/rules/skill-description-scope.md
@@ -1,0 +1,63 @@
+---
+paths:
+  - "**/skills/**/SKILL.md"
+  - "**/agents/*.md"
+---
+
+## SKILL.md / agent 定義の description は「いつ使うか」に絞る
+
+frontmatter の `description` には skill / agent の**起動トリガー**（どんな状況・症状で使うか）
+を書き、本文の手順・ワークフローは要約しない。SKILL.md や agent 定義を書く・直す作業でだけ
+効く話なので `paths` でスコープし、常時ロードはしない。
+
+出典: `superpowers:writing-skills` skill の "Skill Discovery Optimization" → "1. Rich
+Description Field" 節（"CRITICAL: Description = When to Use, NOT What the Skill Does"）。
+
+### 要約を避ける理由は 2 つある
+
+**(a) 本文の方針変更に取り残される。** description は本文とは別の場所で保守されるため、
+本文の手順を変えても description の要約だけ旧方針のまま残りやすい。しかも description は
+skill 一覧として常時 system prompt に載るので、旧方針が「毎回ロードされる誤情報」として
+居座る。本文中の記述なら読んだ agent が矛盾に気づけるが、description は本文を読む前に
+参照されるので気づく機会がそもそも無い。
+
+**(b) 本文を読まずに済ませるショートカットが生まれる。** これは非直感的なので実測ごと
+残す。上記の節いわく、description が "code review between tasks" とワークフローを要約して
+いたために、本文のフローチャートが 2 段階レビュー（spec 準拠 → コード品質）を明示していた
+にもかかわらず agent はレビューを 1 回しか実行しなかった。description を
+"Use when executing implementation plans with independent tasks"（要約なし）に変えたところ、
+agent は正しくフローチャートを読んで 2 段階を実行した。要約された手順は agent にとって
+「本文を読まなくても済む要点」に見え、本文はスキップされる documentation に落ちる。
+
+### トリガー用キーワードは落とさない
+
+description は skill の起動条件そのものを兼ねるので、整理する過程で検索性を削らない。
+ユーザーが言いそうな語（「ハーネス化して」「delegate して」等）・症状・同義語は残す。
+減らす対象は「何をするか（手順）」であって「どういうときか（トリガー）」ではない。
+
+### 本文の方針を変えたら description を点検する
+
+要約を含まない description なら本文の変更で乖離しにくいが、手順の変更がトリガー条件
+そのものを変えることはある（適用範囲が狭まった、別 skill へ分割した等）。本文の方針・
+手順を変える PR では、description が旧方針を述べていないか点検する。
+
+### agent 定義も同じ
+
+`agents/*.md` の description は「どんなタスクで dispatch するか」を示す点で skill と同根。
+選択に必要な役割の一行説明（「〜を担う実装役」等）は残してよいが、本文に書いた手順・判断
+基準をそこへ写さない。乖離（a）と本文スキップ（b）はどちらも同じように起きる。
+
+### 既存 description の一括是正はしない
+
+現状 dotrc の SKILL.md description の多くはこの指針に反してワークフローを要約している
+（`implement-and-review` が典型）。これらは順次個別に是正する対象で、一括では書き換えない。
+description は起動トリガーを兼ねているため、まとめて書き換えると skill が発火しなくなる
+回帰を招きうる。どのキーワードを残すかはユーザーが個別に判断すべき領域であり、agent が
+自律 merge するフローで巻き取る種類の変更ではない。
+
+---
+
+由来: knagiri/dotrc#26。`implement-and-review` の SKILL.md 本文から「無条件に subagent 委譲を
+促進する」ニュアンスを外したのに、frontmatter の description は旧方針（「難度別の実装 subagent
+へ dispatch しながら実装し」）を述べたまま残り、独立した判定役に指摘されて直した。根本原因は
+同期の失念ではなく、description が本文の手順を要約していたこと自体。


### PR DESCRIPTION
## 背景

PR #26 で `implement-and-review` の SKILL.md **本文**から「無条件に subagent 委譲を促進する」ニュアンスを外したが、frontmatter の `description` は旧方針（「難度別の実装 subagent へ dispatch **しながら**実装し」）を述べたまま残り、独立した判定役に指摘されて直した（merge commit 1365459 に該当修正が入っている）。

根本原因は「同期を忘れた」ことではなく、**description が本文の手順・ワークフローを要約していること**そのもの。`superpowers:writing-skills` の "Skill Discovery Optimization" → "1. Rich Description Field" 節（"CRITICAL: Description = When to Use, NOT What the Skill Does"）が明示するとおり、description は「いつ使うか（トリガー条件・症状）」だけを書き、skill が何をするかを要約すべきではない。

## 変更

`dot/claude/rules/skill-description-scope.md` を新規追加（doc のみ、既存ファイルの変更なし）。

要約を避ける理由を 2 つとも本文に記載した。

- **(a) 本文の方針変更に取り残される** — description は本文とは別の場所で保守されるうえ、skill 一覧として常時 system prompt に載るため、旧方針が「毎回ロードされる誤情報」として居座る。本文中の記述と違い、読んだときに矛盾に気づく機会が無い。
- **(b) 本文を読まずに済ませるショートカットが生まれる** — 非直感的なので実測例ごと残した。上記節いわく、description が "code review between tasks" と要約していたために、本文のフローチャートが 2 段階レビュー（spec 準拠 → コード品質）を明示していたにもかかわらず agent はレビューを 1 回しか実行しなかった。要約なしの description に変えたら正しく 2 段階を実行した。

あわせて次を明記した。

- トリガー用キーワード（ユーザーが言いそうな語・症状・同義語）は整理の過程で落とさない。description は起動条件を兼ねるため検索性を削らない
- 本文の方針・手順を変える PR では description が旧方針を述べていないか点検する（要約なしでも、トリガー条件自体が変わることはある）
- `agents/*.md` も同根。選択に必要な役割の一行説明は残してよいが、本文の手順・判断基準は写さない

形式は `rule-authoring.md` に従い、paths スコープ / 理由併記 / ソフト指針 / 由来 を踏襲している。

## paths と想定シナリオ

```yaml
paths:
  - "**/skills/**/SKILL.md"
  - "**/agents/*.md"
```

領域限定で、**常時ロードしない**。発火するのは SKILL.md / agent 定義そのものを編集する作業のみ。

- 新規 skill を書く／既存 skill の description を直すとき → 発火し、ワークフロー要約を避ける指針が効く
- SKILL.md 本文の方針・手順を変える PR → 発火し、description の点検が入る（今回の #26 が該当）
- `agents/*.md` の追加・編集 → 発火する
- それ以外（`bin/`, `rc/`, `docs/`, rules 自身の編集など） → ロードされない

## 既存 description は一括是正しない

現状 dotrc の SKILL.md description の多くはこの指針に反してワークフローを要約している（`implement-and-review` が典型）。**この PR では rule を置くだけに留め、既存 description は順次個別に是正する。**

理由: description は skill の起動トリガーを兼ねているため、一括変更は skill が発火しなくなる回帰を招きうる。どのキーワードを残すかはユーザーが個別に判断すべき領域で、agent が自律 merge するフローで巻き取る種類の変更ではない。この方針は rule 本文にも節として残してある。

## 検証

- 一次情報を現物で確認済み（`superpowers:writing-skills` の当該節を Read。委譲プロンプトの要約と原文の主張が一致することを確認）
- 由来の裏取り済み（`git show 1365459` に description 修正が実在することを確認）
- glob をシェルの globstar で実マッチ確認 — SKILL.md 8 件・agent 定義 5 件にマッチし、他のファイルにはマッチしない
- `~/.claude/rules` は既に symlink 済みディレクトリなので、ファイル追加は自動反映される（`dotrc-deploy.md` §3）。`bin/deploy.sh` の再実行は不要
- doc のみの追加で挙動変更が無いため、テストは追加していない（`test/` は `bin/` スクリプト対象）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
