### PR TITLE
feat(claude-worktree): 委譲先の既定起動を claude --bg へ移し、委譲元 name をプロンプトへ注入する

### DIFF
--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# claude-worktree -- create a git worktree and (optionally) start an interactive
-# claude inside a detached tmux session living in that worktree.
+# claude-worktree -- create a git worktree and (optionally) start a claude
+# session living in that worktree.
 #
 # Worktree path is a sibling of the repository named <toplevel>_<name> so the
 # tmux window is easy to search. The underscore separator is tmux-safe (a dot
@@ -10,17 +10,24 @@ set -euo pipefail
 # to the MAIN repository toplevel so names stay flat even when invoked from
 # inside another worktree.
 #
-# When a prompt is given, claude is launched INSIDE a fresh detached tmux session
-# (session name = worktree basename, matching the `gts` convention). Running it
-# in its own pane means its $TMUX_PANE is that new pane -- so claude-queue tracks
-# it correctly instead of colliding with the launching pane. Attach any time
-# (`gts <session>` / `tmux attach -t <session>`); it is interactive, so it keeps
-# running at the REPL after the initial prompt -- no `claude --resume` needed.
+# When a prompt is given, the default is a BACKGROUND agent (`claude --bg`,
+# acceptEdits) started with the worktree as its cwd. It exits by itself once the
+# task completes, so neither sessions nor worktrees pile up, and tool calls that
+# need approval block and wait rather than degrading silently. Reach it with
+# `claude attach <short-id>` (the id is printed at launch).
 #
-# When invoked from inside tmux, the launch is wrapped so that when claude exits
-# the attached client is switched back to the pane it was called from (not just
-# the origin session's currently-active pane). Nobody attached / origin pane gone
-# both degrade to a silent no-op.
+# `--tmux` selects the other mode: claude is launched INSIDE a fresh detached
+# tmux session (session name = worktree basename, matching the `gts` convention).
+# Running it in its own pane means its $TMUX_PANE is that new pane -- so
+# claude-queue tracks it correctly instead of colliding with the launching pane.
+# Attach any time (`gts <session>` / `tmux attach -t <session>`); it is
+# interactive, so it keeps running at the REPL after the initial prompt -- no
+# `claude --resume` needed. Use it when a human is meant to sit with the session.
+#
+# In `--tmux` mode, when invoked from inside tmux, the launch is wrapped so that
+# when claude exits the attached client is switched back to the pane it was
+# called from (not just the origin session's currently-active pane). Nobody
+# attached / origin pane gone both degrade to a silent no-op.
 #
 # A new worktree only checks out the branch: gitignored / uncommitted files of the
 # invoking checkout do NOT propagate, and a delegated session cannot read outside
@@ -28,10 +35,14 @@ set -euo pipefail
 # copies such files in, so the delegated prompt can reference them relatively.
 #
 # Usage:
-#   claude-worktree [--self] [--model <alias>] [--seed <path>]... <name> [-b <branch>] [-- <prompt...>]
+#   claude-worktree [--self] [--tmux] [--model <alias>] [--seed <path>]... <name> [-b <branch>] [-- <prompt...>]
 #
 #   --self         anchor the worktree to the repo this script lives in (e.g.
 #                  your dotfiles repo), not cwd. Use for repo-independent work.
+#   --tmux         launch the delegate in a detached tmux session running an
+#                  INTERACTIVE claude instead of a background agent. Use when a
+#                  human is meant to sit with it (working a design out together);
+#                  the session stays at the REPL and is reached with `gts`.
 #   --model <alias>
 #                  pass --model <alias> to the launched claude (e.g. opus), so the
 #                  caller picks the model for the role it is delegating. Omitted
@@ -46,9 +57,10 @@ set -euo pipefail
 #   -b <branch>    branch to check out / create (default: <name>). Resolved as:
 #                  local branch, else origin/<branch> (tracked, no fetch), else
 #                  created fresh from the current HEAD.
-#   -- <prompt>    everything after `--` is the initial prompt; when given, an
-#                  interactive claude (acceptEdits) is started in a detached tmux
-#                  session in the worktree. Attach with the printed command.
+#   -- <prompt>    everything after `--` is the initial prompt. By default the
+#                  delegate is started with `claude --bg` (acceptEdits): it exits
+#                  by itself when the task completes, and is reached with
+#                  `claude attach <short-id>`. With --tmux, see above.
 
 usage() {
   # Print the first contiguous "# " comment block (the description), skipping the
@@ -63,6 +75,7 @@ name=""
 branch=""
 prompt=""
 self=0
+use_tmux=0
 model=""
 seeds=()
 while [ $# -gt 0 ]; do
@@ -80,6 +93,7 @@ while [ $# -gt 0 ]; do
       model="$1"; shift ;;
     --seed) shift; [ $# -gt 0 ] || usage 1; seeds+=("$1"); shift ;;
     --self) self=1; shift ;;
+    --tmux) use_tmux=1; shift ;;
     --) shift; prompt="$*"; break ;;
     -*) echo "claude-worktree: unknown flag: $1" >&2; usage 1 ;;
     *)
@@ -128,6 +142,20 @@ if [ "${#seeds[@]}" -gt 0 ]; then
   done
 fi
 
+# A background session already living in this worktree means a second delegation
+# would race the first on the same files. Refuse before creating anything, and
+# name the existing session so the caller can reach it. Skipped when jq is
+# absent: the guard is a convenience, not a correctness boundary.
+if [ -n "$prompt" ] && [ "$use_tmux" = 0 ] && command -v jq >/dev/null 2>&1; then
+  existing="$(claude agents --json 2>/dev/null | jq -r --arg d "$wt_path" \
+    'first(.[] | select(.kind == "background" and .cwd == $d) | .sessionId[0:8]) // empty')"
+  if [ -n "$existing" ]; then
+    echo "claude-worktree: a background session is already running in $wt_path" >&2
+    echo "  attach with: claude attach $existing" >&2
+    exit 1
+  fi
+fi
+
 # Keep stdout clean (path only) so add-only mode is scriptable; git's checkout
 # chatter goes to stderr.
 if [ -d "$wt_path" ]; then
@@ -165,6 +193,41 @@ if [ -z "$prompt" ]; then
   exit 0
 fi
 
+if [ "$use_tmux" = 0 ]; then
+  # Background agent (default). It exits on its own when the task completes,
+  # which is the whole point of preferring it over an interactive session. The
+  # id is assigned by --bg (it ignores --session-id), so the only way to learn
+  # it is to read the launch banner back.
+  #
+  # cwd matters: the delegate reads the checkout it is started in, so the launch
+  # runs inside the worktree. A subshell keeps this script's own cwd untouched.
+  if [ -n "$model" ]; then
+    launch_out="$(cd "$wt_path" && claude --bg --permission-mode acceptEdits --model "$model" "$prompt" 2>&1)"
+  else
+    launch_out="$(cd "$wt_path" && claude --bg --permission-mode acceptEdits "$prompt" 2>&1)"
+  fi
+
+  # `backgrounded · <id>`. Pull the first 8-hex-char field off that line rather
+  # than matching the separator, which is a multibyte middle dot.
+  short="$(printf '%s\n' "$launch_out" \
+    | awk '/backgrounded/ { for (i = 1; i <= NF; i++) if ($i ~ /^[0-9a-f]{8}$/) { print $i; exit } }')"
+
+  echo "worktree : $wt_path"
+  echo "branch   : $branch"
+  if [ -n "$short" ]; then
+    echo "session  : $short (background; acceptEdits)"
+  else
+    # The session IS running -- only the id is unknown. Surfacing the raw banner
+    # beats printing a report with a silently empty field.
+    echo "claude-worktree: could not read the session id from the launch output:" >&2
+    printf '%s\n' "$launch_out" >&2
+  fi
+  [ -z "$model" ] || echo "model    : $model"
+  [ -z "$short" ] || echo "attach   : claude attach $short"
+  exit 0
+fi
+
+# --tmux: detached tmux session running an interactive claude.
 # Session name = worktree basename, matching the `gts` convention (it derives the
 # session name from the dir basename), so gts won't create a duplicate.
 session="$(basename "$wt_path")"

--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -193,6 +193,46 @@ if [ -z "$prompt" ]; then
   exit 0
 fi
 
+# Resolve the delegating session's name so the delegate can report back to it.
+#
+# A delegate has no conversation history and no way to guess who launched it.
+# `claude agents --json` lists every live session with its pid, so walking this
+# process's ancestors until one of them IS a listed session identifies the
+# caller exactly -- no cwd heuristics, no ambiguity when several sessions share
+# a directory. Returns empty (never fails the launch) when there is no claude
+# ancestor, when the entry carries no name, or when jq is unavailable: a human
+# running this from a plain shell has no delegator, and that is not an error.
+resolve_delegator() {
+  command -v jq >/dev/null 2>&1 || return 0
+  local agents p name
+  agents="$(claude agents --json 2>/dev/null)" || return 0
+  [ -n "$agents" ] || return 0
+  p=$$
+  while [ -n "$p" ] && [ "$p" -gt 1 ]; do
+    name="$(printf '%s' "$agents" | jq -r --arg pid "$p" \
+      'first(.[] | select(.pid == ($pid | tonumber)) | .name // empty) // empty')"
+    if [ -n "$name" ]; then
+      printf '%s' "$name"
+      return 0
+    fi
+    p="$(ps -o ppid= -p "$p" 2>/dev/null | tr -d ' ')"
+  done
+}
+
+delegator="$(resolve_delegator)"
+
+# Inject the name as a bare datum. What to report, and when, is doctrine and
+# lives in the implement-and-review skill -- this script only supplies the fact
+# the skill cannot derive. Appending to the prompt (rather than exporting an env
+# var) is deliberate: `claude --bg` starts via a background service, so env
+# inheritance is not guaranteed, whereas the prompt is the one channel that is.
+if [ -n "$delegator" ]; then
+  prompt="${prompt}
+
+## 委譲元
+報告先 name: ${delegator}"
+fi
+
 if [ "$use_tmux" = 0 ]; then
   # Background agent (default). It exits on its own when the task completes,
   # which is the whole point of preferring it over an interactive session. The
@@ -223,6 +263,7 @@ if [ "$use_tmux" = 0 ]; then
     printf '%s\n' "$launch_out" >&2
   fi
   [ -z "$model" ] || echo "model    : $model"
+  [ -z "$delegator" ] || echo "report-to: $delegator"
   [ -z "$short" ] || echo "attach   : claude attach $short"
   exit 0
 fi
@@ -274,4 +315,5 @@ echo "worktree : $wt_path"
 echo "branch   : $branch"
 echo "session  : $session (detached; claude running with acceptEdits)"
 [ -z "$model" ] || echo "model    : $model"
+[ -z "$delegator" ] || echo "report-to: $delegator"
 echo "attach   : $attach"

--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -241,10 +241,33 @@ if [ "$use_tmux" = 0 ]; then
   #
   # cwd matters: the delegate reads the checkout it is started in, so the launch
   # runs inside the worktree. A subshell keeps this script's own cwd untouched.
+  # Under `set -e`, an assignment's exit status IS the command substitution's
+  # exit status: a bare `launch_out="$(... claude ...)"` would abort the script
+  # right here if claude itself failed, discarding the just-captured stderr
+  # along with it. Since a delegation is fire-and-forget, that leaves the
+  # caller with nothing but an unexplained rc=1. The `if cmd; then :; else ...`
+  # shape (NOT `if ! cmd; then`) is deliberate: negating the condition with `!`
+  # also negates the exit status `$?` sees inside the branch, so `rc=$?` there
+  # would read back 0 even though claude failed. Falling through to `else`
+  # keeps `$?` as claude's real exit code.
   if [ -n "$model" ]; then
-    launch_out="$(cd "$wt_path" && claude --bg --permission-mode acceptEdits --model "$model" "$prompt" 2>&1)"
+    if launch_out="$(cd "$wt_path" && claude --bg --permission-mode acceptEdits --model "$model" "$prompt" 2>&1)"; then
+      :
+    else
+      rc=$?
+      echo "claude-worktree: claude --bg failed (exit $rc); worktree left at $wt_path:" >&2
+      printf '%s\n' "$launch_out" >&2
+      exit "$rc"
+    fi
   else
-    launch_out="$(cd "$wt_path" && claude --bg --permission-mode acceptEdits "$prompt" 2>&1)"
+    if launch_out="$(cd "$wt_path" && claude --bg --permission-mode acceptEdits "$prompt" 2>&1)"; then
+      :
+    else
+      rc=$?
+      echo "claude-worktree: claude --bg failed (exit $rc); worktree left at $wt_path:" >&2
+      printf '%s\n' "$launch_out" >&2
+      exit "$rc"
+    fi
   fi
 
   # `backgrounded · <id>`. Pull the first 8-hex-char field off that line rather

--- a/test/claude-worktree.test.sh
+++ b/test/claude-worktree.test.sh
@@ -143,7 +143,7 @@ prompt='say "hi" it'\''s here'
 log="$tmp/ns-in"
 out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
   export PATH="$stubbin:$PATH" TMUX_STUB_LOG="$log" TMUX=fake TMUX_PANE=%9
-  "$wt" insess -- "$prompt"; } 2>/dev/null)"; rc=$?
+  "$wt" --tmux insess -- "$prompt"; } 2>/dev/null)"; rc=$?
 if [ "$rc" -eq 0 ] \
    && grep -q 'switch-client' "$log" \
    && grep -Fxq '%9' "$log" \
@@ -159,7 +159,7 @@ fi
 log="$tmp/ns-out"
 out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
   export PATH="$stubbin:$PATH" TMUX_STUB_LOG="$log"
-  "$wt" nosess -- "$prompt"; } 2>/dev/null)"; rc=$?
+  "$wt" --tmux nosess -- "$prompt"; } 2>/dev/null)"; rc=$?
 if [ "$rc" -eq 0 ] \
    && ! grep -q 'switch-client' "$log" \
    && grep -Fxq 'claude' "$log" \
@@ -200,7 +200,7 @@ fi
 log="$tmp/ns-model-in"
 out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
   export PATH="$stubbin:$PATH" TMUX_STUB_LOG="$log" TMUX=fake TMUX_PANE=%9
-  "$wt" --model opus modelin -- "$prompt"; } 2>/dev/null)"; rc=$?
+  "$wt" --tmux --model opus modelin -- "$prompt"; } 2>/dev/null)"; rc=$?
 if [ "$rc" -eq 0 ] \
    && grep -Fq 'if [ -n "$3" ]; then' "$log" \
    && grep -Fxq 'opus' "$log" \
@@ -217,7 +217,7 @@ fi
 log="$tmp/ns-model-out"
 out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
   export PATH="$stubbin:$PATH" TMUX_STUB_LOG="$log"
-  "$wt" --model sonnet modelout -- "$prompt"; } 2>/dev/null)"; rc=$?
+  "$wt" --tmux --model sonnet modelout -- "$prompt"; } 2>/dev/null)"; rc=$?
 if [ "$rc" -eq 0 ] \
    && grep -A1 -Fx -- '--model' "$log" | grep -Fxq 'sonnet' \
    && grep -Fxq "$prompt" "$log" \
@@ -337,5 +337,116 @@ if [ "$rc" -eq 0 ] && [ "$wt_sha" = "$clone_head_sha" ]; then
 else
   echo "FAIL: new-branch fallback rc=$rc sha=$wt_sha want=$clone_head_sha"; fail=1
 fi
+
+# --- background launch mode (default when a prompt is given) ------------------
+# `claude` is stubbed on PATH: `--bg` records its argv and prints the real
+# banner shape, `agents --json` prints a roster fixture. Nothing is spawned.
+cat >"$stubbin/claude" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "agents" ]; then cat "$CLAUDE_STUB_ROSTER"; exit 0; fi
+printf '%s\n' "$@" >"$CLAUDE_STUB_LOG"
+printf 'Starting background service…\n'
+printf 'backgrounded · %s\n' "${CLAUDE_STUB_ID:-abcd1234}"
+printf '  claude attach %s    open in this terminal\n' "${CLAUDE_STUB_ID:-abcd1234}"
+EOF
+chmod +x "$stubbin/claude"
+
+emptyroster="$tmp/roster-empty.json"
+echo '[]' >"$emptyroster"
+
+# Default (no --tmux): claude --bg is launched with acceptEdits, the short id is
+# lifted out of the banner, and the report tells the user how to attach.
+log="$tmp/bg-default"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" CLAUDE_STUB_LOG="$log" CLAUDE_STUB_ROSTER="$emptyroster"
+  "$wt" bgdefault -- "$prompt"; } 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] \
+   && grep -Fxq -- '--bg' "$log" \
+   && grep -Fxq -- 'acceptEdits' "$log" \
+   && grep -Fxq "$prompt" "$log" \
+   && grep -q 'session  : abcd1234 (background' <<<"$out" \
+   && grep -q 'attach   : claude attach abcd1234' <<<"$out"; then
+  echo "ok: default launch uses claude --bg and reports the short id"
+else
+  echo "FAIL: bg default rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; echo "$out"; fail=1
+fi
+
+# The worktree dir must be the launched session's cwd -- otherwise the delegate
+# reads the wrong checkout. The stub records it via PWD.
+cat >"$stubbin/claude" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "agents" ]; then cat "$CLAUDE_STUB_ROSTER"; exit 0; fi
+printf '%s\n' "$PWD" >"$CLAUDE_STUB_CWDLOG"
+printf '%s\n' "$@" >"$CLAUDE_STUB_LOG"
+printf 'backgrounded · %s\n' "${CLAUDE_STUB_ID:-abcd1234}"
+EOF
+chmod +x "$stubbin/claude"
+log="$tmp/bg-cwd"; cwdlog="$tmp/bg-cwd-pwd"
+(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" CLAUDE_STUB_LOG="$log" CLAUDE_STUB_CWDLOG="$cwdlog" \
+         CLAUDE_STUB_ROSTER="$emptyroster"
+  "$wt" bgcwd -- "$prompt"; }) >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ] && [ "$(cat "$cwdlog" 2>/dev/null)" = "${cwdrepo}_bgcwd" ]; then
+  echo "ok: bg launch runs with the worktree as cwd"
+else echo "FAIL: bg cwd rc=$rc got=$(cat "$cwdlog" 2>/dev/null) want=${cwdrepo}_bgcwd"; fail=1; fi
+
+# --model rides through to the bg launch as two adjacent argv elements.
+log="$tmp/bg-model"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" CLAUDE_STUB_LOG="$log" CLAUDE_STUB_CWDLOG="$tmp/x" \
+         CLAUDE_STUB_ROSTER="$emptyroster"
+  "$wt" --model opus bgmodel -- "$prompt"; } 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] \
+   && grep -A1 -Fx -- '--model' "$log" | grep -Fxq 'opus' \
+   && grep -q 'model    : opus' <<<"$out"; then
+  echo "ok: --model reaches the bg launch and is reported"
+else echo "FAIL: bg --model rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; fail=1; fi
+
+# Omitting --model must not synthesise `--model ""` (claude rejects it).
+log="$tmp/bg-nomodel"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" CLAUDE_STUB_LOG="$log" CLAUDE_STUB_CWDLOG="$tmp/x" \
+         CLAUDE_STUB_ROSTER="$emptyroster"
+  "$wt" bgnomodel -- "$prompt"; } 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] && ! grep -q -- '--model' "$log" && ! grep -q 'model    :' <<<"$out"; then
+  echo "ok: no --model in the bg launch when the flag is omitted"
+else echo "FAIL: bg model leak rc=$rc"; fail=1; fi
+
+# A banner the parser does not recognise must not be swallowed: the session IS
+# running, so the raw output is surfaced instead of a silently missing id.
+cat >"$stubbin/claude" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "agents" ]; then cat "$CLAUDE_STUB_ROSTER"; exit 0; fi
+printf 'some unexpected banner shape\n'
+EOF
+chmod +x "$stubbin/claude"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" CLAUDE_STUB_ROSTER="$emptyroster"
+  "$wt" bgweird -- "$prompt"; } 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && grep -q 'some unexpected banner shape' <<<"$out"; then
+  echo "ok: unparseable banner is surfaced rather than dropped"
+else echo "FAIL: unparseable banner rc=$rc out=$out"; fail=1; fi
+
+# A background session already running in the same worktree means a second
+# delegation would race the first -- refuse, and say how to reach the existing
+# one. Must fail BEFORE launching (stub log stays empty).
+cat >"$stubbin/claude" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "agents" ]; then cat "$CLAUDE_STUB_ROSTER"; exit 0; fi
+printf '%s\n' "$@" >"$CLAUDE_STUB_LOG"
+printf 'backgrounded · abcd1234\n'
+EOF
+chmod +x "$stubbin/claude"
+busyroster="$tmp/roster-busy.json"
+cat >"$busyroster" <<EOF
+[{"pid":1,"cwd":"${cwdrepo}_bgbusy","kind":"background","sessionId":"feedface-1111-2222-3333-444444444444","status":"working"}]
+EOF
+log="$tmp/bg-busy"; : >"$log"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" CLAUDE_STUB_LOG="$log" CLAUDE_STUB_ROSTER="$busyroster"
+  "$wt" bgbusy -- "$prompt"; } 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && [ ! -s "$log" ] && grep -q 'feedface' <<<"$out"; then
+  echo "ok: an existing bg session in the same worktree blocks a second launch"
+else echo "FAIL: bg collision rc=$rc out=$out"; fail=1; fi
 
 exit "$fail"

--- a/test/claude-worktree.test.sh
+++ b/test/claude-worktree.test.sh
@@ -449,4 +449,88 @@ if [ "$rc" -ne 0 ] && [ ! -s "$log" ] && grep -q 'feedface' <<<"$out"; then
   echo "ok: an existing bg session in the same worktree blocks a second launch"
 else echo "FAIL: bg collision rc=$rc out=$out"; fail=1; fi
 
+# --- delegator name injection -------------------------------------------------
+# The delegate has no conversation history, so it can only report back if it is
+# told who to report to. The name is resolved by walking this process's
+# ancestors until one is a live claude session -- the test shell stands in for
+# that session by putting its own pid in the roster.
+# This stub additionally records the LAST argv element on its own. The injected
+# block must ride inside the prompt argument; splitting it into a second
+# argument would make claude treat it as a separate positional. Since the log
+# writes one element per LINE and the prompt itself is multi-line, a line-based
+# grep cannot tell the two apart -- capturing the last element does.
+cat >"$stubbin/claude" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "agents" ]; then cat "$CLAUDE_STUB_ROSTER"; exit 0; fi
+printf '%s\n' "$@" >"$CLAUDE_STUB_LOG"
+printf '%s' "${!#}" >"${CLAUDE_STUB_LASTARG:-/dev/null}"
+printf 'backgrounded · abcd1234\n'
+EOF
+chmod +x "$stubbin/claude"
+
+namedroster="$tmp/roster-named.json"
+cat >"$namedroster" <<EOF
+[{"pid":$$,"cwd":"$cwdrepo","kind":"interactive","sessionId":"eeeeeeee-1111-2222-3333-444444444444","name":"test-delegator","status":"busy"}]
+EOF
+
+log="$tmp/bg-name"; lastarg="$tmp/bg-name-last"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" CLAUDE_STUB_LOG="$log" CLAUDE_STUB_LASTARG="$lastarg" \
+         CLAUDE_STUB_ROSTER="$namedroster"
+  "$wt" bgname -- "$prompt"; } 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] \
+   && grep -Fq '## 委譲元' "$log" \
+   && grep -Fq '報告先 name: test-delegator' "$log" \
+   && grep -q 'report-to: test-delegator' <<<"$out"; then
+  echo "ok: delegator name is resolved, injected, and reported"
+else
+  echo "FAIL: name injection rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; fail=1
+fi
+
+# Same argv element: the last argument must contain BOTH the original prompt and
+# the injected block. Two separate arguments would make claude read the block as
+# a stray positional instead of part of the delegated instructions.
+if grep -Fq "$prompt" "$lastarg" && grep -Fq '報告先 name: test-delegator' "$lastarg"; then
+  echo "ok: the injected block rides inside the prompt argument"
+else
+  echo "FAIL: injected block is not in the prompt argv element"; fail=1
+fi
+
+# No claude ancestor (a human running the script from a plain shell) -> nothing
+# is injected and no report-to line is printed. Silence is correct here: there
+# is no delegator to report to.
+log="$tmp/bg-noname"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" CLAUDE_STUB_LOG="$log" CLAUDE_STUB_ROSTER="$emptyroster"
+  "$wt" bgnoname -- "$prompt"; } 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] \
+   && ! grep -Fq '委譲元' "$log" \
+   && ! grep -q 'report-to' <<<"$out"; then
+  echo "ok: no delegator resolvable -> nothing injected, nothing reported"
+else echo "FAIL: unexpected injection rc=$rc"; fail=1; fi
+
+# A roster entry without a `name` field (older sessions have none) must be
+# treated as unresolvable rather than injecting an empty name.
+nonameroster="$tmp/roster-noname.json"
+cat >"$nonameroster" <<EOF
+[{"pid":$$,"cwd":"$cwdrepo","kind":"interactive","sessionId":"ffffffff-1111-2222-3333-444444444444","status":"busy"}]
+EOF
+log="$tmp/bg-nullname"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" CLAUDE_STUB_LOG="$log" CLAUDE_STUB_ROSTER="$nonameroster"
+  "$wt" bgnullname -- "$prompt"; } 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 0 ] && ! grep -Fq '委譲元' "$log" && ! grep -q 'report-to' <<<"$out"; then
+  echo "ok: a roster entry without a name is treated as unresolvable"
+else echo "FAIL: nameless entry injected rc=$rc"; fail=1; fi
+
+# --tmux gets the same injection: a human may be sitting with that session, but
+# the delegate still benefits from knowing who asked.
+log="$tmp/tmux-name"
+(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" TMUX_STUB_LOG="$log" CLAUDE_STUB_ROSTER="$namedroster"
+  "$wt" --tmux tmuxname -- "$prompt"; }) >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ] && grep -Fq '報告先 name: test-delegator' "$log"; then
+  echo "ok: --tmux receives the same delegator injection"
+else echo "FAIL: --tmux missing injection rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; fail=1; fi
+
 exit "$fail"

--- a/test/claude-worktree.test.sh
+++ b/test/claude-worktree.test.sh
@@ -133,6 +133,25 @@ esac
 EOF
 chmod +x "$stubbin/tmux"
 
+# claude-worktree unconditionally calls `claude agents --json` to resolve the
+# delegator name (and, in bg mode, to check for a colliding session) whenever a
+# prompt is given -- including in the --tmux-mode tests below, which predate
+# the more elaborate claude stub further down this file. Without a stub here,
+# those tests would fall through to the AMBIENT claude on $PATH, making them
+# depend on the host's live session roster (and call an external process from
+# what should be a self-contained test). Default to an empty roster; tests that
+# care about a specific roster override it via $CLAUDE_STUB_ROSTER.
+cat >"$stubbin/claude" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "agents" ]; then
+  if [ -n "${CLAUDE_STUB_ROSTER:-}" ]; then cat "$CLAUDE_STUB_ROSTER"; else printf '[]\n'; fi
+  exit 0
+fi
+printf '%s\n' "$@" >"${CLAUDE_STUB_LOG:-/dev/null}"
+printf 'backgrounded · %s\n' "${CLAUDE_STUB_ID:-abcd1234}"
+EOF
+chmod +x "$stubbin/claude"
+
 # Prompt carrying a space plus both quote kinds -- must survive as ONE argv
 # element (the whole point of passing it separately, not folded into a string).
 prompt='say "hi" it'\''s here'
@@ -426,6 +445,25 @@ out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
 if [ "$rc" -eq 0 ] && grep -q 'some unexpected banner shape' <<<"$out"; then
   echo "ok: unparseable banner is surfaced rather than dropped"
 else echo "FAIL: unparseable banner rc=$rc out=$out"; fail=1; fi
+
+# When claude itself FAILS (nonzero exit), the failure must be diagnosable: rc
+# is nonzero AND the captured stderr reaches the caller. Under `set -e`, a bare
+# `launch_out="$(... claude ...)"` assignment aborts the script the instant
+# claude exits nonzero -- before the captured output is ever printed -- so this
+# guards against that regression (rc=1 with empty output).
+cat >"$stubbin/claude" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "agents" ]; then cat "$CLAUDE_STUB_ROSTER"; exit 0; fi
+echo "claude: fatal: something went wrong" >&2
+exit 1
+EOF
+chmod +x "$stubbin/claude"
+out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
+  export PATH="$stubbin:$PATH" CLAUDE_STUB_ROSTER="$emptyroster"
+  "$wt" bgfail -- "$prompt"; } 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && grep -q 'claude: fatal: something went wrong' <<<"$out"; then
+  echo "ok: a failing bg launch reports its captured stderr instead of dying silently"
+else echo "FAIL: bg launch failure rc=$rc out=$out"; fail=1; fi
 
 # A background session already running in the same worktree means a second
 # delegation would race the first -- refuse, and say how to reach the existing


### PR DESCRIPTION
## Summary

`bin/claude-worktree` を 3 モード化し、委譲先 claude session の既定起動を `claude --bg`（background agent）へ移す。あわせて委譲元 session の name をプロンプトへ注入する。

**モード**

| 起動形 | 挙動 |
|---|---|
| prompt 無し | worktree のみ作成（add-only。変更なし） |
| prompt あり（既定） | worktree を cwd にして `claude --bg --permission-mode acceptEdits [--model <alias>] "<prompt>"` |
| prompt あり + `--tmux` | 従来の detached tmux session + interactive claude（コード・出力とも従来のまま） |

**bg モードの実装**

- 起動 stdout の `backgrounded · <id>` 行から short id（8 桁 hex）を awk で抽出する。区切りが multibyte の middle dot なので、セパレータではなく「8 桁 hex のフィールド」で拾う
- 抽出できなければ raw な launch output を stderr にそのまま流す。session は現に走っているので、id 欄が黙って空の report を出すより生の出力を晒すほうが安全
- 出力は `worktree` / `branch` / `session : <short> (background; acceptEdits)` / `model` / `report-to` / `attach : claude attach <short>`
- 同一 worktree dir に生存 bg session があれば、`git worktree add` より**前**に拒否する（orphan worktree を残さない既存方針に合わせる）。判定は `claude agents --json` の `kind == "background"` かつ `cwd` 一致。`jq` が無い環境では skip する（guard は利便であって correctness boundary ではない）

**委譲元 name の注入**

委譲先は会話履歴を持たないため、報告先を自力で知る手段が無い。`$$` の祖先 pid を辿り `claude agents --json` の `pid` と突き合わせて `.name` を引き、プロンプト末尾へ datum だけを足す:

```
## 委譲元
報告先 name: <name>
```

何を・いつ報告するかの doctrine は `implement-and-review` skill 側に置く（本 PR のスコープ外）。祖先に claude が居ない（人間が素の shell から叩いた）・entry に `name` が無い・`jq` が無い場合は何も足さず、起動も失敗させない。`--tmux` モードにも同じく注入する。

## Why

現行の委譲（detached tmux + interactive claude）の不満は 1 点で、**タスクを完遂しても session が閉じない**こと。REPL に残り続けるので tmux session と worktree が溜まる。

`-p`（非対話）は棄却済み。permission prompt を出せず tool call が拒否されるため、人間不在の委譲先が「静かに劣化したまま完了扱い」になる。`claude --bg` は両方を満たす — 完遂すればプロセスが自分で終了し、承認が要る tool call はブロックして待つ（`claude agents --json` が `status: waiting`, `waitingFor: permission prompt` を返す）。

`--tmux` は退避路ではなく**用途の異なる第 2 モード**として残す。WHAT 確定後に HOW をその場で詰める等、interactivity を要求する委譲は今後も一級のユースケースであるため、既存コードをそのまま維持している。フラグ名は実体を名指しする `--tmux`（`--interactive` は tmux 外で誤解を招く）。

設計上の非自明な制約 2 つ（いずれも実測で確定）:

- `claude --bg` は `--session-id` を**無視する**。id は `--bg` 自身が採番するので、起動時 stdout を読み返す以外に知る方法が無い
- `claude attach` は **short id しか受けない**。full UUID は `No job matching` で失敗する

環境変数ではなくプロンプトへ注入するのも実測由来で、`claude --bg` は background service 経由で起動するため env の継承が保証されない。プロンプトが唯一確実な経路。

## テスト

`test/claude-worktree.test.sh` に bg セクションと注入セクションを追加（既存慣習どおりフレームワーク無し・PATH stub）。`claude` / `tmux` を stub するので実プロセスは起こさない。

新規ケース: bg 既定起動の argv と short id 報告 / 起動 cwd が worktree であること / `--model` の透過と `--model ""` を合成しないこと / 未知 banner の surface / 同一 worktree の bg 衝突拒否（起動**前**に落ちること）/ name の解決・注入・報告 / 注入ブロックが**同一 argv 要素**に乗ること（別引数になると claude が stray positional として読む）/ 祖先無し・`name` 欄無しで注入を黙って省くこと / `--tmux` への注入。

既存の tmux 起動 4 ケースは `--tmux` を付けて回帰として維持した。`bash test/claude-worktree.test.sh` は 32 ケース全て ok / exit 0。

## スコープ外

全体計画のうち Task 2 / Task 3 のみ。`bin/claude-stop-bg`、claude-queue picker の background 対応、skill / rule / doc / allowlist の更新は別 PR で並行実装中。実機での通し検証（`claude --bg` の実 banner 書式、祖先辿り、picker からの attach）は全 Task の merge 後にまとめて回す。
