### PR TITLE
feat(claude-queue,bin): background 委譲先の後始末を自動化する（reconcile + claude-reap-bg）

### DIFF
--- a/bin/claude-reap-bg
+++ b/bin/claude-reap-bg
@@ -117,12 +117,18 @@ queue="$(sqlite3 -separator $'\t' "$db" \
 # results also arrive as type=="user" entries, so they are excluded by shape
 # (content is a string or contains something other than tool_result); counting
 # them would cut every turn down to its final tool call. Sidechain entries are
-# subagent traffic, not this session's own messages.
+# subagent traffic, not this session's own messages. isMeta=="true" entries
+# (e.g. the skill-launch "Base directory for this skill: ..." injection, or
+# "[Request interrupted by user]") are also type=="user" with non-tool_result
+# content but are not something the human typed, so they are excluded too --
+# counting one as a turn boundary would truncate the turn right past a
+# SendMessage and make the guard below skip a session that is actually
+# waiting on a reply.
 last_turn_sent_message() {
   jq -s '
     [ .[] | select((.isSidechain != true) and (.type == "user" or .type == "assistant")) ] as $msgs
     | ( [ $msgs | to_entries[]
-          | select(.value.type == "user")
+          | select(.value.type == "user" and (.value.isMeta != true))
           | select( (.value.message.content | type) == "string"
                     or ( (.value.message.content | type) == "array"
                          and ( [ .value.message.content[]?.type ] | any(. != "tool_result") ) ) )

--- a/bin/claude-reap-bg
+++ b/bin/claude-reap-bg
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# claude-reap-bg [--dry-run] [--idle-minutes <n>] [<short-id>...] -- conservatively
+# stop background claude sessions that finished and were never closed.
+#
+# A delegated background session does NOT end when its task ends: it sits at
+# `idle` waiting for further input and, roughly an hour later, disappears
+# without firing SessionEnd, leaving a ghost row in claude-queue. The primary
+# fix is for the delegator to run claude-stop-bg once it has the completion
+# report -- this sweep only picks up what that path dropped.
+#
+# Deciding "finished" from the outside is guesswork, so every candidate must
+# clear ALL of these; anything short of that is SKIPPED with the blocking
+# reason, never stopped on a hunch:
+#   * the roster (`claude agents --json`) says kind=="background" and
+#     status=="idle" -- a busy session is still working.
+#   * claude-queue's latest event for it is idle_done (the Stop hook), and that
+#     event is at least --idle-minutes old (default 15). The queue is the only
+#     record of WHEN the turn ended; the roster has no timestamp for it.
+#   * the last assistant turn in the transcript contains no SendMessage
+#     tool_use. A delegate that asked its delegator a question and is waiting
+#     for the reply also sits at `idle`, and killing that discards live work.
+#     This is the check that makes a bulk sweep safe at all -- it is exactly the
+#     case claude-stop-bg's header calls out as the reason it has no sweep of
+#     its own.
+#
+# Stopping goes through claude-stop-bg, never `claude stop` directly, so that
+# wrapper's guard (refuse anything not kind=="background", refuse ambiguous
+# ids) still applies on top of the checks here.
+#
+# Manual, best-effort: exits 0 even when candidates are skipped. There is no
+# cron/daemon on purpose -- an unattended killer of sessions is exactly what
+# the conservative predicates above are trying to avoid becoming.
+#
+# Usage:
+#   claude-reap-bg [--dry-run] [--idle-minutes <n>] [<short-id>...]
+#
+#   --dry-run           report what would be stopped, stop nothing
+#   --idle-minutes <n>  age the idle_done event must reach (default 15)
+#   <short-id>...       restrict the sweep to these 8-hex-char ids (still fully
+#                       gated; ids that are not live idle background sessions
+#                       are reported skipped)
+
+usage() {
+  awk '/^#!/ {next} /^#/ {sub(/^# ?/, ""); print; seen=1; next} seen {exit}' "$0"
+  exit "${1:-1}"
+}
+
+dry_run=0
+idle_minutes=15
+declare -a filters=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage 0 ;;
+    --dry-run) dry_run=1; shift ;;
+    --idle-minutes)
+      [ $# -ge 2 ] || { echo "claude-reap-bg: --idle-minutes needs a value" >&2; exit 1; }
+      idle_minutes="$2"; shift 2 ;;
+    --idle-minutes=*) idle_minutes="${1#*=}"; shift ;;
+    --) shift; while [ $# -gt 0 ]; do filters+=("$1"); shift; done ;;
+    -*) echo "claude-reap-bg: unknown flag: $1" >&2; usage 1 ;;
+    *) filters+=("$1"); shift ;;
+  esac
+done
+
+if [[ ! "$idle_minutes" =~ ^[0-9]+$ ]]; then
+  echo "claude-reap-bg: --idle-minutes wants a non-negative integer: $idle_minutes" >&2
+  exit 1
+fi
+idle_seconds=$(( idle_minutes * 60 ))
+
+for tool in claude jq sqlite3; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "claude-reap-bg: $tool is required" >&2
+    exit 1
+  }
+done
+
+command -v claude-stop-bg >/dev/null 2>&1 || {
+  echo "claude-reap-bg: claude-stop-bg is required (stopping never bypasses it)" >&2
+  exit 1
+}
+
+db="${CLAUDE_QUEUE_DB:-$HOME/.claude/session-queue.db}"
+[ -f "$db" ] || {
+  echo "claude-reap-bg: no claude-queue database at $db" >&2
+  exit 1
+}
+
+# Report accumulators, mirroring git-reap-gone. Each entry is "<id>\t<detail>".
+declare -a reaped=()
+declare -a skipped=()
+reap_ok()   { reaped+=("$1"$'\t'"$2"); }
+reap_skip() { skipped+=("$1"$'\t'"$2"); }
+
+# Fetch the roster as its own step (rather than piping into jq) so a fetch
+# failure gets a diagnostic instead of `set -e` exiting silently.
+roster="$(claude agents --json 2>/dev/null)" || {
+  echo "claude-reap-bg: could not read the session roster" >&2
+  exit 1
+}
+
+# Read the whole queue view once and match ids in bash afterwards. Building a
+# per-session SQL string would mean interpolating roster-supplied text into a
+# query; reading everything up front removes that question entirely.
+queue="$(sqlite3 -separator $'\t' "$db" \
+  "SELECT session_id, raw_state, created_at, COALESCE(transcript_path, '') FROM queue")" || {
+  echo "claude-reap-bg: could not read the claude-queue database at $db" >&2
+  exit 1
+}
+
+# last_turn_sent_message <transcript.jsonl> -- true when the most recent
+# assistant turn issued a SendMessage.
+#
+# "Turn" is the run of assistant entries after the last real user prompt. Tool
+# results also arrive as type=="user" entries, so they are excluded by shape
+# (content is a string or contains something other than tool_result); counting
+# them would cut every turn down to its final tool call. Sidechain entries are
+# subagent traffic, not this session's own messages.
+last_turn_sent_message() {
+  jq -s '
+    [ .[] | select((.isSidechain != true) and (.type == "user" or .type == "assistant")) ] as $msgs
+    | ( [ $msgs | to_entries[]
+          | select(.value.type == "user")
+          | select( (.value.message.content | type) == "string"
+                    or ( (.value.message.content | type) == "array"
+                         and ( [ .value.message.content[]?.type ] | any(. != "tool_result") ) ) )
+          | .key ] | last // -1 ) as $start
+    | [ $msgs[($start + 1):][]
+        | select(.type == "assistant")
+        | .message.content[]? | select(.type == "tool_use") | .name ]
+    | any(. == "SendMessage")
+  ' "$1"
+}
+
+in_list() { local x="$1"; shift; for e in "$@"; do [ "$e" = "$x" ] && return 0; done; return 1; }
+
+# Candidates: live background sessions the roster reports as idle.
+declare -a candidates=()
+while IFS= read -r sid; do
+  [ -n "$sid" ] || continue
+  candidates+=("$sid")
+done < <(jq -r '.[] | select(.kind == "background" and .status == "idle") | .sessionId' <<<"$roster")
+
+declare -a shorts=()
+for sid in "${candidates[@]}"; do shorts+=("${sid:0:8}"); done
+
+# Requested ids that are not candidates get a skip line, so a caller who named
+# an id learns why nothing happened to it.
+if [ "${#filters[@]}" -gt 0 ]; then
+  for f in "${filters[@]}"; do
+    if [ "${#shorts[@]}" -eq 0 ] || ! in_list "$f" "${shorts[@]}"; then
+      reap_skip "$f" "not a live idle background session"
+    fi
+  done
+fi
+
+now="$(date +%s)"
+
+for sid in "${candidates[@]}"; do
+  short="${sid:0:8}"
+  if [ "${#filters[@]}" -gt 0 ] && ! in_list "$short" "${filters[@]}"; then
+    continue
+  fi
+
+  row=""
+  while IFS=$'\t' read -r q_id q_state q_created q_transcript; do
+    if [ "$q_id" = "$sid" ]; then
+      row="found"
+      break
+    fi
+  done <<<"$queue"
+
+  if [ -z "$row" ]; then
+    reap_skip "$short" "no live claude-queue row (untracked, or already ended)"
+    continue
+  fi
+
+  if [ "$q_state" != "idle_done" ]; then
+    reap_skip "$short" "latest queue event is '$q_state', not idle_done"
+    continue
+  fi
+
+  age=$(( now - q_created ))
+  if [ "$age" -lt "$idle_seconds" ]; then
+    reap_skip "$short" "idle for $(( age / 60 ))m, under the ${idle_minutes}m threshold"
+    continue
+  fi
+
+  # No transcript means the SendMessage check cannot run. Skip rather than
+  # assume: an unverifiable session is indistinguishable from one holding a
+  # pending question.
+  if [ -z "$q_transcript" ] || [ ! -r "$q_transcript" ]; then
+    reap_skip "$short" "no readable transcript to check for a pending question"
+    continue
+  fi
+  if ! sent="$(last_turn_sent_message "$q_transcript" 2>/dev/null)"; then
+    reap_skip "$short" "could not parse the transcript ($q_transcript)"
+    continue
+  fi
+  if [ "$sent" != "false" ]; then
+    reap_skip "$short" "last turn sent a SendMessage (likely awaiting a reply)"
+    continue
+  fi
+
+  if [ "$dry_run" = 1 ]; then
+    reap_ok "$short" "would stop (idle $(( age / 60 ))m)"
+    continue
+  fi
+  if claude-stop-bg "$short"; then
+    reap_ok "$short" "stopped (idle $(( age / 60 ))m)"
+  else
+    reap_skip "$short" "claude-stop-bg refused"
+  fi
+done
+
+echo
+label="reaped"
+if [ "$dry_run" = 1 ]; then label="would reap"; fi
+if [ "${#reaped[@]}" -gt 0 ]; then
+  echo "$label (${#reaped[@]}):"
+  for e in "${reaped[@]}"; do printf '  %s\n' "${e/$'\t'/  -- }"; done
+else
+  echo "$label (0): nothing"
+fi
+if [ "${#skipped[@]}" -gt 0 ]; then
+  echo "skipped (${#skipped[@]}):"
+  for e in "${skipped[@]}"; do printf '  %s\n' "${e/$'\t'/  -- }"; done
+fi

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -40,6 +40,7 @@ make install
 | `claude-queue hook <event>` | stdin JSON を受け取り SQLite に状態書き込み（Claude Code hook 経由で呼ばれる） |
 | `claude-queue status` | tmux status-right 用のカウンタ文字列を stdout に出力 |
 | `claude-queue picker` | fzf を popup で起動し、選択 session の pane に `tmux switch-client`。pane が無い（background session）行は `tmux new-window` で `claude attach <short-id>` を起動 |
+| `claude-queue reconcile` | `claude agents --json` に載っていない生存扱いの row を terminated にする（picker 起動時に自動実行される） |
 | `claude-queue reset [--force]` | DB (`~/.claude/session-queue.db`) を削除、対話 y/N |
 | `claude-queue --version` | バージョン表示 |
 
@@ -120,7 +121,6 @@ v0.1 MVP の後続候補。優先度順に整理（implementation plan の final
 
 ### Refactor / Polish
 - **MCP tool naming**: `mcp__server__tool` → `server.tool` 整形（`internal/summary/summary.go:toolInputSummary` に TODO あり）
-- **共有 `dbPath()` の抽出**: 現状 hook/run.go, status/, picker/, reset/ で 4 重複。`internal/config` か `internal/paths` に集約
 - **共有 icon maps の抽出**: status/ と picker/ で emoji/ascii マップが重複。`internal/icons` 化
 - **`db.ListRows` filter**: `where[0]` を上書きする現方式を slice-of-states に書き換え。state 追加時の保守性向上
 - **status の debug log**: `db.Open` 失敗を once-per-process で throttle log

--- a/src/claude-queue/cmd/claude-queue/main.go
+++ b/src/claude-queue/cmd/claude-queue/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/knagiri/dotrc/src/claude-queue/internal/hook"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/picker"
+	"github.com/knagiri/dotrc/src/claude-queue/internal/reconcile"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/reset"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/status"
 )
@@ -14,7 +15,7 @@ import (
 var version = "dev"
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage: claude-queue {hook <event>|status|picker|reset} [flags]")
+	fmt.Fprintln(os.Stderr, "usage: claude-queue {hook <event>|status|picker|reconcile|reset} [flags]")
 	fmt.Fprintln(os.Stderr, "       claude-queue --version")
 }
 
@@ -38,6 +39,8 @@ func main() {
 		status.Run()
 	case "picker":
 		picker.Run(os.Args[2:])
+	case "reconcile":
+		reconcile.Run(os.Args[2:])
 	case "reset":
 		reset.Run(os.Args[2:])
 	default:

--- a/src/claude-queue/internal/db/path.go
+++ b/src/claude-queue/internal/db/path.go
@@ -1,0 +1,20 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// DefaultPath is where the queue database lives. CLAUDE_QUEUE_DB overrides it,
+// which is how the shell tests and bin/claude-reap-bg point at a fixture
+// database instead of the real one.
+func DefaultPath() string {
+	if p := os.Getenv("CLAUDE_QUEUE_DB"); p != "" {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "session-queue.db"
+	}
+	return filepath.Join(home, ".claude", "session-queue.db")
+}

--- a/src/claude-queue/internal/db/queries.go
+++ b/src/claude-queue/internal/db/queries.go
@@ -88,6 +88,28 @@ func ListRows(conn *sql.DB, opts ListOpts) ([]Row, error) {
 	return out, rows.Err()
 }
 
+// LiveSessionIDs returns the session ids the ledger still considers running,
+// i.e. every row that never got a terminated_at. Ordered oldest first so a
+// reconcile pass reports in a stable order.
+func LiveSessionIDs(conn *sql.DB) ([]string, error) {
+	rows, err := conn.Query(
+		"SELECT session_id FROM sessions WHERE terminated_at IS NULL ORDER BY started_at, session_id",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("live sessions: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
 // TerminateSession marks a session ended (terminated_at + ForcedEnd event),
 // matching the cleanup pattern in hook.forcedEndSiblings. Used by the picker
 // when tmux switch-client fails because the recorded pane no longer exists.

--- a/src/claude-queue/internal/hook/run.go
+++ b/src/claude-queue/internal/hook/run.go
@@ -24,7 +24,7 @@ func Run(event string) {
 		logDebug("event mismatch: argv=%s stdin=%s (argv wins)", event, in.HookEventName)
 	}
 
-	path := dbPath()
+	path := db.DefaultPath()
 	conn, err := db.Open(path)
 	if err != nil {
 		logDebug("db.Open(%s): %v", path, err)
@@ -39,17 +39,6 @@ func Run(event string) {
 		return
 	}
 	mux.RefreshStatus()
-}
-
-func dbPath() string {
-	if p := os.Getenv("CLAUDE_QUEUE_DB"); p != "" {
-		return p
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "session-queue.db"
-	}
-	return filepath.Join(home, ".claude", "session-queue.db")
 }
 
 func logDebug(format string, args ...interface{}) {

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/multiplexer"
+	"github.com/knagiri/dotrc/src/claude-queue/internal/reconcile"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/summary"
 )
 
@@ -122,12 +123,23 @@ func Run(args []string) {
 	showStale := fs.Bool("show-stale", false, "include stale sessions")
 	_ = fs.Parse(args)
 
-	conn, err := db.Open(dbPath())
+	conn, err := db.Open(db.DefaultPath())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		return
 	}
 	defer conn.Close()
+
+	// Reconcile before reading the rows, so the list never offers a session
+	// that has already vanished. This is the cheapest place to put it: the
+	// picker is user-driven (so it runs rarely) and it is the one caller that
+	// would otherwise show the stale rows. Best-effort -- an unreadable roster
+	// is no reason to refuse to display the queue.
+	if n, err := reconcile.Sweep(conn); err != nil {
+		fmt.Fprintln(os.Stderr, "reconcile skipped:", err)
+	} else if n > 0 {
+		fmt.Fprintf(os.Stderr, "reconciled %d ended session(s)\n", n)
+	}
 
 	rows, err := db.ListRows(conn, db.ListOpts{
 		ShowWorking: *showWorking,
@@ -199,15 +211,4 @@ func runFzf(input string) (string, error) {
 		return "", err
 	}
 	return strings.TrimRight(string(out), "\n"), nil
-}
-
-func dbPath() string {
-	if p := os.Getenv("CLAUDE_QUEUE_DB"); p != "" {
-		return p
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "session-queue.db"
-	}
-	return filepath.Join(home, ".claude", "session-queue.db")
 }

--- a/src/claude-queue/internal/reconcile/reconcile.go
+++ b/src/claude-queue/internal/reconcile/reconcile.go
@@ -1,0 +1,111 @@
+// Package reconcile closes ledger rows whose sessions are no longer running.
+//
+// A background session does not end when its turn ends: it sits at `idle`
+// waiting for further input and, roughly an hour later, disappears WITHOUT
+// firing the SessionEnd hook. Nothing then writes terminated_at, so the row
+// stays live forever and the picker keeps offering a session that is not there.
+// (Closing a session with `claude stop` does fire SessionEnd, which is why the
+// primary path -- the delegator running claude-stop-bg -- needs no sweeping.)
+//
+// The match itself is pure bookkeeping: `claude agents --json` is the
+// authoritative roster of live sessions, so a tracked id the roster does not
+// list is gone. There is no heuristic and no threshold, which is what makes it
+// safe to run unattended on every picker invocation.
+package reconcile
+
+import (
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
+)
+
+// ToClose returns the tracked session ids that the live roster does not list,
+// preserving the order of tracked. Split out from the exec and SQL around it
+// because this set difference is the entire decision, and it is the part worth
+// testing directly.
+func ToClose(tracked, live []string) []string {
+	liveSet := make(map[string]struct{}, len(live))
+	for _, id := range live {
+		liveSet[id] = struct{}{}
+	}
+	var out []string
+	for _, id := range tracked {
+		if _, ok := liveSet[id]; ok {
+			continue
+		}
+		out = append(out, id)
+	}
+	return out
+}
+
+// roster returns the session ids reported by `claude agents --json`.
+func roster() ([]string, error) {
+	out, err := exec.Command("claude", "agents", "--json").Output()
+	if err != nil {
+		return nil, fmt.Errorf("claude agents --json: %w", err)
+	}
+	var agents []struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(out, &agents); err != nil {
+		return nil, fmt.Errorf("parse roster: %w", err)
+	}
+	ids := make([]string, 0, len(agents))
+	for _, a := range agents {
+		if a.SessionID != "" {
+			ids = append(ids, a.SessionID)
+		}
+	}
+	return ids, nil
+}
+
+// Sweep matches the ledger against the live roster and terminates every tracked
+// session the roster does not list, returning how many were closed.
+//
+// A roster that cannot be read is returned as an error with a zero count, never
+// as an empty roster: "claude agents failed" is not evidence that anything
+// died, and treating it as one would terminate every tracked session at once.
+// Callers are expected to skip the pass on error rather than fail.
+func Sweep(conn *sql.DB) (int, error) {
+	live, err := roster()
+	if err != nil {
+		return 0, err
+	}
+	tracked, err := db.LiveSessionIDs(conn)
+	if err != nil {
+		return 0, err
+	}
+	closed := 0
+	for _, id := range ToClose(tracked, live) {
+		if err := db.TerminateSession(conn, id); err != nil {
+			return closed, err
+		}
+		closed++
+	}
+	return closed, nil
+}
+
+// Run is the CLI entrypoint for `claude-queue reconcile`.
+func Run(args []string) {
+	fs := flag.NewFlagSet("reconcile", flag.ExitOnError)
+	_ = fs.Parse(args)
+
+	conn, err := db.Open(db.DefaultPath())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return
+	}
+	defer conn.Close()
+
+	n, err := Sweep(conn)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "reconcile: skipped:", err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "reconcile: closed %d session(s) missing from the roster\n", n)
+}

--- a/src/claude-queue/internal/reconcile/reconcile_test.go
+++ b/src/claude-queue/internal/reconcile/reconcile_test.go
@@ -1,0 +1,109 @@
+package reconcile
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
+)
+
+func TestToClose(t *testing.T) {
+	cases := []struct {
+		name    string
+		tracked []string
+		live    []string
+		want    []string
+	}{
+		{
+			name:    "roster lists every tracked session",
+			tracked: []string{"a", "b"},
+			live:    []string{"b", "a", "c"},
+			want:    nil,
+		},
+		{
+			name:    "sessions missing from the roster are closed, in tracked order",
+			tracked: []string{"a", "b", "c"},
+			live:    []string{"b"},
+			want:    []string{"a", "c"},
+		},
+		{
+			// The disappearance this whole package exists for: an empty roster
+			// really does mean nothing is running, so everything tracked closes.
+			// It is only an UNREADABLE roster that must not reach here -- Sweep
+			// keeps that case out by erroring instead of passing an empty slice.
+			name:    "an empty roster closes everything tracked",
+			tracked: []string{"a", "b"},
+			live:    nil,
+			want:    []string{"a", "b"},
+		},
+		{
+			name:    "nothing tracked is a no-op",
+			tracked: nil,
+			live:    []string{"a"},
+			want:    nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ToClose(tc.tracked, tc.live)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ToClose(%v, %v) = %v, want %v", tc.tracked, tc.live, got, tc.want)
+			}
+		})
+	}
+}
+
+// The ledger side of the sweep: rows named by ToClose must actually leave the
+// queue view, and rows still on the roster must stay.
+func TestTerminateSessionRemovesRowFromQueue(t *testing.T) {
+	conn, err := db.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	for _, id := range []string{"ghost", "alive"} {
+		if _, err := conn.Exec(
+			"INSERT INTO sessions(session_id) VALUES (?)", id,
+		); err != nil {
+			t.Fatalf("insert session %s: %v", id, err)
+		}
+		if _, err := conn.Exec(
+			"INSERT INTO events(session_id, event_type, state) VALUES (?, 'Stop', 'idle_done')", id,
+		); err != nil {
+			t.Fatalf("insert event %s: %v", id, err)
+		}
+	}
+
+	tracked, err := db.LiveSessionIDs(conn)
+	if err != nil {
+		t.Fatalf("LiveSessionIDs: %v", err)
+	}
+	closing := ToClose(tracked, []string{"alive"})
+	if !reflect.DeepEqual(closing, []string{"ghost"}) {
+		t.Fatalf("ToClose = %v, want [ghost]", closing)
+	}
+	for _, id := range closing {
+		if err := db.TerminateSession(conn, id); err != nil {
+			t.Fatalf("TerminateSession %s: %v", id, err)
+		}
+	}
+
+	var remaining []string
+	rows, err := conn.Query("SELECT session_id FROM queue")
+	if err != nil {
+		t.Fatalf("query queue: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		remaining = append(remaining, id)
+	}
+	if !reflect.DeepEqual(remaining, []string{"alive"}) {
+		t.Errorf("queue after sweep = %v, want [alive]", remaining)
+	}
+}

--- a/src/claude-queue/internal/reset/reset.go
+++ b/src/claude-queue/internal/reset/reset.go
@@ -5,8 +5,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
+
+	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
 )
 
 // Run is the CLI entrypoint for `claude-queue reset`.
@@ -15,7 +16,7 @@ func Run(args []string) {
 	force := fs.Bool("force", false, "skip confirmation prompt")
 	_ = fs.Parse(args)
 
-	path := dbPath()
+	path := db.DefaultPath()
 	if !*force {
 		fmt.Fprintf(os.Stderr, "About to delete %s. Continue? [y/N]: ", path)
 		r := bufio.NewReader(os.Stdin)
@@ -38,15 +39,4 @@ func Run(args []string) {
 	} else {
 		fmt.Fprintf(os.Stderr, "nothing to remove at %s\n", path)
 	}
-}
-
-func dbPath() string {
-	if p := os.Getenv("CLAUDE_QUEUE_DB"); p != "" {
-		return p
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "session-queue.db"
-	}
-	return filepath.Join(home, ".claude", "session-queue.db")
 }

--- a/src/claude-queue/internal/status/status.go
+++ b/src/claude-queue/internal/status/status.go
@@ -3,7 +3,6 @@ package status
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
@@ -46,7 +45,7 @@ func Format(counts map[string]int, asciiMode bool) string {
 // Run is the CLI entrypoint for `claude-queue status`.
 // Never returns a non-zero exit: on error prints empty string.
 func Run() {
-	path := dbPath()
+	path := db.DefaultPath()
 	conn, err := db.Open(path)
 	if err != nil {
 		return
@@ -62,15 +61,4 @@ func Run() {
 
 func asciiEnv() bool {
 	return os.Getenv("CLAUDE_QUEUE_ASCII") == "1"
-}
-
-func dbPath() string {
-	if p := os.Getenv("CLAUDE_QUEUE_DB"); p != "" {
-		return p
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "session-queue.db"
-	}
-	return filepath.Join(home, ".claude", "session-queue.db")
 }

--- a/test/claude-reap-bg.test.sh
+++ b/test/claude-reap-bg.test.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# Functional tests for claude-reap-bg. A PATH stub stands in for the `claude`
+# CLI (`agents --json` prints a fixture roster, `stop` records its argv) and
+# CLAUDE_QUEUE_DB points at a fixture sqlite database, so every predicate can be
+# exercised without a real session existing.
+#
+# bin/ is on PATH ahead of the stub dir's parent so the REAL claude-stop-bg runs
+# in between: the point of routing through it is that its own guard still
+# applies, and stubbing it out would test a shortcut this script does not take.
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+src="$here/../bin/claude-reap-bg"
+bindir="$here/../bin"
+fail=0
+
+for tool in jq sqlite3; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "SKIP: $tool is required to run these tests"
+    exit 0
+  }
+done
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+stubbin="$tmp/stubbin"
+mkdir -p "$stubbin"
+cat >"$stubbin/claude" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  agents) cat "$CLAUDE_STUB_ROSTER" ;;
+  stop)   printf '%s\n' "$2" >>"$CLAUDE_STUB_STOPLOG" ;;
+  *)      exit 1 ;;
+esac
+EOF
+chmod +x "$stubbin/claude"
+
+# Four background sessions plus one interactive, all `idle`. Only the id prefix
+# matters downstream; the rest mirrors the real roster shape.
+roster="$tmp/roster.json"
+cat >"$roster" <<'EOF'
+[
+  {"pid":1,"cwd":"/w/ripe","kind":"background","sessionId":"aaaaaaaa-1111-2222-3333-444444444444","status":"idle"},
+  {"pid":2,"cwd":"/w/fresh","kind":"background","sessionId":"bbbbbbbb-1111-2222-3333-444444444444","status":"idle"},
+  {"pid":3,"cwd":"/w/asked","kind":"background","sessionId":"cccccccc-1111-2222-3333-444444444444","status":"idle"},
+  {"pid":4,"cwd":"/w/busy","kind":"background","sessionId":"dddddddd-1111-2222-3333-444444444444","status":"busy"},
+  {"pid":5,"cwd":"/w/human","kind":"interactive","sessionId":"eeeeeeee-1111-2222-3333-444444444444","status":"idle"}
+]
+EOF
+
+# Transcripts. `quiet` ends its last turn with a plain text reply; `asked` ends
+# it with a SendMessage, i.e. a question the delegator has not answered yet.
+quiet="$tmp/quiet.jsonl"
+cat >"$quiet" <<'EOF'
+{"type":"user","message":{"role":"user","content":"go do the thing"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"SendMessage","input":{}}]}}
+{"type":"user","message":{"role":"user","content":"here is your answer"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"ok"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}
+EOF
+
+asked="$tmp/asked.jsonl"
+cat >"$asked" <<'EOF'
+{"type":"user","message":{"role":"user","content":"go do the thing"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"ok"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"SendMessage","input":{}}]}}
+{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"sent"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"waiting for the reply"}]}}
+EOF
+
+# Fixture database. Ages are relative to unixepoch() so the thresholds are
+# exercised without freezing the clock.
+db="$tmp/queue.db"
+sqlite3 "$db" <<SQL
+CREATE TABLE sessions (
+  session_id      TEXT PRIMARY KEY,
+  tmux_pane       TEXT,
+  cwd             TEXT,
+  transcript_path TEXT,
+  started_at      INTEGER NOT NULL DEFAULT (unixepoch()),
+  terminated_at   INTEGER
+);
+CREATE TABLE events (
+  id         INTEGER PRIMARY KEY AUTOINCREMENT,
+  session_id TEXT NOT NULL REFERENCES sessions(session_id),
+  event_type TEXT NOT NULL,
+  state      TEXT NOT NULL,
+  payload    TEXT,
+  created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+CREATE VIEW queue AS
+SELECT s.session_id, s.tmux_pane, s.cwd, s.transcript_path,
+       e.event_type, e.state AS raw_state, e.payload, e.created_at
+FROM events e
+JOIN (SELECT session_id, MAX(id) AS mid FROM events GROUP BY session_id) l
+  ON e.id = l.mid
+JOIN sessions s ON s.session_id = e.session_id
+WHERE s.terminated_at IS NULL AND e.state != 'ended';
+
+INSERT INTO sessions(session_id, transcript_path) VALUES
+  ('aaaaaaaa-1111-2222-3333-444444444444', '$quiet'),
+  ('bbbbbbbb-1111-2222-3333-444444444444', '$quiet'),
+  ('cccccccc-1111-2222-3333-444444444444', '$asked'),
+  ('dddddddd-1111-2222-3333-444444444444', '$quiet'),
+  ('eeeeeeee-1111-2222-3333-444444444444', '$quiet');
+
+-- ripe: stopped 40 minutes ago. fresh: 2 minutes ago (under the threshold).
+INSERT INTO events(session_id, event_type, state, created_at) VALUES
+  ('aaaaaaaa-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 2400),
+  ('bbbbbbbb-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 120),
+  ('cccccccc-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 2400),
+  ('dddddddd-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 2400),
+  ('eeeeeeee-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 2400);
+SQL
+
+stoplog="$tmp/stop.log"
+run() {
+  : >"$stoplog"
+  PATH="$stubbin:$bindir:$PATH" \
+    CLAUDE_STUB_ROSTER="$roster" CLAUDE_STUB_STOPLOG="$stoplog" \
+    CLAUDE_QUEUE_DB="$db" "$src" "$@"
+}
+stopped() { grep -qF "$1" "$stoplog"; }
+
+# The whole point: an idle background session whose turn ended long enough ago
+# and which is not waiting on a reply gets stopped.
+out="$(run 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && stopped aaaaaaaa; then
+  echo "ok: idle background session past the threshold is stopped"
+else echo "FAIL: ripe session not stopped rc=$rc out=$out"; fail=1; fi
+
+# Under the threshold -> skipped. The turn may have ended seconds ago and the
+# delegator may still be about to send the next message.
+if ! stopped bbbbbbbb && grep -q 'bbbbbbbb.*threshold' <<<"$out"; then
+  echo "ok: session under the idle threshold is skipped, with the reason"
+else echo "FAIL: fresh session not skipped out=$out"; fail=1; fi
+
+# Last turn ended with SendMessage -> skipped. This is the delegate that asked
+# a question and is waiting; stopping it discards live work.
+if ! stopped cccccccc && grep -q 'cccccccc.*SendMessage' <<<"$out"; then
+  echo "ok: session whose last turn sent a SendMessage is skipped"
+else echo "FAIL: asking session not skipped out=$out"; fail=1; fi
+
+# status=="busy" -> never a candidate, so it is not even reported.
+if ! stopped dddddddd && ! grep -q dddddddd <<<"$out"; then
+  echo "ok: busy background session is not a candidate"
+else echo "FAIL: busy session considered out=$out"; fail=1; fi
+
+# kind=="interactive" -> never a candidate. A sweep that could touch the user's
+# own session is the failure mode this tool must not have.
+if ! stopped eeeeeeee && ! grep -q eeeeeeee <<<"$out"; then
+  echo "ok: interactive session is not a candidate"
+else echo "FAIL: interactive session considered out=$out"; fail=1; fi
+
+# --dry-run reports the same decision but stops nothing.
+out="$(run --dry-run 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && [ ! -s "$stoplog" ] && grep -q 'would reap' <<<"$out" && grep -q aaaaaaaa <<<"$out"; then
+  echo "ok: --dry-run reports the candidate and stops nothing"
+else echo "FAIL: dry-run rc=$rc stoplog=$(cat "$stoplog") out=$out"; fail=1; fi
+
+# An explicit id restricts the sweep to that session.
+out="$(run cccccccc 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && [ ! -s "$stoplog" ] && grep -q cccccccc <<<"$out" && ! grep -q aaaaaaaa <<<"$out"; then
+  echo "ok: an explicit id restricts the sweep to that session"
+else echo "FAIL: id filter rc=$rc out=$out"; fail=1; fi
+
+# An id that is not a live idle background session is reported, not silently
+# ignored, so the caller learns why nothing happened.
+out="$(run eeeeeeee 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && [ ! -s "$stoplog" ] && grep -q 'eeeeeeee.*not a live idle background session' <<<"$out"; then
+  echo "ok: a non-candidate id is reported as skipped"
+else echo "FAIL: non-candidate id rc=$rc out=$out"; fail=1; fi
+
+# --idle-minutes moves the threshold: at 1 minute the 2-minute-old session
+# becomes reapable too. This proves the flag is wired to the comparison rather
+# than merely accepted.
+out="$(run --idle-minutes 1 --dry-run 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && grep -q bbbbbbbb <<<"$out" && ! grep -q 'bbbbbbbb.*threshold' <<<"$out"; then
+  echo "ok: --idle-minutes lowers the threshold"
+else echo "FAIL: --idle-minutes ignored rc=$rc out=$out"; fail=1; fi
+
+# A non-numeric threshold is rejected before anything is stopped.
+out="$(run --idle-minutes soon 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ]; then
+  echo "ok: a non-numeric --idle-minutes is rejected"
+else echo "FAIL: bad --idle-minutes accepted rc=$rc out=$out"; fail=1; fi
+
+# A session with no queue row is skipped rather than stopped: without the
+# ledger there is no timestamp to age, so the threshold cannot be checked.
+noqueue="$tmp/noqueue.db"
+sqlite3 "$db" ".dump" | sqlite3 "$noqueue"
+sqlite3 "$noqueue" "DELETE FROM events WHERE session_id = 'aaaaaaaa-1111-2222-3333-444444444444';"
+: >"$stoplog"
+out="$(PATH="$stubbin:$bindir:$PATH" CLAUDE_STUB_ROSTER="$roster" CLAUDE_STUB_STOPLOG="$stoplog" \
+  CLAUDE_QUEUE_DB="$noqueue" "$src" aaaaaaaa 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && [ ! -s "$stoplog" ] && grep -q 'aaaaaaaa.*no live claude-queue row' <<<"$out"; then
+  echo "ok: a session with no queue row is skipped"
+else echo "FAIL: missing queue row rc=$rc out=$out"; fail=1; fi
+
+# A missing transcript is skipped: the pending-question check cannot run, and an
+# unverifiable session must not be treated as a quiet one.
+notx="$tmp/notx.db"
+sqlite3 "$db" ".dump" | sqlite3 "$notx"
+sqlite3 "$notx" "UPDATE sessions SET transcript_path = '$tmp/gone.jsonl' WHERE session_id = 'aaaaaaaa-1111-2222-3333-444444444444';"
+: >"$stoplog"
+out="$(PATH="$stubbin:$bindir:$PATH" CLAUDE_STUB_ROSTER="$roster" CLAUDE_STUB_STOPLOG="$stoplog" \
+  CLAUDE_QUEUE_DB="$notx" "$src" aaaaaaaa 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ] && [ ! -s "$stoplog" ] && grep -q 'aaaaaaaa.*transcript' <<<"$out"; then
+  echo "ok: an unreadable transcript is skipped"
+else echo "FAIL: missing transcript rc=$rc out=$out"; fail=1; fi
+
+# An unreadable roster must abort, not sweep: "claude agents failed" says
+# nothing about which sessions are alive.
+: >"$stoplog"
+out="$(PATH="$stubbin:$bindir:$PATH" CLAUDE_STUB_ROSTER="$tmp/nope.json" CLAUDE_STUB_STOPLOG="$stoplog" \
+  CLAUDE_QUEUE_DB="$db" "$src" 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ]; then
+  echo "ok: an unreadable roster aborts without stopping anything"
+else echo "FAIL: unreadable roster swept rc=$rc out=$out"; fail=1; fi
+
+# A missing database aborts for the same reason.
+: >"$stoplog"
+out="$(PATH="$stubbin:$bindir:$PATH" CLAUDE_STUB_ROSTER="$roster" CLAUDE_STUB_STOPLOG="$stoplog" \
+  CLAUDE_QUEUE_DB="$tmp/absent.db" "$src" 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ] && [ ! -s "$stoplog" ] && grep -q 'no claude-queue database' <<<"$out"; then
+  echo "ok: a missing claude-queue database is refused"
+else echo "FAIL: missing db rc=$rc out=$out"; fail=1; fi
+
+exit "$fail"

--- a/test/claude-reap-bg.test.sh
+++ b/test/claude-reap-bg.test.sh
@@ -45,7 +45,8 @@ cat >"$roster" <<'EOF'
   {"pid":2,"cwd":"/w/fresh","kind":"background","sessionId":"bbbbbbbb-1111-2222-3333-444444444444","status":"idle"},
   {"pid":3,"cwd":"/w/asked","kind":"background","sessionId":"cccccccc-1111-2222-3333-444444444444","status":"idle"},
   {"pid":4,"cwd":"/w/busy","kind":"background","sessionId":"dddddddd-1111-2222-3333-444444444444","status":"busy"},
-  {"pid":5,"cwd":"/w/human","kind":"interactive","sessionId":"eeeeeeee-1111-2222-3333-444444444444","status":"idle"}
+  {"pid":5,"cwd":"/w/human","kind":"interactive","sessionId":"eeeeeeee-1111-2222-3333-444444444444","status":"idle"},
+  {"pid":6,"cwd":"/w/asked-meta","kind":"background","sessionId":"ffffffff-1111-2222-3333-444444444444","status":"idle"}
 ]
 EOF
 
@@ -71,8 +72,29 @@ cat >"$asked" <<'EOF'
 {"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"waiting for the reply"}]}}
 EOF
 
+# `asked_meta` is `asked` with an isMeta injected entry (skill-launch style)
+# tacked on after the SendMessage turn. isMeta entries are not something the
+# human typed, so they must not count as a turn boundary -- if they did, the
+# "last turn" window would start after this entry and would no longer contain
+# the SendMessage, and the session would be wrongly stopped mid-question.
+asked_meta="$tmp/asked_meta.jsonl"
+cat >"$asked_meta" <<'EOF'
+{"type":"user","message":{"role":"user","content":"go do the thing"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"SendMessage","input":{}}]}}
+{"type":"user","isMeta":true,"message":{"role":"user","content":[{"type":"text","text":"Base directory for this skill: /x"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"waiting for the reply"}]}}
+EOF
+
 # Fixture database. Ages are relative to unixepoch() so the thresholds are
 # exercised without freezing the clock.
+#
+# This DDL is a hand-written subset of src/claude-queue/internal/db/schema.go
+# (the `Schema` constant) -- the source of truth. It intentionally drops
+# `effective_state` and `priority` from the `queue` view because
+# claude-reap-bg only ever reads `session_id`, `raw_state`, `created_at`, and
+# `transcript_path`, plus the view's live-row filter (terminated_at IS NULL
+# AND state != 'ended'). If schema.go's column names or that filter change,
+# update this block to match.
 db="$tmp/queue.db"
 sqlite3 "$db" <<SQL
 CREATE TABLE sessions (
@@ -105,7 +127,8 @@ INSERT INTO sessions(session_id, transcript_path) VALUES
   ('bbbbbbbb-1111-2222-3333-444444444444', '$quiet'),
   ('cccccccc-1111-2222-3333-444444444444', '$asked'),
   ('dddddddd-1111-2222-3333-444444444444', '$quiet'),
-  ('eeeeeeee-1111-2222-3333-444444444444', '$quiet');
+  ('eeeeeeee-1111-2222-3333-444444444444', '$quiet'),
+  ('ffffffff-1111-2222-3333-444444444444', '$asked_meta');
 
 -- ripe: stopped 40 minutes ago. fresh: 2 minutes ago (under the threshold).
 INSERT INTO events(session_id, event_type, state, created_at) VALUES
@@ -113,7 +136,8 @@ INSERT INTO events(session_id, event_type, state, created_at) VALUES
   ('bbbbbbbb-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 120),
   ('cccccccc-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 2400),
   ('dddddddd-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 2400),
-  ('eeeeeeee-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 2400);
+  ('eeeeeeee-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 2400),
+  ('ffffffff-1111-2222-3333-444444444444', 'Stop', 'idle_done', unixepoch() - 2400);
 SQL
 
 stoplog="$tmp/stop.log"
@@ -143,6 +167,14 @@ else echo "FAIL: fresh session not skipped out=$out"; fail=1; fi
 if ! stopped cccccccc && grep -q 'cccccccc.*SendMessage' <<<"$out"; then
   echo "ok: session whose last turn sent a SendMessage is skipped"
 else echo "FAIL: asking session not skipped out=$out"; fail=1; fi
+
+# An isMeta injected entry (skill-launch style) after the SendMessage must not
+# be mistaken for a turn boundary -- otherwise the "last turn" window would
+# start past it, no longer see the SendMessage, and the session would be
+# wrongly stopped while still awaiting a reply.
+if ! stopped ffffffff && grep -q 'ffffffff.*SendMessage' <<<"$out"; then
+  echo "ok: an isMeta entry after SendMessage does not defeat the pending-reply guard"
+else echo "FAIL: isMeta-confused session not skipped out=$out"; fail=1; fi
 
 # status=="busy" -> never a candidate, so it is not even reported.
 if ! stopped dddddddd && ! grep -q dddddddd <<<"$out"; then


### PR DESCRIPTION
## Summary

background 委譲先の後始末を自動化する 2 つの artifact を追加する。

**A. `claude-queue reconcile`**（`internal/reconcile`）

`terminated_at IS NULL` の row のうち、`claude agents --json` の roster に載っていない
session を `db.TerminateSession` で terminated にする。純粋な帳簿の突き合わせで、判定は
「roster に居るか否か」だけ。

- roster の取得に失敗したら**何もせず正常終了**する。「`claude agents` が失敗した」は
  「session が死んだ」の証拠ではなく、空 roster として扱うと全件 terminate してしまうため
- 判定本体（live set と tracked set の差分）は `ToClose` として純関数に切り出し、unit test を付けた
- `internal/picker` の `Run` 冒頭（行を読む前）で自動実行する。ユーザー起点で頻度が低く、
  一覧が常に掃除済みになる位置。roster が読めないときは picker 表示を止めず skip する
- 併せて README の TODO にあった `dbPath()` の 4 重複（hook / status / picker / reset）を
  `db.DefaultPath()` に集約した

**B. `bin/claude-reap-bg`**

残存 bg session を停止する。`bin/git-reap-gone` と同じ思想で、保守的な predicate を
**全通過**したものだけ停止し、欠けるものは skip して理由を report する。

predicate（すべて満たすこと）:

| # | 条件 | 落とすもの |
|---|---|---|
| 1 | roster が `kind == "background"` かつ `status == "idle"` | 作業中の session、interactive session |
| 2 | claude-queue の最新 event が `idle_done` で、`created_at` から 15 分以上経過 | ターンが終わった直後の session |
| 3 | transcript の最後の assistant ターンに `SendMessage` の tool_use が無い | 質問を送って返信待ちの委譲先 |

- 停止は `claude-stop-bg <short-id>` 経由で、生の `claude stop` は呼ばない（guard の二重化）
- 引数無しで全 sweep、short-id 指定で対象限定。`--dry-run` / `--idle-minutes <n>`（既定 15）
- manual 運用。cron 常駐は作らない

## Why

background session はターンを終えても session を終えない。`claude agents --json` の
`status: idle` で次の入力を待ち続け、**約 60 分後に `SessionEnd` hook を伴わずに消える**。
そのため claude-queue の `terminated_at` は NULL のまま残り、`queue` view に幽霊行が積む
（実測で 4 件確認）。`claude stop`（= `claude-stop-bg`）で閉じた場合だけ `SessionEnd` が
飛んで追跡がきれいに閉じる。

一次経路は「委譲元が完了報告を受けたら `claude-stop-bg` で閉じる」で、これは既に
`dot/claude/skills/delegate-to-worktree/SKILL.md` に doctrine 化済み。本 PR はその
取りこぼしを拾う自浄システムで、A が帳簿を、B が実体を掃除する。

predicate 3 が bulk sweep を安全にしている核。`bin/claude-stop-bg` のヘッダが
「`idle` は質問して返信待ちの委譲先も含むので sweep は持たない」と書いている、その
制約を transcript の検査で解いている。

## Tests

- `src/claude-queue`: `go build ./...` / `go vet ./...` / `go test ./...` / `gofmt -l` すべて通過
- `test/claude-reap-bg.test.sh`（新規, 14 ケース）: `test/claude-stop-bg.test.sh` に倣い、
  PATH stub で `claude` を差し替え、`CLAUDE_QUEUE_DB` で fixture の sqlite を与える。
  `claude-stop-bg` は stub せず実物を PATH に置き、二重 guard の合成まで通す
- 各 predicate を潰す mutation（SendMessage 判定を無効化 / 閾値比較を無効化 /
  `kind`・`status` filter を緩和）でテストが実際に落ちることを確認済み。
  filter を緩めた mutation では `claude-stop-bg` 側の guard が interactive session の
  停止を拒否しており、二重化が効いていることも確認できた
- 既存 shell テスト 4 本も引き続き通過

## Notes

- `bin/claude-reap-bg` は `sqlite3` に依存する（`command -v` で guard 済み）。
  `bin/list-install.sh` の commands には未追加 — 本 PR のスコープ外のため
- allowlist（`Bash(claude-reap-bg *)`）は `dot/claude/settings.json` に未追加。
  同じくスコープ外なので、必要なら別途
