### PR TITLE
fix(claude-queue): picker の attach 経路を worktree の tmux session に向け、表示も worktree 名にする

### DIFF
--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -161,15 +161,13 @@ worktree の滞留も同様に残る — ①はどちらの経路でも走り、
 ③との噛み合わせは「pane 無し = 追跡は完全、ジャンプだけ不能」になる。status-right のカウントは
 `terminated_at IS NULL` と state だけで絞るので background も普通に乗る。ジャンプは picker が
 `tmux_pane` の有無で分岐し、NULL ならその worktree の tmux session（session 名 = worktree
-ディレクトリ名。`gts` / `claude-worktree` と同じ慣習）を単位に開く。`has-session` で判定し、
-無ければ `new-session -d -s <name> -n <window> ...` で session ごと作成、既にあれば
-`new-window -S -n <window> -t "=<name>:" ...` で window を追加してから `switch-client` で
-そこへ移る（`claude attach` は short id しか受けない）。`-d` の要否は経路によって**逆**になる —
-`new-session` は popup 内での attach 競合を避けるため **必須**、`new-window` は付けると window
-が背景に残って選んでも何も起きて見えなくなるため **禁止**。`-t` の `=` 接頭辞・末尾 `:`・`-S`
-による window 再利用（同じ target を二度選んでも window が増えない）の詳細は
-`src/claude-queue/README.md` と `internal/multiplexer/tmux.go` のコメントを参照。承認待ちで
-止まった background 委譲先へ入る経路はこれだけなので、picker から隠さず出す。
+ディレクトリ名。`gts` / `claude-worktree` と同じ慣習）を単位に開く。無ければ session ごと作成、
+既にあれば window を足して client をそこへ移す（`claude attach` は short id しか受けない）。
+popup を開いた時点の current session には作らない — これが「1 worktree = 1 tmux session」を
+守る理由で、承認待ちで止まった background 委譲先へ入る経路はこれだけなので picker から隠さず
+出す。flag レベルの詳細（`-d` の要否が経路で逆になる理由、`-t` の `=` 接頭辞・末尾 `:`・`-S` に
+よる window 再利用）は `src/claude-queue/README.md` と `internal/multiplexer/tmux.go` のコメント
+に一本化してあるので、そちらを参照。
 
 ### ④は **メイン** toplevel 基準でパスを作る
 

--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -166,8 +166,8 @@ worktree の滞留も同様に残る — ①はどちらの経路でも走り、
 popup を開いた時点の current session には作らない — これが「1 worktree = 1 tmux session」を
 守る理由で、承認待ちで止まった background 委譲先へ入る経路はこれだけなので picker から隠さず
 出す。flag レベルの詳細（`-d` の要否が経路で逆になる理由、`-t` の `=` 接頭辞・末尾 `:`・`-S` に
-よる window 再利用）は `src/claude-queue/README.md` と `internal/multiplexer/tmux.go` のコメント
-に一本化してあるので、そちらを参照。
+よる window 再利用）は `internal/multiplexer/tmux.go` のコメントに一本化してあるので、そちらを
+参照（README.md は挙動レベルの説明に留め、flag レベルは書かない）。
 
 ### ④は **メイン** toplevel 基準でパスを作る
 

--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -160,10 +160,16 @@ worktree の滞留も同様に残る — ①はどちらの経路でも走り、
 
 ③との噛み合わせは「pane 無し = 追跡は完全、ジャンプだけ不能」になる。status-right のカウントは
 `terminated_at IS NULL` と state だけで絞るので background も普通に乗る。ジャンプは picker が
-`tmux_pane` の有無で分岐し、NULL なら `tmux new-window -c <cwd> claude attach <short-id>` で
-開く（`claude attach` は short id しか受けない）。`-d` を付けないのは、pane 有りの
-`switch-client` と揃えて「選んだら実際にそこへ移る」を守るため。承認待ちで止まった
-background 委譲先へ入る経路はこれだけなので、picker から隠さず出す。
+`tmux_pane` の有無で分岐し、NULL ならその worktree の tmux session（session 名 = worktree
+ディレクトリ名。`gts` / `claude-worktree` と同じ慣習）を単位に開く。`has-session` で判定し、
+無ければ `new-session -d -s <name> -n <window> ...` で session ごと作成、既にあれば
+`new-window -S -n <window> -t "=<name>:" ...` で window を追加してから `switch-client` で
+そこへ移る（`claude attach` は short id しか受けない）。`-d` の要否は経路によって**逆**になる —
+`new-session` は popup 内での attach 競合を避けるため **必須**、`new-window` は付けると window
+が背景に残って選んでも何も起きて見えなくなるため **禁止**。`-t` の `=` 接頭辞・末尾 `:`・`-S`
+による window 再利用（同じ target を二度選んでも window が増えない）の詳細は
+`src/claude-queue/README.md` と `internal/multiplexer/tmux.go` のコメントを参照。承認待ちで
+止まった background 委譲先へ入る経路はこれだけなので、picker から隠さず出す。
 
 ### ④は **メイン** toplevel 基準でパスを作る
 

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -39,7 +39,7 @@ make install
 |---|---|
 | `claude-queue hook <event>` | stdin JSON を受け取り SQLite に状態書き込み（Claude Code hook 経由で呼ばれる） |
 | `claude-queue status` | tmux status-right 用のカウンタ文字列を stdout に出力 |
-| `claude-queue picker` | fzf を popup で起動し、選択 session の pane に `tmux switch-client`。pane が無い（background session）行は `tmux new-window` で `claude attach <short-id>` を起動 |
+| `claude-queue picker` | fzf を popup で起動し、選択 session の pane に `tmux switch-client`。pane が無い（background session）行は、その worktree の tmux session（無ければ作成）に window を開いて `claude attach <short-id>` を起動し、client をそこへ移す。session 名 = worktree ディレクトリ名（`gts` / `claude-worktree` と同じ慣習） |
 | `claude-queue reconcile` | `claude agents --json` に載っていない生存扱いの row を terminated にする（picker 起動時に自動実行される） |
 | `claude-queue reset [--force]` | DB (`~/.claude/session-queue.db`) を削除、対話 y/N |
 | `claude-queue --version` | バージョン表示 |
@@ -105,7 +105,8 @@ PR 作成時に description に貼って確認：
 - [ ] 承認後 `⚙️1`（working）、応答完了で `✅1`（idle_done）
 - [ ] 拒否時は `PermissionDenied` で `⚙️1` に戻る
 - [ ] `C-q q` で popup、Enter で目的 pane にジャンプ、popup 自動閉
-- [ ] `claude --bg` で起動した background session（tmux_pane が NULL）を picker から選択、新規 window で `claude attach` される
+- [ ] `claude --bg` で起動した background session（tmux_pane が NULL）を picker から選択、その worktree の tmux session に window が開いて `claude attach` される（popup を開いた session には増えない）
+- [ ] worktree のサブディレクトリで起動した session が、picker の 2 列目に worktree 名で並ぶ
 - [ ] 同 pane で `/clear` 後、旧 session が view から消える（L3）
 - [ ] `CLAUDE_QUEUE_ASCII=1` で `[!]1` 等に切替
 - [ ] 2 pane 並行で approve 連打、busy_timeout 超過しない

--- a/src/claude-queue/internal/multiplexer/multiplexer.go
+++ b/src/claude-queue/internal/multiplexer/multiplexer.go
@@ -16,10 +16,11 @@ type Multiplexer interface {
 	// Switch focuses the pane/target identified by the string returned
 	// from a prior PaneID() call.
 	Switch(target string) error
-	// NewWindow opens a new window running argv with cwd as its working
-	// directory and moves focus to it. Returns an error when there is no
-	// multiplexer to open a window in.
-	NewWindow(cwd string, argv []string) error
+	// OpenSession opens argv in a window of the multiplexer session named
+	// name, creating that session if it does not exist, and moves the client
+	// there. cwd is the window's working directory. Returns an error when
+	// there is no multiplexer to open a session in.
+	OpenSession(name, cwd string, argv []string) error
 }
 
 // Detect selects an implementation based on environment variables.
@@ -40,9 +41,9 @@ func (noopImpl) PaneID() string             { return "" }
 func (noopImpl) RefreshStatus()             {}
 func (noopImpl) Switch(target string) error { return nil }
 
-// NewWindow cannot succeed without a multiplexer, and callers need to know:
+// OpenSession cannot succeed without a multiplexer, and callers need to know:
 // unlike Switch, there is no silent degradation that still gets the user to
 // their session. The error is what makes the caller print a manual fallback.
-func (noopImpl) NewWindow(cwd string, argv []string) error {
+func (noopImpl) OpenSession(name, cwd string, argv []string) error {
 	return errors.New("no multiplexer detected")
 }

--- a/src/claude-queue/internal/multiplexer/multiplexer_test.go
+++ b/src/claude-queue/internal/multiplexer/multiplexer_test.go
@@ -28,9 +28,9 @@ func TestDetect_NoMultiplexer(t *testing.T) {
 	if err := m.Switch("anything"); err != nil {
 		t.Errorf("noop Switch err = %v, want nil", err)
 	}
-	// Unlike Switch, NewWindow must return an error: the picker's attach path
+	// Unlike Switch, OpenSession must return an error: the picker's attach path
 	// relies on this to decide whether to print a manual-fallback hint.
-	if err := m.NewWindow("/w/a", []string{"claude", "attach", "abc"}); err == nil {
-		t.Errorf("noop NewWindow err = nil, want non-nil")
+	if err := m.OpenSession("dotrc_wt", "/w/a", []string{"claude", "attach", "abc"}); err == nil {
+		t.Errorf("noop OpenSession err = nil, want non-nil")
 	}
 }

--- a/src/claude-queue/internal/multiplexer/tmux.go
+++ b/src/claude-queue/internal/multiplexer/tmux.go
@@ -30,16 +30,17 @@ func (tmuxImpl) OpenSession(name, cwd string, argv []string) error {
 	if name == "" {
 		return errors.New("no session name")
 	}
+	window := windowName(argv)
 	if err := exec.Command("tmux", "has-session", "-t="+name).Run(); err != nil {
 		// A new session must be created detached. The picker runs inside
 		// `display-popup -E`, and an attaching new-session would try to take
 		// over that popup's terminal; switch-client below moves the client
 		// deliberately instead. This is why -d is right here and wrong for
 		// new-window, where it would leave the pick looking like a no-op.
-		if err := exec.Command("tmux", newSessionArgs(name, cwd, argv)...).Run(); err != nil {
+		if err := exec.Command("tmux", newSessionArgs(name, window, cwd, argv)...).Run(); err != nil {
 			return err
 		}
-	} else if err := exec.Command("tmux", newWindowArgs(name, windowName(argv), cwd, argv)...).Run(); err != nil {
+	} else if err := exec.Command("tmux", newWindowArgs(name, window, cwd, argv)...).Run(); err != nil {
 		return err
 	}
 	return exec.Command("tmux", "switch-client", "-t="+name).Run()
@@ -47,8 +48,16 @@ func (tmuxImpl) OpenSession(name, cwd string, argv []string) error {
 
 // newSessionArgs builds the tmux argv for creating the session. Split out from
 // OpenSession so the contract can be asserted without starting a tmux server.
-func newSessionArgs(name, cwd string, argv []string) []string {
-	args := []string{"new-session", "-d", "-s", name}
+//
+// -n names the initial window explicitly with the same windowName(argv) used
+// by newWindowArgs below. Without it tmux auto-names the window from the
+// shell command, which does not match the name newWindowArgs' -S looks for,
+// so a session created via this path would never dedupe on a second pick of
+// the same target (a second window would stack instead of -S selecting the
+// first one). Naming it here also disables tmux's automatic-rename for the
+// window, so the name -S depends on cannot drift later.
+func newSessionArgs(name, window, cwd string, argv []string) []string {
+	args := []string{"new-session", "-d", "-s", name, "-n", window}
 	if cwd != "" {
 		args = append(args, "-c", cwd)
 	}

--- a/src/claude-queue/internal/multiplexer/tmux.go
+++ b/src/claude-queue/internal/multiplexer/tmux.go
@@ -30,6 +30,12 @@ func (tmuxImpl) OpenSession(name, cwd string, argv []string) error {
 	if name == "" {
 		return errors.New("no session name")
 	}
+	// Sanitize here, not in the caller: this is the tmux-specific target
+	// escaping rule (see sanitizeSessionName), so it belongs with the other
+	// tmux implementation, not leaked across the Multiplexer interface. Every
+	// tmux invocation below must see the same sanitized name has-session
+	// checks, so this has to run before any of them.
+	name = sanitizeSessionName(name)
 	window := windowName(argv)
 	if err := exec.Command("tmux", "has-session", "-t="+name).Run(); err != nil {
 		// A new session must be created detached. The picker runs inside
@@ -104,4 +110,16 @@ func windowName(argv []string) string {
 		}
 	}
 	return b.String()
+}
+
+// sanitizeSessionName makes a worktree directory name usable as a tmux target.
+//
+// tmux does not reject "." or ":" in `new-session -s`; it silently rewrites
+// them to "_", which is worse than rejecting them: the session would exist
+// under a name that the `has-session -t=` lookup never matches ("." is read as
+// the window.pane separator), so every pick would create yet another session.
+// Substituting up front keeps the name we ask for and the name tmux stores
+// identical. claude-worktree already uses "_" as its separator for this reason.
+func sanitizeSessionName(name string) string {
+	return strings.NewReplacer(".", "_", ":", "_").Replace(name)
 }

--- a/src/claude-queue/internal/multiplexer/tmux.go
+++ b/src/claude-queue/internal/multiplexer/tmux.go
@@ -1,8 +1,10 @@
 package multiplexer
 
 import (
+	"errors"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 type tmuxImpl struct{}
@@ -19,19 +21,78 @@ func (tmuxImpl) Switch(target string) error {
 	return exec.Command("tmux", "switch-client", "-t", target).Run()
 }
 
-// NewWindow opens the command in a new window and makes it current, so
-// picking a background session in the picker actually takes the user there;
-// -c sets the window's working directory.
-func (tmuxImpl) NewWindow(cwd string, argv []string) error {
-	return exec.Command("tmux", newWindowArgs(cwd, argv)...).Run()
+// OpenSession puts argv in a window of the tmux session called name, creating
+// that session when it is missing, then moves the client there. The picker
+// needs the session, not just the window: a background session belongs to a
+// worktree, and opening its window wherever the popup happened to be invoked
+// from would scatter unrelated worktrees across one session.
+func (tmuxImpl) OpenSession(name, cwd string, argv []string) error {
+	if name == "" {
+		return errors.New("no session name")
+	}
+	if err := exec.Command("tmux", "has-session", "-t="+name).Run(); err != nil {
+		// A new session must be created detached. The picker runs inside
+		// `display-popup -E`, and an attaching new-session would try to take
+		// over that popup's terminal; switch-client below moves the client
+		// deliberately instead. This is why -d is right here and wrong for
+		// new-window, where it would leave the pick looking like a no-op.
+		if err := exec.Command("tmux", newSessionArgs(name, cwd, argv)...).Run(); err != nil {
+			return err
+		}
+	} else if err := exec.Command("tmux", newWindowArgs(name, windowName(argv), cwd, argv)...).Run(); err != nil {
+		return err
+	}
+	return exec.Command("tmux", "switch-client", "-t="+name).Run()
 }
 
-// newWindowArgs builds the tmux argv. Split out from NewWindow so the
-// contract can be asserted without starting a tmux server.
-func newWindowArgs(cwd string, argv []string) []string {
-	args := []string{"new-window"}
+// newSessionArgs builds the tmux argv for creating the session. Split out from
+// OpenSession so the contract can be asserted without starting a tmux server.
+func newSessionArgs(name, cwd string, argv []string) []string {
+	args := []string{"new-session", "-d", "-s", name}
 	if cwd != "" {
 		args = append(args, "-c", cwd)
 	}
 	return append(args, argv...)
+}
+
+// newWindowArgs builds the tmux argv for adding a window to an existing
+// session. The "=" prefix on the target is required: without it tmux also
+// tries prefix and glob matches, so a session named `dotrc` would ambiguously
+// match `dotrc_queue-picker-worktree-session` and grow the window in the wrong
+// place. The target's empty window name (the trailing ":") asks for the next
+// unused index -- naming an index instead would error out once it is taken.
+// -S selects an existing window of the same name rather than stacking another,
+// so picking the same session twice is idempotent.
+func newWindowArgs(name, window, cwd string, argv []string) []string {
+	args := []string{"new-window", "-S", "-n", window, "-t", "=" + name + ":"}
+	if cwd != "" {
+		args = append(args, "-c", cwd)
+	}
+	return append(args, argv...)
+}
+
+// windowName derives a window name from the command being run, so repeated
+// picks of the same target collapse onto one window (see -S above) while two
+// different sessions opened in the same tmux session stay apart. Anything
+// outside [A-Za-z0-9_-] becomes "_": tmux reads "." and ":" as the
+// window.pane and session:window separators in -t targets.
+func windowName(argv []string) string {
+	if len(argv) == 0 {
+		return "cmd"
+	}
+	var b strings.Builder
+	for i, a := range argv {
+		if i > 0 {
+			b.WriteByte('-')
+		}
+		for _, r := range a {
+			switch {
+			case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+				b.WriteRune(r)
+			default:
+				b.WriteByte('_')
+			}
+		}
+	}
+	return b.String()
 }

--- a/src/claude-queue/internal/multiplexer/tmux_test.go
+++ b/src/claude-queue/internal/multiplexer/tmux_test.go
@@ -2,42 +2,138 @@ package multiplexer
 
 import (
 	"slices"
+	"strings"
 	"testing"
 )
 
-// newWindowArgs is exercised instead of NewWindow itself so the argv contract
+// The argv builders are exercised instead of OpenSession itself so the contract
 // is checked without starting a real tmux server.
-func TestNewWindowArgs(t *testing.T) {
+func TestNewSessionArgs(t *testing.T) {
 	tests := []struct {
 		name string
+		sess string
 		cwd  string
 		argv []string
 		want []string
 	}{
 		{
 			name: "with cwd",
+			sess: "dotrc_wt",
 			cwd:  "/w/a",
 			argv: []string{"claude", "attach", "abc"},
-			want: []string{"new-window", "-c", "/w/a", "claude", "attach", "abc"},
+			want: []string{"new-session", "-d", "-s", "dotrc_wt", "-c", "/w/a", "claude", "attach", "abc"},
 		},
 		{
 			name: "without cwd",
+			sess: "dotrc_wt",
 			cwd:  "",
 			argv: []string{"claude", "attach", "abc"},
-			want: []string{"new-window", "claude", "attach", "abc"},
+			want: []string{"new-session", "-d", "-s", "dotrc_wt", "claude", "attach", "abc"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := newWindowArgs(tt.cwd, tt.argv)
+			got := newSessionArgs(tt.sess, tt.cwd, tt.argv)
 			if !slices.Equal(got, tt.want) {
-				t.Errorf("newWindowArgs(%q, %v) = %v, want %v", tt.cwd, tt.argv, got, tt.want)
+				t.Errorf("newSessionArgs(%q, %q, %v) = %v, want %v", tt.sess, tt.cwd, tt.argv, got, tt.want)
+			}
+			// Creating the session detached is mandatory: the picker runs in
+			// a display-popup, and an attaching new-session would fight it
+			// for the terminal. switch-client moves the client afterwards.
+			if !slices.Contains(got, "-d") {
+				t.Errorf("newSessionArgs(...) = %v, must contain -d", got)
+			}
+		})
+	}
+}
+
+func TestNewWindowArgs(t *testing.T) {
+	tests := []struct {
+		name   string
+		sess   string
+		window string
+		cwd    string
+		argv   []string
+		want   []string
+	}{
+		{
+			name:   "with cwd",
+			sess:   "dotrc",
+			window: "claude-attach-abc",
+			cwd:    "/w/a",
+			argv:   []string{"claude", "attach", "abc"},
+			want: []string{
+				"new-window", "-S", "-n", "claude-attach-abc", "-t", "=dotrc:",
+				"-c", "/w/a", "claude", "attach", "abc",
+			},
+		},
+		{
+			name:   "without cwd",
+			sess:   "dotrc",
+			window: "claude-attach-abc",
+			cwd:    "",
+			argv:   []string{"claude", "attach", "abc"},
+			want: []string{
+				"new-window", "-S", "-n", "claude-attach-abc", "-t", "=dotrc:",
+				"claude", "attach", "abc",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := newWindowArgs(tt.sess, tt.window, tt.cwd, tt.argv)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("newWindowArgs(...) = %v, want %v", got, tt.want)
 			}
 			// The picker opens a window to move the user there; -d would
 			// leave the new window in the background and make the pick
 			// look like a no-op.
 			if slices.Contains(got, "-d") {
-				t.Errorf("newWindowArgs(%q, %v) = %v, must not contain -d", tt.cwd, tt.argv, got)
+				t.Errorf("newWindowArgs(...) = %v, must not contain -d", got)
+			}
+			// Without the "=" prefix tmux falls back to prefix/glob matching,
+			// so "dotrc" could land in "dotrc_queue-picker-worktree-session".
+			target := got[slices.Index(got, "-t")+1]
+			if !strings.HasPrefix(target, "=") {
+				t.Errorf("target = %q, must be anchored with a leading =", target)
+			}
+			// The trailing ":" leaves the window name empty, which is what
+			// asks tmux for the next unused index.
+			if !strings.HasSuffix(target, ":") {
+				t.Errorf("target = %q, must end with : to take the next free index", target)
+			}
+		})
+	}
+}
+
+func TestWindowName(t *testing.T) {
+	tests := []struct {
+		name string
+		argv []string
+		want string
+	}{
+		{
+			name: "claude attach",
+			argv: []string{"claude", "attach", "61c846eb"},
+			want: "claude-attach-61c846eb",
+		},
+		{
+			// "." and ":" are the window.pane and session:window separators
+			// in tmux -t targets, so they cannot survive in a window name.
+			name: "separators are replaced",
+			argv: []string{"a.b", "c:d"},
+			want: "a_b-c_d",
+		},
+		{
+			name: "empty argv",
+			argv: nil,
+			want: "cmd",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := windowName(tt.argv); got != tt.want {
+				t.Errorf("windowName(%v) = %q, want %q", tt.argv, got, tt.want)
 			}
 		})
 	}

--- a/src/claude-queue/internal/multiplexer/tmux_test.go
+++ b/src/claude-queue/internal/multiplexer/tmux_test.go
@@ -10,32 +10,35 @@ import (
 // is checked without starting a real tmux server.
 func TestNewSessionArgs(t *testing.T) {
 	tests := []struct {
-		name string
-		sess string
-		cwd  string
-		argv []string
-		want []string
+		name   string
+		sess   string
+		window string
+		cwd    string
+		argv   []string
+		want   []string
 	}{
 		{
-			name: "with cwd",
-			sess: "dotrc_wt",
-			cwd:  "/w/a",
-			argv: []string{"claude", "attach", "abc"},
-			want: []string{"new-session", "-d", "-s", "dotrc_wt", "-c", "/w/a", "claude", "attach", "abc"},
+			name:   "with cwd",
+			sess:   "dotrc_wt",
+			window: "claude-attach-abc",
+			cwd:    "/w/a",
+			argv:   []string{"claude", "attach", "abc"},
+			want:   []string{"new-session", "-d", "-s", "dotrc_wt", "-n", "claude-attach-abc", "-c", "/w/a", "claude", "attach", "abc"},
 		},
 		{
-			name: "without cwd",
-			sess: "dotrc_wt",
-			cwd:  "",
-			argv: []string{"claude", "attach", "abc"},
-			want: []string{"new-session", "-d", "-s", "dotrc_wt", "claude", "attach", "abc"},
+			name:   "without cwd",
+			sess:   "dotrc_wt",
+			window: "claude-attach-abc",
+			cwd:    "",
+			argv:   []string{"claude", "attach", "abc"},
+			want:   []string{"new-session", "-d", "-s", "dotrc_wt", "-n", "claude-attach-abc", "claude", "attach", "abc"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := newSessionArgs(tt.sess, tt.cwd, tt.argv)
+			got := newSessionArgs(tt.sess, tt.window, tt.cwd, tt.argv)
 			if !slices.Equal(got, tt.want) {
-				t.Errorf("newSessionArgs(%q, %q, %v) = %v, want %v", tt.sess, tt.cwd, tt.argv, got, tt.want)
+				t.Errorf("newSessionArgs(%q, %q, %q, %v) = %v, want %v", tt.sess, tt.window, tt.cwd, tt.argv, got, tt.want)
 			}
 			// Creating the session detached is mandatory: the picker runs in
 			// a display-popup, and an attaching new-session would fight it
@@ -44,6 +47,27 @@ func TestNewSessionArgs(t *testing.T) {
 				t.Errorf("newSessionArgs(...) = %v, must contain -d", got)
 			}
 		})
+	}
+}
+
+// TestNewSessionArgsWindowNameMatchesNewWindow pins the regression this fix
+// addresses: the window newSessionArgs creates (via -n) must be named exactly
+// what newWindowArgs' -S will later look for. If these two ever diverge, a
+// second OpenSession pick of the same target stacks a second window instead
+// of -S selecting the first one -- the idempotency newWindowArgs documents
+// would only hold when the session already existed, never on first creation.
+func TestNewSessionArgsWindowNameMatchesNewWindow(t *testing.T) {
+	argv := []string{"claude", "attach", "abc"}
+	window := windowName(argv)
+
+	sessionArgs := newSessionArgs("dotrc_wt", window, "/w/a", argv)
+	windowArgs := newWindowArgs("dotrc_wt", window, "/w/a", argv)
+
+	sessionWindowName := sessionArgs[slices.Index(sessionArgs, "-n")+1]
+	targetWindowName := windowArgs[slices.Index(windowArgs, "-n")+1]
+
+	if sessionWindowName != targetWindowName {
+		t.Errorf("newSessionArgs names the initial window %q, but newWindowArgs' -S looks for %q; a second pick would stack a new window instead of reusing it", sessionWindowName, targetWindowName)
 	}
 }
 

--- a/src/claude-queue/internal/multiplexer/tmux_test.go
+++ b/src/claude-queue/internal/multiplexer/tmux_test.go
@@ -130,6 +130,45 @@ func TestNewWindowArgs(t *testing.T) {
 	}
 }
 
+func TestSanitizeSessionName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "already valid",
+			in:   "dotrc_queue-picker-worktree-session",
+			want: "dotrc_queue-picker-worktree-session",
+		},
+		{
+			// tmux reads "." as the window.pane separator in -t targets, and
+			// silently stores the session under the substituted name anyway.
+			name: "dot becomes underscore",
+			in:   "eversteel.api",
+			want: "eversteel_api",
+		},
+		{
+			// ":" is the session:window separator.
+			name: "colon becomes underscore",
+			in:   "repo:branch",
+			want: "repo_branch",
+		},
+		{
+			name: "empty stays empty",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeSessionName(tt.in); got != tt.want {
+				t.Errorf("sanitizeSessionName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestWindowName(t *testing.T) {
 	tests := []struct {
 		name string

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -31,14 +30,18 @@ var ascii = map[string]string{
 }
 
 // FormatLine renders one queue row as a tab-delimited line for fzf.
-// Visible columns (--with-nth=1,2,3,4): icon, cwd-basename, summary, age.
-// cwd-basename (the worktree dir name) comes right after the icon so it
-// starts at a fixed position and stays scannable; the variable-width summary
-// is demoted behind it and left untruncated.
+// Visible columns (--with-nth=1,2,3,4): icon, worktree, summary, age.
+// The worktree name comes right after the icon so it starts at a fixed
+// position and stays scannable; the variable-width summary is demoted behind
+// it and left untruncated.
 // Hidden columns: session_id (5), tmux_pane (6), full cwd (7). The full cwd is
-// carried separately from the basename because a background session is opened
-// in a new window that needs a real working directory.
-func FormatLine(row db.Row, nowSec int64, asciiMode bool) string {
+// carried separately from the worktree name because a background session is
+// opened in a window that needs a real working directory.
+//
+// worktree is passed in rather than derived here: resolving it needs git (see
+// worktreeName), and keeping FormatLine pure is what lets the column contract
+// be asserted without a repository on disk.
+func FormatLine(row db.Row, worktree string, nowSec int64, asciiMode bool) string {
 	icons := emoji
 	if asciiMode {
 		icons = ascii
@@ -51,16 +54,6 @@ func FormatLine(row db.Row, nowSec int64, asciiMode bool) string {
 		Payload:        row.Payload.String,
 	})
 
-	cwdFull := ""
-	if row.Cwd.Valid {
-		cwdFull = row.Cwd.String
-	}
-
-	cwdBase := ""
-	if cwdFull != "" {
-		cwdBase = filepath.Base(cwdFull)
-	}
-
 	age := formatAge(nowSec - row.CreatedAt)
 
 	pane := ""
@@ -68,7 +61,16 @@ func FormatLine(row db.Row, nowSec int64, asciiMode bool) string {
 		pane = row.TmuxPane.String
 	}
 
-	return strings.Join([]string{icon, cwdBase, sum, age, row.SessionID, pane, cwdFull}, "\t")
+	return strings.Join([]string{icon, worktree, sum, age, row.SessionID, pane, rowCwd(row)}, "\t")
+}
+
+// rowCwd unwraps the nullable cwd column into the "" that the rest of the
+// picker treats as "no working directory recorded".
+func rowCwd(row db.Row) string {
+	if row.Cwd.Valid {
+		return row.Cwd.String
+	}
+	return ""
 }
 
 func formatAge(sec int64) string {
@@ -157,8 +159,9 @@ func Run(args []string) {
 	var buf bytes.Buffer
 	now := time.Now().Unix()
 	asciiMode := os.Getenv("CLAUDE_QUEUE_ASCII") == "1"
+	names := worktreeCache{}
 	for _, r := range rows {
-		buf.WriteString(FormatLine(r, now, asciiMode))
+		buf.WriteString(FormatLine(r, names.name(rowCwd(r)), now, asciiMode))
 		buf.WriteByte('\n')
 	}
 
@@ -185,11 +188,18 @@ func Run(args []string) {
 			}
 		}
 	case "attach":
+		// Open the session belonging to the row's worktree, not whichever
+		// session the popup happened to be invoked from -- that is what keeps
+		// "1 worktree = 1 tmux session" (the gts / claude-worktree convention)
+		// intact. The cache lookup is a hit: the name was already resolved to
+		// render this row.
+		//
 		// Do NOT terminate the session on failure the way the pane path does:
 		// a failed window open says nothing about whether the session is alive,
 		// and the manual command still works.
-		if err := mux.NewWindow(act.Cwd, []string{"claude", "attach", act.Short}); err != nil {
-			fmt.Fprintf(os.Stderr, "new window failed: %v\nrun: claude attach %s\n", err, act.Short)
+		session := sanitizeSessionName(names.name(act.Cwd))
+		if err := mux.OpenSession(session, act.Cwd, []string{"claude", "attach", act.Short}); err != nil {
+			fmt.Fprintf(os.Stderr, "open session failed: %v\nrun: claude attach %s\n", err, act.Short)
 		}
 	default:
 		fmt.Fprintln(os.Stderr, act.Reason)

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -197,8 +197,7 @@ func Run(args []string) {
 		// Do NOT terminate the session on failure the way the pane path does:
 		// a failed window open says nothing about whether the session is alive,
 		// and the manual command still works.
-		session := sanitizeSessionName(names.name(act.Cwd))
-		if err := mux.OpenSession(session, act.Cwd, []string{"claude", "attach", act.Short}); err != nil {
+		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, []string{"claude", "attach", act.Short}); err != nil {
 			fmt.Fprintf(os.Stderr, "open session failed: %v\nrun: claude attach %s\n", err, act.Short)
 		}
 	default:

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -20,7 +20,7 @@ func TestFormatLine_AwaitingApproval(t *testing.T) {
 		Payload:        sql.NullString{String: `{"tool_name":"Bash","tool_input":{"command":"pnpm prisma migrate"}}`, Valid: true},
 		CreatedAt:      nowMinus(120),
 	}
-	got := FormatLine(row, nowUnix(), false)
+	got := FormatLine(row, "everysteel-api", nowUnix(), false)
 	fields := strings.Split(got, "\t")
 	if len(fields) != 7 {
 		t.Fatalf("want 7 tab-separated fields, got %d: %q", len(fields), got)
@@ -29,7 +29,7 @@ func TestFormatLine_AwaitingApproval(t *testing.T) {
 		t.Errorf("icon = %q, want ⏳", fields[0])
 	}
 	if fields[1] != "everysteel-api" {
-		t.Errorf("cwd basename = %q, want everysteel-api", fields[1])
+		t.Errorf("worktree = %q, want everysteel-api", fields[1])
 	}
 	if !strings.Contains(fields[2], "Bash: pnpm prisma migrate") {
 		t.Errorf("summary = %q", fields[2])
@@ -45,6 +45,29 @@ func TestFormatLine_AwaitingApproval(t *testing.T) {
 	}
 	if fields[6] != "/home/x/projects/everysteel-api" {
 		t.Errorf("hidden cwd = %q, want the full path", fields[6])
+	}
+}
+
+// The visible column names the worktree, which is not the cwd's basename when
+// the session was started in a subdirectory. Getting the cwd's basename here
+// is the bug this column had: a session recorded under .../src/claude-queue
+// showed up as "claude-queue" and could not be found by its worktree name.
+func TestFormatLine_DeepCwdShowsWorktree(t *testing.T) {
+	const cwd = "/home/x/ghq/github.com/knagiri/dotrc_queue-picker/src/claude-queue"
+	row := db.Row{
+		SessionID:      "s2",
+		Cwd:            sql.NullString{String: cwd, Valid: true},
+		EffectiveState: "idle_done",
+		CreatedAt:      nowMinus(30),
+	}
+	fields := strings.Split(FormatLine(row, "dotrc_queue-picker", nowUnix(), false), "\t")
+	if fields[1] != "dotrc_queue-picker" {
+		t.Errorf("worktree = %q, want dotrc_queue-picker", fields[1])
+	}
+	// The full cwd still rides along hidden: the attach path opens the window
+	// in the directory the session actually ran in.
+	if fields[6] != cwd {
+		t.Errorf("hidden cwd = %q, want %q", fields[6], cwd)
 	}
 }
 

--- a/src/claude-queue/internal/picker/worktree.go
+++ b/src/claude-queue/internal/picker/worktree.go
@@ -1,0 +1,80 @@
+package picker
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// worktreeName returns the name of the git worktree directory containing cwd.
+//
+// A recorded cwd is not necessarily a worktree root: sessions are routinely
+// started in a subdirectory, so filepath.Base(cwd) alone shows "claude-queue"
+// where the worktree is "dotrc_queue-picker-worktree-session". A worktree's git
+// toplevel is the worktree directory itself, which is the unit both the picker
+// column and the tmux session name are after.
+//
+// The name is returned raw -- the on-disk directory name is what the column
+// should show. Escaping for tmux targets is sanitizeSessionName's job, applied
+// only where a target is actually built.
+func worktreeName(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	// A non-repo cwd (or no git at all) is not an error worth reporting: the
+	// cwd's own basename is still the best name available.
+	toplevel, err := exec.Command("git", "-C", cwd, "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		toplevel = nil
+	}
+	return worktreeNameFrom(cwd, string(toplevel))
+}
+
+// worktreeNameFrom picks the name given a cwd and the git toplevel resolved
+// for it, if any. Split from worktreeName so the fallback rule is testable
+// without a git repository.
+func worktreeNameFrom(cwd, toplevel string) string {
+	if t := strings.TrimSpace(toplevel); t != "" {
+		return dirName(t)
+	}
+	return dirName(cwd)
+}
+
+// dirName is filepath.Base with the degenerate results ("." for an empty path,
+// "/" for the root) flattened to "", since neither names a worktree.
+func dirName(path string) string {
+	if path == "" {
+		return ""
+	}
+	base := filepath.Base(path)
+	if base == "." || base == string(filepath.Separator) {
+		return ""
+	}
+	return base
+}
+
+// worktreeCache memoizes worktreeName per cwd. One name is resolved per picker
+// row, and rows cluster onto a handful of worktrees (several sessions per
+// repo), so this collapses tens of git invocations into one per distinct cwd.
+type worktreeCache map[string]string
+
+func (c worktreeCache) name(cwd string) string {
+	if n, ok := c[cwd]; ok {
+		return n
+	}
+	n := worktreeName(cwd)
+	c[cwd] = n
+	return n
+}
+
+// sanitizeSessionName makes a worktree directory name usable as a tmux target.
+//
+// tmux does not reject "." or ":" in `new-session -s`; it silently rewrites
+// them to "_", which is worse than rejecting them: the session would exist
+// under a name that the `has-session -t=` lookup never matches ("." is read as
+// the window.pane separator), so every pick would create yet another session.
+// Substituting up front keeps the name we ask for and the name tmux stores
+// identical. claude-worktree already uses "_" as its separator for this reason.
+func sanitizeSessionName(name string) string {
+	return strings.NewReplacer(".", "_", ":", "_").Replace(name)
+}

--- a/src/claude-queue/internal/picker/worktree.go
+++ b/src/claude-queue/internal/picker/worktree.go
@@ -15,8 +15,10 @@ import (
 // column and the tmux session name are after.
 //
 // The name is returned raw -- the on-disk directory name is what the column
-// should show. Escaping for tmux targets is sanitizeSessionName's job, applied
-// only where a target is actually built.
+// should show. Escaping for a multiplexer target (tmux's "." / ":" rewrite,
+// e.g.) is that multiplexer implementation's own job, applied only where a
+// target is actually built; this package stays multiplexer-agnostic per the
+// Multiplexer abstraction (see internal/multiplexer's doc comment).
 func worktreeName(cwd string) string {
 	if cwd == "" {
 		return ""
@@ -65,16 +67,4 @@ func (c worktreeCache) name(cwd string) string {
 	n := worktreeName(cwd)
 	c[cwd] = n
 	return n
-}
-
-// sanitizeSessionName makes a worktree directory name usable as a tmux target.
-//
-// tmux does not reject "." or ":" in `new-session -s`; it silently rewrites
-// them to "_", which is worse than rejecting them: the session would exist
-// under a name that the `has-session -t=` lookup never matches ("." is read as
-// the window.pane separator), so every pick would create yet another session.
-// Substituting up front keeps the name we ask for and the name tmux stores
-// identical. claude-worktree already uses "_" as its separator for this reason.
-func sanitizeSessionName(name string) string {
-	return strings.NewReplacer(".", "_", ":", "_").Replace(name)
 }

--- a/src/claude-queue/internal/picker/worktree_test.go
+++ b/src/claude-queue/internal/picker/worktree_test.go
@@ -94,45 +94,6 @@ func TestWorktreeName_DeepSubdirectoryOfRealRepo(t *testing.T) {
 	}
 }
 
-func TestSanitizeSessionName(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{
-			name: "already valid",
-			in:   "dotrc_queue-picker-worktree-session",
-			want: "dotrc_queue-picker-worktree-session",
-		},
-		{
-			// tmux reads "." as the window.pane separator in -t targets, and
-			// silently stores the session under the substituted name anyway.
-			name: "dot becomes underscore",
-			in:   "eversteel.api",
-			want: "eversteel_api",
-		},
-		{
-			// ":" is the session:window separator.
-			name: "colon becomes underscore",
-			in:   "repo:branch",
-			want: "repo_branch",
-		},
-		{
-			name: "empty stays empty",
-			in:   "",
-			want: "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := sanitizeSessionName(tt.in); got != tt.want {
-				t.Errorf("sanitizeSessionName(%q) = %q, want %q", tt.in, got, tt.want)
-			}
-		})
-	}
-}
-
 // A cached cwd must not re-run git: the picker resolves a name for every row
 // and rows cluster onto a few worktrees. The sentinel would be impossible to
 // derive from the path, so seeing it back proves the cache was consulted.

--- a/src/claude-queue/internal/picker/worktree_test.go
+++ b/src/claude-queue/internal/picker/worktree_test.go
@@ -1,0 +1,152 @@
+package picker
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// The git call and the naming rule are split so this table can pin the rule --
+// including the fallback -- without a repository on disk.
+func TestWorktreeNameFrom(t *testing.T) {
+	tests := []struct {
+		name     string
+		cwd      string
+		toplevel string
+		want     string
+	}{
+		{
+			// The case this whole derivation exists for: a session started
+			// well below the worktree root still names the worktree.
+			name:     "deep subdirectory resolves to the worktree",
+			cwd:      "/home/x/ghq/github.com/knagiri/dotrc_wt/src/claude-queue",
+			toplevel: "/home/x/ghq/github.com/knagiri/dotrc_wt\n",
+			want:     "dotrc_wt",
+		},
+		{
+			name:     "cwd already at the worktree root",
+			cwd:      "/home/x/ghq/github.com/knagiri/dotrc_wt",
+			toplevel: "/home/x/ghq/github.com/knagiri/dotrc_wt\n",
+			want:     "dotrc_wt",
+		},
+		{
+			// git failed (not a repo, or git missing): the cwd's own basename
+			// is still the best name available.
+			name:     "no toplevel falls back to the cwd basename",
+			cwd:      "/home/x/scratch/notes",
+			toplevel: "",
+			want:     "notes",
+		},
+		{
+			name:     "blank toplevel is treated as no toplevel",
+			cwd:      "/home/x/scratch/notes",
+			toplevel: "  \n",
+			want:     "notes",
+		},
+		{
+			// No cwd recorded: there is no worktree to name, and "" is what
+			// makes the attach path print its manual fallback instead of
+			// building a nonsense tmux target.
+			name:     "empty cwd yields no name",
+			cwd:      "",
+			toplevel: "",
+			want:     "",
+		},
+		{
+			name:     "root cwd yields no name",
+			cwd:      "/",
+			toplevel: "",
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := worktreeNameFrom(tt.cwd, tt.toplevel); got != tt.want {
+				t.Errorf("worktreeNameFrom(%q, %q) = %q, want %q", tt.cwd, tt.toplevel, got, tt.want)
+			}
+		})
+	}
+}
+
+// The end-to-end shape of the reported bug, against a real git worktree: the
+// session's cwd is <worktree>/src/claude-queue and the name must still be the
+// worktree directory, not "claude-queue".
+func TestWorktreeName_DeepSubdirectoryOfRealRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	const wtName = "dotrc_queue-picker-worktree-session"
+	root := filepath.Join(t.TempDir(), wtName)
+	deep := filepath.Join(root, "src", "claude-queue")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+
+	if got := worktreeName(deep); got != wtName {
+		t.Errorf("worktreeName(%q) = %q, want %q", deep, got, wtName)
+	}
+	if got := worktreeName(root); got != wtName {
+		t.Errorf("worktreeName(%q) = %q, want %q", root, got, wtName)
+	}
+}
+
+func TestSanitizeSessionName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "already valid",
+			in:   "dotrc_queue-picker-worktree-session",
+			want: "dotrc_queue-picker-worktree-session",
+		},
+		{
+			// tmux reads "." as the window.pane separator in -t targets, and
+			// silently stores the session under the substituted name anyway.
+			name: "dot becomes underscore",
+			in:   "eversteel.api",
+			want: "eversteel_api",
+		},
+		{
+			// ":" is the session:window separator.
+			name: "colon becomes underscore",
+			in:   "repo:branch",
+			want: "repo_branch",
+		},
+		{
+			name: "empty stays empty",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeSessionName(tt.in); got != tt.want {
+				t.Errorf("sanitizeSessionName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// A cached cwd must not re-run git: the picker resolves a name for every row
+// and rows cluster onto a few worktrees. The sentinel would be impossible to
+// derive from the path, so seeing it back proves the cache was consulted.
+func TestWorktreeCache_ReusesResolvedName(t *testing.T) {
+	c := worktreeCache{"/w/a": "sentinel"}
+	if got := c.name("/w/a"); got != "sentinel" {
+		t.Errorf("cached name = %q, want sentinel", got)
+	}
+	// A miss resolves and then memoizes, so a second lookup is served from
+	// the map.
+	if got := c.name(""); got != "" {
+		t.Errorf("empty cwd name = %q, want empty", got)
+	}
+	if _, ok := c[""]; !ok {
+		t.Error("resolved name was not memoized")
+	}
+}


### PR DESCRIPTION
## Summary

`claude-queue picker` の attach 経路（tmux pane を持たない background session の行）を、
**その worktree の tmux session に window を開く**形へ変える。併せて picker の表示列を
worktree 名にする。

**A. attach 先を worktree の tmux session にする**

`multiplexer.Multiplexer` の `NewWindow(cwd, argv)` を `OpenSession(name, cwd, argv)` に
置き換えた。tmux 実装は `has-session -t=<name>` で分岐し、無ければ `new-session -d`、
有れば `new-window -S -n <window> -t "=<name>:"`、最後に `switch-client -t=<name>` で
client を移す。

- `=` prefix は必須。無いと target-session は前方一致・glob まで試すので、`dotrc` が
  `dotrc_queue-picker-worktree-session` に曖昧マッチして別 session に window が生える
- target の末尾 `:`（空 window 名）が「次の空き index」を意味する。index を明示すると
  既存と衝突したときにエラーになる
- `-S` により、同じ session を二度選んでも window が積み上がらない
- `new-session` 側の `-d` は必須。picker は `display-popup -E` の中で走るので、attach 形の
  `new-session` は popup の端末を奪おうとする。detached で作って `switch-client` で移す。
  `new-window` 側で `-d` が禁止（選択が no-op に見える）なのと理由が逆になる点はコメントに残した

**B. 表示列を worktree 名にする**

`FormatLine` の 2 列目が `filepath.Base(cwd)` だったため、cwd が worktree root より深いと
worktree 名が出なかった。`git rev-parse --show-toplevel` の basename を使う
`worktreeName(cwd)` に差し替え、失敗時のみ `filepath.Base(cwd)` へフォールバックする。

- 表示は**生のディレクトリ名**。tmux target 向けの `.` / `:` → `_` 置換は
  `sanitizeSessionName` が担い、`tmuxImpl.OpenSession` の入口でのみ適用する。
  この escape は tmux 固有なので `internal/multiplexer` 側に置き、`internal/picker` は
  multiplexer 非依存のまま保つ（README「Multiplexer 抽象」の契約）
- `FormatLine` は純関数のまま維持し（git を中で叩かない）、名前は `Run` 側で解決して
  引数で渡す
- cwd をキーに memo 化。live 行が数十件あり cwd が重複するため、行ごとの git 呼び出しを
  distinct cwd 数まで潰す

## Why

tmux server が落ちて pane id が振り直された結果、ledger の live 行 44 件が存在しない pane を
指す状態になった。これを NULL に修復したので、picker の選択はほぼ全てが attach 経路を通る。
つまりこの経路の作成先が実用上の主経路になっている。

その attach 経路が `tmux new-window` に `-t` を渡しておらず、**popup を開いた時点の current
session** に window を作っていた。`-c` で working directory は目的の worktree になるが tmux
session は今いる場所のままなので、`gts` / `claude-worktree` が前提にしている
「1 worktree = 1 tmux session」が崩れ、無関係な worktree の window が 1 つの session に散らばる。

B は運用中に実際に踏んだ問題。委譲先 session の記録 cwd が

```
/home/.../dotrc_queue-picker-worktree-session/src/claude-queue
```

だったため picker には `claude-queue` と表示され、`dotrc_queue-picker-worktree-session` を
探したユーザーが「一覧に無い」と判断した。A の session 名導出と同じ「cwd は worktree root
とは限らない」問題が表示側にも効いていたので、導出ロジックを共有させた。

`sanitizeSessionName` が必要な理由は実測で確かめた。tmux 3.6b は `new-session -s 'cqprobe.dot'`
を**拒否せず** session 名を `cqprobe_dot` に暗黙置換する。その状態で `has-session -t '=cqprobe.dot'`
は `can't find window: cqprobe` で失敗する（`.` が window.pane 区切りとして解釈される）。
先に sanitize しないと「tmux は作れたのに毎回 has-session が外れて session を作り直す」に落ちる。

## Tests

- `gofmt -l` 出力なし / `go vet ./...` clean / `go test ./...` 全 pass
- `internal/multiplexer`: `TestNewSessionArgs`（`-d` 必須）、`TestNewWindowArgs`（`-d` 禁止・
  target の `=` prefix と末尾 `:`）、`TestWindowName` のテーブル駆動テスト
- `internal/picker/worktree_test.go`（新規）: `t.TempDir()` に実 git repo を作り、深い
  サブディレクトリ（`<wt>/src/claude-queue`）から worktree 名が返ることを固定。これが
  今回の実バグそのものなのでガードの実体になる。memo 化のテストも同居
- `TestFormatLine_DeepCwdShowsWorktree`: 表示列が worktree 名になることを固定

実 tmux（3.6b）に対する統合確認も実施。使い捨て session で:

| ケース | 結果 |
|---|---|
| (a) 存在しない session 名 | `cqverify-a` が作られ window 1 つでコマンドが走る |
| (b) 既存 session 名 | 対象 session の window が 1→2。同時に、両者の prefix になる guard session `cqverify` の window 数が不変であることを assert（`=` prefix が前方一致を防いでいることの実測） |
| (c) 同じ argv で二度目 | window 数 2 のまま不変（`-S` の冪等性） |

確認用の Go テストと使い捨て session はいずれも後始末済みで commit していない。稼働中の実
session には触れていない。

## 既知の懸念（本 PR では手当てしない）

- **cwd が空の行**: `worktreeName("") == ""` → `OpenSession` が `no session name` で error →
  manual fallback を stderr に出す。ただし `display-popup -E` は picker 終了で閉じるので
  この stderr はユーザーに見えない可能性が高い。既存の error 経路も同じ問題を抱えており、
  本 PR で新たに生まれたものではない
- **`switch-client` の失敗を error として返している**: session と window は正しく作られたのに
  picker が失敗を報告する状態になりうる。今回は既存の失敗時の扱いを変えない方針にした
- **git 呼び出しのレイテンシ**: memo 化で distinct cwd 数まで落ちているが、popup 起動時の
  実測はしていない

## レビューループでの追加変更

PR 作成後の独立レビューで以下を修正済み。

| commit | 内容 |
|---|---|
| `2c2673a` | `newSessionArgs` に `-n windowName(argv)` を追加。`-n` 省略時 tmux は window を command から自動命名するため、`new-window -S -n <window>` の**window 名一致**判定と噛み合わず、新規 session 作成経路だけ冪等性が成立していなかった（同じ session を 2 回選ぶと window が 2 つ生える）。回帰テスト `TestNewSessionArgsWindowNameMatchesNewWindow` 付き |
| `863fa1c` | tmux 固有の `sanitizeSessionName` を `internal/picker` から `internal/multiplexer/tmux.go` へ移設し、`OpenSession` 入口で適用する形へ。挙動不変の refactor |
| `9c46cb3`, `21998e5` | `docs/design/claude-tmux-worktree.md` の重複記述と参照先を整理 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
