### PR TITLE
docs: background 委譲先が自分で終了するという誤りを直し、picker の stale な -d を落とす

### DIFF
--- a/bin/claude-stop-bg
+++ b/bin/claude-stop-bg
@@ -3,12 +3,14 @@ set -euo pipefail
 
 # claude-stop-bg -- stop a BACKGROUND claude session by its short id.
 #
-# A delegated background session normally exits on its own when the task
-# completes. One case does not: a session that received a message (e.g. it asked
-# the delegator a question and got an answer) stays alive at `idle` after it
-# finishes, because receiving makes it a participant in a conversation. The side
-# that replied is the one that knows to close it, and it already holds the short
-# id from claude-worktree's output.
+# A delegated background session does NOT exit when its task completes. It stays
+# at `status: idle` waiting for further input -- whether or not it ever exchanged
+# messages with its delegator -- and falls off the roster roughly an hour later.
+# That expiry fires no `SessionEnd` hook, so claude-queue is left with a ghost
+# row whose `terminated_at` never gets filled in; stopping the session here is
+# what closes the tracking cleanly. So the delegator runs this once it has the
+# completion report, whether or not it replied to anything, and it already holds
+# the short id from claude-worktree's output.
 #
 # This wrapper exists so that ability can be granted without granting `claude
 # stop *`, which would let an agent kill ANY session -- including the user's own

--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -11,10 +11,19 @@ set -euo pipefail
 # inside another worktree.
 #
 # When a prompt is given, the default is a BACKGROUND agent (`claude --bg`,
-# acceptEdits) started with the worktree as its cwd. It exits by itself once the
-# task completes, so neither sessions nor worktrees pile up, and tool calls that
-# need approval block and wait rather than degrading silently. Reach it with
+# acceptEdits) started with the worktree as its cwd. Tool calls that need
+# approval block and wait rather than degrading silently. Reach it with
 # `claude attach <short-id>` (the id is printed at launch).
+#
+# A delegate does NOT exit when its task completes: it stays at `status: idle`
+# waiting for further input (a different state from `status: waiting` /
+# `waitingFor: permission prompt`). It falls off the roster roughly an hour
+# later, but that expiry fires no `SessionEnd` hook, so claude-queue is left
+# with a ghost row whose `terminated_at` never gets filled in. Only `claude
+# stop` (= `claude-stop-bg`) closes the tracking cleanly, which is why the
+# delegator closes the session itself once it has the completion report --
+# whether or not it replied to anything. Worktrees outlive the session either
+# way; `git-reap-gone` reaps them.
 #
 # `--tmux` selects the other mode: claude is launched INSIDE a fresh detached
 # tmux session (session name = worktree basename, matching the `gts` convention).
@@ -58,9 +67,10 @@ set -euo pipefail
 #                  local branch, else origin/<branch> (tracked, no fetch), else
 #                  created fresh from the current HEAD.
 #   -- <prompt>    everything after `--` is the initial prompt. By default the
-#                  delegate is started with `claude --bg` (acceptEdits): it exits
-#                  by itself when the task completes, and is reached with
-#                  `claude attach <short-id>`. With --tmux, see above.
+#                  delegate is started with `claude --bg` (acceptEdits) and is
+#                  reached with `claude attach <short-id>`; it stays alive once
+#                  the task completes, so the delegator closes it with
+#                  `claude-stop-bg`. With --tmux, see above.
 
 usage() {
   # Print the first contiguous "# " comment block (the description), skipping the

--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -244,10 +244,12 @@ if [ -n "$delegator" ]; then
 fi
 
 if [ "$use_tmux" = 0 ]; then
-  # Background agent (default). It exits on its own when the task completes,
-  # which is the whole point of preferring it over an interactive session. The
-  # id is assigned by --bg (it ignores --session-id), so the only way to learn
-  # it is to read the launch banner back.
+  # Background agent (default). It does NOT exit on its own when the task
+  # completes -- see the header for that. It's preferred over an interactive
+  # session because it doesn't occupy a tmux session/pane and blocks on
+  # approval-requiring tool calls instead of degrading silently. The id is
+  # assigned by --bg (it ignores --session-id), so the only way to learn it is
+  # to read the launch banner back.
   #
   # cwd matters: the delegate reads the checkout it is started in, so the launch
   # runs inside the worktree. A subshell keeps this script's own cwd untouched.

--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -162,8 +162,8 @@ worktree の滞留も同様に残る — ①はどちらの経路でも走り、
 `terminated_at IS NULL` と state だけで絞るので background も普通に乗る。ジャンプは picker が
 `tmux_pane` の有無で分岐し、NULL なら `tmux new-window -c <cwd> claude attach <short-id>` で
 開く（`claude attach` は short id しか受けない）。`-d` を付けないのは、pane 有りの
-`switch-client` と揃えて「選んだら実際にそこへ移る」を守るため。承認待ちで止まった background 委譲先へ入る
-経路はこれだけなので、picker から隠さず出す。
+`switch-client` と揃えて「選んだら実際にそこへ移る」を守るため。承認待ちで止まった
+background 委譲先へ入る経路はこれだけなので、picker から隠さず出す。
 
 ### ④は **メイン** toplevel 基準でパスを作る
 

--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -160,8 +160,9 @@ worktree の滞留も同様に残る — ①はどちらの経路でも走り、
 
 ③との噛み合わせは「pane 無し = 追跡は完全、ジャンプだけ不能」になる。status-right のカウントは
 `terminated_at IS NULL` と state だけで絞るので background も普通に乗る。ジャンプは picker が
-`tmux_pane` の有無で分岐し、NULL なら `tmux new-window -d -c <cwd> claude attach <short-id>` で
-開く（`claude attach` は short id しか受けない）。承認待ちで止まった background 委譲先へ入る
+`tmux_pane` の有無で分岐し、NULL なら `tmux new-window -c <cwd> claude attach <short-id>` で
+開く（`claude attach` は short id しか受けない）。`-d` を付けないのは、pane 有りの
+`switch-client` と揃えて「選んだら実際にそこへ移る」を守るため。承認待ちで止まった background 委譲先へ入る
 経路はこれだけなので、picker から隠さず出す。
 
 ### ④は **メイン** toplevel 基準でパスを作る


### PR DESCRIPTION
## Summary

background 委譲への移行で取り残された doc / コメントを実態に合わせる。

- `bin/claude-worktree` / `bin/claude-stop-bg` のヘッダから「委譲先はタスクを完遂すると自分で終了する」という記述を除去し、実測の挙動に置き換えた。`claude-stop-bg` はさらに「メッセージを受信した session だけが例外的に残る」と条件を狭めていたが、受信の有無に関わらず残る。
- `docs/design/claude-tmux-worktree.md` の picker 記述から stale な `-d` を落とし、付けない理由を併記した。

## Why

**session の寿命**: background 委譲先はターンを終えても session を終えず、`claude agents --json` の `status: idle`（承認待ちの `status: waiting` / `waitingFor: permission prompt` とは別状態）で次の入力を待ち続ける。完遂から約 60 分で roster から消えるが、その消滅では `SessionEnd` hook が飛ばないため claude-queue の `terminated_at` は NULL のまま幽霊行が残る。追跡がきれいに閉じるのは `claude stop`（= `claude-stop-bg`）経路だけなので、「完遂すれば自分で閉じるので溜まらない」は成立しない。

`claude-stop-bg` のヘッダは `usage()` が `--help` として印字する本文そのもので、誤った説明がユーザーに直接出ていた。修正後の文面は `dot/claude/skills/delegate-to-worktree/SKILL.md` 手順 6 が既に採っている doctrine（委譲元は完了報告を受けたら、返信の有無に関わらず `claude-stop-bg <short-id>` で閉じる）と揃えてある。同 doctrine は `docs/design/claude-tmux-worktree.md` にも既に反映済みで、今回はヘッダ側の追随。

**picker の `-d`**: #48 で `tmux new-window` から `-d` を除去した（pane 有りの行が `switch-client` でフォーカスを移すのと揃え、picker から選んだら実際にそこへ移るようにするため）。design doc だけが detached 形のまま残っていた。

## Refs

- #48 — picker が開く window にフォーカスを移す変更
