### PR TITLE
feat(claude-stop-bg): background session だけを停止するラッパーを追加

### DIFF
--- a/bin/claude-stop-bg
+++ b/bin/claude-stop-bg
@@ -38,16 +38,30 @@ if [[ ! "$id" =~ ^[0-9a-f]{8}$ ]]; then
   exit 1
 fi
 
+command -v claude >/dev/null 2>&1 || {
+  echo "claude-stop-bg: the claude CLI is required" >&2
+  exit 1
+}
+
 command -v jq >/dev/null 2>&1 || {
   echo "claude-stop-bg: jq is required to verify the session kind" >&2
+  exit 1
+}
+
+# Fetch the roster and parse it as two separate steps (rather than piping
+# straight into jq) so a roster-fetch failure gets its own diagnostic instead
+# of `set -e` exiting silently with no output at all.
+roster="$(claude agents --json 2>/dev/null)" || {
+  echo "claude-stop-bg: could not read the session roster" >&2
   exit 1
 }
 
 # Resolve the id to exactly one live session and read its kind. An empty result
 # means either "no match" or "more than one match"; both are refusals, because
 # stopping the wrong session cannot be undone.
-kind="$(claude agents --json 2>/dev/null | jq -r --arg id "$id" \
-  '[.[] | select(.sessionId | startswith($id))] | if length == 1 then .[0].kind else "" end')"
+kind="$(jq -r --arg id "$id" \
+  '[.[] | select(.sessionId | startswith($id))] | if length == 1 then .[0].kind else "" end' \
+  <<<"$roster")"
 
 case "$kind" in
   background) ;;

--- a/bin/claude-stop-bg
+++ b/bin/claude-stop-bg
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# claude-stop-bg -- stop a BACKGROUND claude session by its short id.
+#
+# A delegated background session normally exits on its own when the task
+# completes. One case does not: a session that received a message (e.g. it asked
+# the delegator a question and got an answer) stays alive at `idle` after it
+# finishes, because receiving makes it a participant in a conversation. The side
+# that replied is the one that knows to close it, and it already holds the short
+# id from claude-worktree's output.
+#
+# This wrapper exists so that ability can be granted without granting `claude
+# stop *`, which would let an agent kill ANY session -- including the user's own
+# interactive one. The guard refuses anything that is not kind=="background",
+# and refuses ids that do not resolve to exactly one live session.
+#
+# There is deliberately no bulk sweep: `idle` also covers a delegate that asked a
+# question and is waiting for the reply, so sweeping would kill live work.
+#
+# Usage:
+#   claude-stop-bg <short-id>        # 8 hex chars, as printed by claude-worktree
+
+usage() {
+  awk '/^#!/ {next} /^#/ {sub(/^# ?/, ""); print; seen=1; next} seen {exit}' "$0"
+  exit "${1:-1}"
+}
+
+[ $# -eq 1 ] || usage 1
+case "$1" in -h|--help) usage 0 ;; esac
+id="$1"
+
+# Validate the shape before touching the roster. The realistic mistake is
+# passing the full UUID (which `claude stop` itself rejects), and catching it
+# here gives a message that names the actual problem.
+if [[ ! "$id" =~ ^[0-9a-f]{8}$ ]]; then
+  echo "claude-stop-bg: not a short session id (want 8 hex chars): $id" >&2
+  exit 1
+fi
+
+command -v jq >/dev/null 2>&1 || {
+  echo "claude-stop-bg: jq is required to verify the session kind" >&2
+  exit 1
+}
+
+# Resolve the id to exactly one live session and read its kind. An empty result
+# means either "no match" or "more than one match"; both are refusals, because
+# stopping the wrong session cannot be undone.
+kind="$(claude agents --json 2>/dev/null | jq -r --arg id "$id" \
+  '[.[] | select(.sessionId | startswith($id))] | if length == 1 then .[0].kind else "" end')"
+
+case "$kind" in
+  background) ;;
+  "") echo "claude-stop-bg: no unique live session matching: $id" >&2; exit 1 ;;
+  *)  echo "claude-stop-bg: refusing to stop a $kind session: $id" >&2; exit 1 ;;
+esac
+
+claude stop "$id"

--- a/test/claude-stop-bg.test.sh
+++ b/test/claude-stop-bg.test.sh
@@ -64,10 +64,14 @@ if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ]; then
   echo "ok: full UUID is rejected as not a short id"
 else echo "FAIL: full UUID accepted rc=$rc"; fail=1; fi
 
-# No argument -> usage error.
-run >/dev/null 2>&1; [ $? -ne 0 ] \
-  && echo "ok: missing argument is rejected" \
-  || { echo "FAIL: missing argument accepted"; fail=1; }
+# No argument -> usage error. Same shape as the other refusal cases (reset the
+# stoplog, assert it stays empty) so this case proves `claude stop` was never
+# reached, not just that the exit code is nonzero.
+: >"$stoplog"
+run >/dev/null 2>&1; rc=$?
+if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ]; then
+  echo "ok: missing argument is rejected"
+else echo "FAIL: missing argument accepted rc=$rc"; fail=1; fi
 
 # Too many arguments -> usage error. [ $# -eq 1 ] is what stops a caller from
 # smuggling extra flags (e.g. --force) past this wrapper into `claude stop`.
@@ -91,6 +95,27 @@ out="$(PATH="$noclaude" "$src" aaaaaaaa 2>&1)"; rc=$?
 if [ "$rc" -ne 0 ] && [ -n "$out" ] && grep -qF 'the claude CLI is required' <<<"$out"; then
   echo "ok: missing claude CLI is refused with a diagnostic message"
 else echo "FAIL: missing claude CLI rc=$rc out=$out"; fail=1; fi
+
+# Missing `jq` -> refused with a diagnostic message. PATH here has claude (the
+# stub, so the claude-CLI guard passes) but no jq, so the jq guard must be the
+# one that fires. The stub claude script itself uses `cat` to print the
+# fixture roster, so `cat` is symlinked in too even though this guard fires
+# before `claude agents` is ever invoked -- keeping the stub runnable if that
+# ordering ever changes is cheap insurance.
+nojq="$tmp/nojq"
+mkdir -p "$nojq"
+ln -s "$(command -v bash)" "$nojq/bash"
+ln -s "$(command -v cat)" "$nojq/cat"
+cp "$stubbin/claude" "$nojq/claude"
+chmod +x "$nojq/claude"
+: >"$stoplog"
+out="$(PATH="$nojq" CLAUDE_STUB_ROSTER="$roster" CLAUDE_STUB_STOPLOG="$stoplog" "$src" aaaaaaaa 2>&1)"; rc=$?
+# Pinned to the exact guard message (not a loose 'jq' substring) for the same
+# reason as the missing-claude case: a loose match would also pass if a
+# *different* guard fired instead, losing the discriminating power.
+if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ] && grep -qF 'jq is required to verify the session kind' <<<"$out"; then
+  echo "ok: missing jq is refused with a diagnostic message"
+else echo "FAIL: missing jq rc=$rc out=$out"; fail=1; fi
 
 # Two roster entries sharing the prefix are ambiguous -> refuse rather than
 # guess, since stopping the wrong session is unrecoverable.

--- a/test/claude-stop-bg.test.sh
+++ b/test/claude-stop-bg.test.sh
@@ -64,10 +64,30 @@ if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ]; then
   echo "ok: full UUID is rejected as not a short id"
 else echo "FAIL: full UUID accepted rc=$rc"; fail=1; fi
 
-# No argument / too many arguments -> usage error.
+# No argument -> usage error.
 run >/dev/null 2>&1; [ $? -ne 0 ] \
   && echo "ok: missing argument is rejected" \
   || { echo "FAIL: missing argument accepted"; fail=1; }
+
+# Too many arguments -> usage error. [ $# -eq 1 ] is what stops a caller from
+# smuggling extra flags (e.g. --force) past this wrapper into `claude stop`.
+: >"$stoplog"
+run aaaaaaaa --force >/dev/null 2>&1; rc=$?
+if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ]; then
+  echo "ok: extra arguments are rejected"
+else echo "FAIL: extra arguments accepted rc=$rc stoplog=$(cat "$stoplog")"; fail=1; fi
+
+# Missing `claude` CLI -> refused with a diagnostic message, not a silent
+# non-zero exit. PATH here has jq but no claude (real or stub), so the
+# roster-fetch step must fail loudly.
+noclaude="$tmp/noclaude"
+mkdir -p "$noclaude"
+ln -s "$(command -v bash)" "$noclaude/bash"
+ln -s "$(command -v jq)" "$noclaude/jq"
+out="$(PATH="$noclaude" "$src" aaaaaaaa 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && [ -n "$out" ] && grep -qi 'claude' <<<"$out"; then
+  echo "ok: missing claude CLI is refused with a diagnostic message"
+else echo "FAIL: missing claude CLI rc=$rc out=$out"; fail=1; fi
 
 # Two roster entries sharing the prefix are ambiguous -> refuse rather than
 # guess, since stopping the wrong session is unrecoverable.

--- a/test/claude-stop-bg.test.sh
+++ b/test/claude-stop-bg.test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Functional tests for claude-stop-bg. A PATH stub stands in for the `claude`
+# CLI: `agents --json` prints a fixture roster, `stop` records its argv. No real
+# session is ever started, so the guard can be exercised exhaustively.
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+src="$here/../bin/claude-stop-bg"
+fail=0
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+stubbin="$tmp/stubbin"
+mkdir -p "$stubbin"
+cat >"$stubbin/claude" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  agents) cat "$CLAUDE_STUB_ROSTER" ;;
+  stop)   printf '%s\n' "$2" >"$CLAUDE_STUB_STOPLOG" ;;
+  *)      exit 1 ;;
+esac
+EOF
+chmod +x "$stubbin/claude"
+
+roster="$tmp/roster.json"
+cat >"$roster" <<'EOF'
+[
+  {"pid":111,"cwd":"/w/a","kind":"background","sessionId":"aaaaaaaa-1111-2222-3333-444444444444","status":"idle"},
+  {"pid":222,"cwd":"/w/b","kind":"interactive","sessionId":"bbbbbbbb-1111-2222-3333-444444444444","name":"dotrc-32","status":"busy"}
+]
+EOF
+
+stoplog="$tmp/stop.log"
+run() { PATH="$stubbin:$PATH" CLAUDE_STUB_ROSTER="$roster" CLAUDE_STUB_STOPLOG="$stoplog" "$src" "$@"; }
+
+# background session -> stopped, and the SHORT id is what reaches `claude stop`.
+: >"$stoplog"
+run aaaaaaaa >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ] && [ "$(cat "$stoplog")" = "aaaaaaaa" ]; then
+  echo "ok: background session is stopped by short id"
+else echo "FAIL: background stop rc=$rc stoplog=$(cat "$stoplog")"; fail=1; fi
+
+# interactive session -> refused. This is the whole reason the wrapper exists:
+# a broad `claude stop *` grant would let an agent kill the user's own session.
+: >"$stoplog"
+out="$(run bbbbbbbb 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ] && grep -q 'interactive' <<<"$out"; then
+  echo "ok: interactive session is refused and never reaches claude stop"
+else echo "FAIL: interactive not refused rc=$rc out=$out"; fail=1; fi
+
+# unknown id -> refused (no session matches the prefix).
+: >"$stoplog"
+run cccccccc >/dev/null 2>&1; rc=$?
+if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ]; then
+  echo "ok: unknown short id is refused"
+else echo "FAIL: unknown id accepted rc=$rc"; fail=1; fi
+
+# Malformed ids must be rejected before any roster lookup: a full UUID is the
+# realistic mistake (claude attach/stop only accept the 8-char form).
+: >"$stoplog"
+run aaaaaaaa-1111-2222-3333-444444444444 >/dev/null 2>&1; rc=$?
+if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ]; then
+  echo "ok: full UUID is rejected as not a short id"
+else echo "FAIL: full UUID accepted rc=$rc"; fail=1; fi
+
+# No argument / too many arguments -> usage error.
+run >/dev/null 2>&1; [ $? -ne 0 ] \
+  && echo "ok: missing argument is rejected" \
+  || { echo "FAIL: missing argument accepted"; fail=1; }
+
+# Two roster entries sharing the prefix are ambiguous -> refuse rather than
+# guess, since stopping the wrong session is unrecoverable.
+cat >"$tmp/dup.json" <<'EOF'
+[
+  {"pid":111,"cwd":"/w/a","kind":"background","sessionId":"dddddddd-1111-2222-3333-444444444444","status":"idle"},
+  {"pid":333,"cwd":"/w/c","kind":"background","sessionId":"dddddddd-9999-2222-3333-444444444444","status":"idle"}
+]
+EOF
+: >"$stoplog"
+PATH="$stubbin:$PATH" CLAUDE_STUB_ROSTER="$tmp/dup.json" CLAUDE_STUB_STOPLOG="$stoplog" \
+  "$src" dddddddd >/dev/null 2>&1; rc=$?
+if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ]; then
+  echo "ok: ambiguous short id is refused"
+else echo "FAIL: ambiguous id accepted rc=$rc"; fail=1; fi
+
+exit "$fail"

--- a/test/claude-stop-bg.test.sh
+++ b/test/claude-stop-bg.test.sh
@@ -85,7 +85,10 @@ mkdir -p "$noclaude"
 ln -s "$(command -v bash)" "$noclaude/bash"
 ln -s "$(command -v jq)" "$noclaude/jq"
 out="$(PATH="$noclaude" "$src" aaaaaaaa 2>&1)"; rc=$?
-if [ "$rc" -ne 0 ] && [ -n "$out" ] && grep -qi 'claude' <<<"$out"; then
+# Pinned to the exact guard message rather than a loose 'claude' substring: every
+# diagnostic this script prints is prefixed "claude-stop-bg:", so a loose match
+# would also pass if a *different* guard (e.g. the jq one) fired instead.
+if [ "$rc" -ne 0 ] && [ -n "$out" ] && grep -qF 'the claude CLI is required' <<<"$out"; then
   echo "ok: missing claude CLI is refused with a diagnostic message"
 else echo "FAIL: missing claude CLI rc=$rc out=$out"; fail=1; fi
 


### PR DESCRIPTION
## Summary

`bin/claude-stop-bg` を新設する。short session id（8 桁 hex）を 1 つ受け取り、`claude agents --json` でその id が **一意の live session** に解決でき、かつ `kind == "background"` のときだけ `claude stop <short-id>` を実行する。

ガードは 4 段:

- 引数は厳密に 1 つ（`-h` / `--help` は usage を出して exit 0）
- roster を引く前に形を検証する。`^[0-9a-f]{8}$` に合わないものは拒否 — 現実的な間違いは full UUID を渡すことで、`claude attach` / `claude stop` は short id しか受けないため、ここで弾いて実際の問題を名指しするメッセージを返す
- `jq` が無ければ kind を検証できないので実行しない（fail open しない）
- prefix にマッチする roster 行が 0 件でも 2 件以上でも拒否。`background` 以外（`interactive` 等）も拒否

`test/claude-stop-bg.test.sh` は PATH stub で `claude` を差し替え（`agents --json` は fixture roster を出力、`stop` は argv を記録）、実 session を一切起こさずに 6 ケースを検証する: background の正常停止（`claude stop` に届くのが short id であること）、interactive の拒否、未知 id の拒否、full UUID の拒否、引数欠落の拒否、prefix 重複（ambiguous）の拒否。拒否系は `claude stop` に一切到達しないことを stop ログの空判定で確かめる。

## Why

委譲先の background session は通常タスク完了時に自分で終了するが、**メッセージを受け取った session だけは例外**で、完了後も `idle` のまま残る（受信により会話の参加者になるため）。返信した側がその session を閉じる立場にあり、`claude-worktree` の出力から short id を既に持っている。

その能力を付与するのに生の `claude stop *` を allowlist へ足すと、agent が**任意の** session — ユーザー自身の作業中 interactive session を含む — を落とせてしまう。このラッパーは付与範囲を「background のみ・一意に解決できる id のみ」へ絞るために存在する。

一括 sweep は意図的に実装していない。`idle` は「委譲元に質問して返答を待っている delegate」も含むため、sweep すると生きている作業を落とすため。

このスクリプトは委譲ハーネスを background agent 起動へ移行する作業の一部で、他タスクに依存しない独立した部品。`bin/` は PATH 経由なので `bin/deploy.sh` の再実行は不要。allowlist への `Bash(claude-stop-bg *)` 追加は後続の別 PR で入る。
