### PR TITLE
docs(worktree-scope): ask git instead of probing .git paths

### DIFF
--- a/dot/claude/rules/worktree-scope.md
+++ b/dot/claude/rules/worktree-scope.md
@@ -27,6 +27,37 @@ git worktree list                          # worktree ↔ ブランチ対応
 
 いずれも settings.json の allow（`git rev-parse *` / `git worktree list`）に含まれ、承認なしで実行できる。
 
+#### 状態の確認は `.git/` のパスを直接見ず、git plumbing で行う
+
+linked worktree の `.git` は**ディレクトリではなくファイル**である（`gitdir: <path>` を書いた
+1 行のテキストファイルで、実体は main repo 側の `.git/worktrees/<name>/` にある）。したがって
+`ls .git/MERGE_HEAD` / `cat .git/HEAD` / `ls .git/rebase-merge` のようにパスを直接叩く確認は、
+一般にしない。
+
+理由は、状態が実在していても「無い」と読めてしまう（false negative）ため。`.git` がファイル
+なので配下のパスは解決自体が成立せず、`ls` は "No such file" ではなく "Not a directory" で
+落ちる。だが存在チェックの文脈ではどちらも「無い」と同義に読まれ、しかもコマンドとしては
+ただの非ゼロ終了なので、誤りに気づかないまま結論へ直結する。
+
+代わりに git plumbing で問う。git は worktree のレイアウトを知っているので、main working tree
+でも linked worktree でも同じ答えを返す。
+
+```
+git rev-parse -q --verify MERGE_HEAD   # 中断中の merge があるか（exit 0 なら在る）
+git status                             # rebase / cherry-pick を含む中断状態の全般
+```
+
+main working tree にいると確定している場面など、上の理由が当てはまらないなら縛られなくてよい。
+ただし linked worktree かどうかは §1 冒頭の `git rev-parse` で確かめられるので、確かめずに
+main working tree だと決めてかからない。
+
+<!-- 文脈: tetsunavi-monorepo PR #5982（ncs-player の ARM64 対応）で main を merge して衝突解消中、
+     git commit が hook のタイムアウトで中断した際、`ls .git/MERGE_HEAD` で状態を確認して
+     「マージが失われた」と誤認しかけた incident。`.git` がファイルであるためパス probe が
+     成立していなかっただけで、`git rev-parse -q --verify MERGE_HEAD` では MERGE_HEAD は実在し、
+     そのまま復帰できた。根本: worktree のレイアウトを確認せず main working tree と同じ前提で
+     ファイルパスを直接叩いたこと。 -->
+
 ### 2. 原則：起動した worktree ディレクトリに閉じる
 
 linked worktree で起動された場合、デフォルトは以下に従う。「permission」列は settings.json 上の扱い。

--- a/dot/claude/rules/worktree-scope.md
+++ b/dot/claude/rules/worktree-scope.md
@@ -45,18 +45,24 @@ linked worktree の `.git` は**ディレクトリではなくファイル**で�
 ```
 git rev-parse -q --verify MERGE_HEAD   # 中断中の merge があるか（exit 0 なら在る）
 git status                             # rebase / cherry-pick を含む中断状態の全般
+git rev-parse --git-path <name>        # 内部ファイルの実体パスが要るとき（例: MERGE_MSG）。worktree/submodule でも正しい実パスを返す
 ```
 
-main working tree にいると確定している場面など、上の理由が当てはまらないなら縛られなくてよい。
-ただし linked worktree かどうかは §1 冒頭の `git rev-parse` で確かめられるので、確かめずに
-main working tree だと決めてかからない。
+`.git` が**ディレクトリだと確認できている**場面は、上の false negative の理由が当てはまらない
+ので縛られなくてよい。ただし判定基準は「linked worktree でないこと」ではない。§1 の
+`--git-common-dir` / `--git-dir` 一致判定は submodule の working tree でも「一致」を返す
+（submodule の `.git` も `gitdir: ...` を書いたファイルで、両方とも
+`<super>/.git/modules/<name>` を指すため）。つまり §1 の判定だけでは submodule を誤って
+「main working tree（= `.git` がディレクトリ）」と分類してしまい、この例外がまさに防ごうと
+している false negative を許すことになる。`.git` の種別は `test -d .git` 等で別途確かめてから
+縛りを外す。
 
-<!-- 文脈: tetsunavi-monorepo PR #5982（ncs-player の ARM64 対応）で main を merge して衝突解消中、
-     git commit が hook のタイムアウトで中断した際、`ls .git/MERGE_HEAD` で状態を確認して
-     「マージが失われた」と誤認しかけた incident。`.git` がファイルであるためパス probe が
-     成立していなかっただけで、`git rev-parse -q --verify MERGE_HEAD` では MERGE_HEAD は実在し、
-     そのまま復帰できた。根本: worktree のレイアウトを確認せず main working tree と同じ前提で
-     ファイルパスを直接叩いたこと。 -->
+<!-- 文脈: 別 repo での monorepo 作業中、main を merge して衝突解消の途中で
+     git commit が hook のタイムアウトで中断した際、`ls .git/MERGE_HEAD` で状態を
+     確認して「マージが失われた」と誤認しかけた incident。`.git` がファイルである
+     ためパス probe が成立していなかっただけで、`git rev-parse -q --verify
+     MERGE_HEAD` では MERGE_HEAD は実在し、そのまま復帰できた。根本: worktree の
+     レイアウトを確認せず main working tree と同じ前提でファイルパスを直接叩いたこと。 -->
 
 ### 2. 原則：起動した worktree ディレクトリに閉じる
 

--- a/dot/claude/rules/worktree-scope.md
+++ b/dot/claude/rules/worktree-scope.md
@@ -27,7 +27,7 @@ git worktree list                          # worktree ↔ ブランチ対応
 
 いずれも settings.json の allow（`git rev-parse *` / `git worktree list`）に含まれ、承認なしで実行できる。
 
-#### 状態の確認は `.git/` のパスを直接見ず、git plumbing で行う
+#### 状態の確認は `.git/` のパスを直接見ず、git コマンドに問う
 
 linked worktree の `.git` は**ディレクトリではなくファイル**である（`gitdir: <path>` を書いた
 1 行のテキストファイルで、実体は main repo 側の `.git/worktrees/<name>/` にある）。したがって
@@ -39,8 +39,10 @@ linked worktree の `.git` は**ディレクトリではなくファイル**で�
 落ちる。だが存在チェックの文脈ではどちらも「無い」と同義に読まれ、しかもコマンドとしては
 ただの非ゼロ終了なので、誤りに気づかないまま結論へ直結する。
 
-代わりに git plumbing で問う。git は worktree のレイアウトを知っているので、main working tree
-でも linked worktree でも同じ答えを返す。
+代わりに git 自身に問う。git は worktree のレイアウトを知っているので、main working tree でも
+linked worktree でも同じ答えを返す（下記コマンドは `git status` のような porcelain と
+`git rev-parse` のような plumbing が混在するが、この区別はここでは関係ない。共通するのは
+`.git/` 配下へ直接パスを通さず git のコマンド層を経由する点）。
 
 ```
 git rev-parse -q --verify MERGE_HEAD   # 中断中の merge があるか（exit 0 なら在る）
@@ -50,12 +52,14 @@ git rev-parse --git-path <name>        # 内部ファイルの実体パスが要
 
 `.git` が**ディレクトリだと確認できている**場面は、上の false negative の理由が当てはまらない
 ので縛られなくてよい。ただし判定基準は「linked worktree でないこと」ではない。§1 の
-`--git-common-dir` / `--git-dir` 一致判定は submodule の working tree でも「一致」を返す
-（submodule の `.git` も `gitdir: ...` を書いたファイルで、両方とも
-`<super>/.git/modules/<name>` を指すため）。つまり §1 の判定だけでは submodule を誤って
-「main working tree（= `.git` がディレクトリ）」と分類してしまい、この例外がまさに防ごうと
-している false negative を許すことになる。`.git` の種別は `test -d .git` 等で別途確かめてから
-縛りを外す。
+`--git-common-dir` / `--git-dir` 一致判定は submodule の working tree でも「一致」を返し、
+これは分類として誤りではない（submodule はそれ自体が別 repo の main working tree であり、
+`--git-common-dir` と `--git-dir` は両方とも `<super>/.git/modules/<name>` を指すため）。破綻
+するのは「main working tree なら `.git` はディレクトリ」という**含意**のほうで、submodule の
+`.git` は `gitdir: <super>/.git/modules/<name>` を書いた 1 行のファイルである。つまり §1 の
+「main working tree」という結果だけで `.git` がディレクトリだと決め打つと、submodule で
+この例外がまさに防ごうとしている false negative を許すことになる。`.git` の種別は
+`test -d .git` 等で別途確かめてから縛りを外す。
 
 <!-- 文脈: 別 repo での monorepo 作業中、main を merge して衝突解消の途中で
      git commit が hook のタイムアウトで中断した際、`ls .git/MERGE_HEAD` で状態を


### PR DESCRIPTION
## 背景 / 指摘

linked worktree では `.git` がディレクトリではなくファイル（`gitdir: <path>` を書いた 1 行のファイル。実体は main repo 側の `.git/worktrees/<name>/`）である。このため `ls .git/MERGE_HEAD` のようなパス probe は、中断状態が実在していても必ず「無い」と読めてしまう。

根本原因は、worktree のレイアウトを確認せず main working tree と同じ前提でファイルパスを直接叩いたこと。状態確認は git 自身に問うべき。

## 変更

`dot/claude/rules/worktree-scope.md` §1「自分が linked worktree にいるかの判定」の末尾に、サブセクション「状態の確認は `.git/` のパスを直接見ず、git コマンドに問う」を追記。

- `.git` がファイルであること（実体の所在つき）
- パス probe が false negative になること。`ls` は "No such file" ではなく "Not a directory" で落ちるが、存在チェックの文脈では「無い」と同義に読まれ誤結論に直結する
- 代替: `git rev-parse -q --verify MERGE_HEAD`（中断中の merge）、`git status`（rebase / cherry-pick を含む全般）、`git rev-parse --git-path <name>`（内部ファイルの実体パスが要るとき）
- 例外は「linked worktree でないこと」ではなく「`.git` がディレクトリだと確認できていること」で判定する。§1 の `--git-common-dir` / `--git-dir` 一致判定は submodule の working tree でも一致を返すため、それだけでは `.git` の種別を見分けられない
- 「一般に〜しない」のソフト指針とし、理由が当てはまらないときの余地を残す（`rule-authoring.md` の方針に従う）
- 由来はファイル既存の慣習に合わせて `<!-- 文脈: ... -->` コメントで残す

`paths` は追加していない（`worktree-scope.md` は frontmatter を持たない常時ロードのルールで、その方針を変えない）。

## 検証

主張は実測で裏取りした。

- linked worktree: `ls -la .git` → `-rw-rw-r-- ... 110`（ファイル）、`ls .git/MERGE_HEAD` → `Not a directory`、`git rev-parse --git-common-dir --git-dir` → 不一致
- submodule: `.git` はファイル、かつ `--git-common-dir` と `--git-dir` は両方 `<super>/.git/modules/<name>` を返して**一致する**（= §1 の判定だけでは種別を見分けられない）
- `git rev-parse --git-path MERGE_HEAD` は linked worktree / submodule のいずれでも正しい実体パスを返す

docs-only の変更で、`test/` の既存テストは `bin/` のシェルスクリプト対象なので影響しない（回帰テストの対象になるコード変更を含まない）。

## レビュー対応

- Copilot: 見出し・本文の「git plumbing」が例示に porcelain の `git status` を含み用語と不一致 → 「git コマンドに問う」へ変更（be6903e）
- 外部の社内 repo 名・PR 番号・案件名を public repo の由来コメントに書かない形へ一般化（9b0cacd）
- 例外条項が submodule で false negative を許す問題を修正（9b0cacd → be6903e で言い回しを精緻化）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
