### PR TITLE
fix(claude-queue): picker から interactive session に到達できない問題と resume 後の消失を直す

### DIFF
--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -160,9 +160,11 @@ worktree の滞留も同様に残る — ①はどちらの経路でも走り、
 
 ③との噛み合わせは「pane 無し = 追跡は完全、ジャンプだけ不能」になる。status-right のカウントは
 `terminated_at IS NULL` と state だけで絞るので background も普通に乗る。ジャンプは picker が
-`tmux_pane` の有無で分岐し、NULL ならその worktree の tmux session（session 名 = worktree
-ディレクトリ名。`gts` / `claude-worktree` と同じ慣習）を単位に開く。無ければ session ごと作成、
-既にあれば window を足して client をそこへ移す（`claude attach` は short id しか受けない）。
+`tmux_pane` の有無で分岐し、NULL のときはまず現行 tmux server 上の pane を再解決し、見つかれば
+そちらへ switch する。再解決できなかった（background session、または pane がこの tmux server の
+外にある）場合のみ、その worktree の tmux session（session 名 = worktree ディレクトリ名。`gts` /
+`claude-worktree` と同じ慣習）を単位に開く。無ければ session ごと作成、既にあれば window を足して
+client をそこへ移す（`claude attach` は short id しか受けない）。
 popup を開いた時点の current session には作らない — これが「1 worktree = 1 tmux session」を
 守る理由で、承認待ちで止まった background 委譲先へ入る経路はこれだけなので picker から隠さず
 出す。flag レベルの詳細（`-d` の要否が経路で逆になる理由、`-t` の `=` 接頭辞・末尾 `:`・`-S` に

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -39,7 +39,7 @@ make install
 |---|---|
 | `claude-queue hook <event>` | stdin JSON を受け取り SQLite に状態書き込み（Claude Code hook 経由で呼ばれる） |
 | `claude-queue status` | tmux status-right 用のカウンタ文字列を stdout に出力 |
-| `claude-queue picker` | fzf を popup で起動し、選択 session の pane に `tmux switch-client`。pane が無い（background session）行は、その worktree の tmux session（無ければ作成）に window を開いて `claude attach <short-id>` を起動し、client をそこへ移す。session 名 = worktree ディレクトリ名（`gts` / `claude-worktree` と同じ慣習） |
+| `claude-queue picker` | fzf を popup で起動し、選択 session の pane に `tmux switch-client`。pane 列が空の行はまず `claude agents --json` とプロセス祖先辿りで現行 tmux server 上の pane を再解決し、見つかればそちらへ switch する。再解決できなかった（background session、または pane がこの tmux server の外にある）場合のみ、その worktree の tmux session（無ければ作成）に window を開いて `claude attach <short-id>` を起動し、client をそこへ移す。session 名 = worktree ディレクトリ名（`gts` / `claude-worktree` と同じ慣習） |
 | `claude-queue reconcile` | `claude agents --json` に載っていない生存扱いの row を terminated にする（picker 起動時に自動実行される） |
 | `claude-queue reset [--force]` | DB (`~/.claude/session-queue.db`) を削除、対話 y/N |
 | `claude-queue --version` | バージョン表示 |
@@ -91,7 +91,7 @@ prefix (`C-q`) のあと `q` で popup → fzf → Enter でジャンプ。
 |---|---|
 | status-right が更新されない | `~/.claude/session-queue.db` 存在確認、`claude-queue status` 単体起動 |
 | hook が動かない | `CLAUDE_QUEUE_DEBUG=1` で `~/.claude/session-queue.log` 確認 |
-| picker から jump できない | `sqlite3 ~/.claude/session-queue.db "SELECT tmux_pane FROM sessions WHERE terminated_at IS NULL"` |
+| picker から jump できない | `sqlite3 ~/.claude/session-queue.db "SELECT tmux_pane FROM sessions WHERE terminated_at IS NULL"` で確認。`tmux_pane` が NULL でも picker は pane 再解決を試みるので、これだけでは jump 不能と断定できない。`claude agents --json` で該当 session が生存扱いか、`tmux list-panes -a` にプロセスが実在するかも合わせて見る |
 | DB が壊れた | `claude-queue reset` |
 
 ## Manual verification checklist
@@ -107,6 +107,8 @@ PR 作成時に description に貼って確認：
 - [ ] `C-q q` で popup、Enter で目的 pane にジャンプ、popup 自動閉
 - [ ] `claude --bg` で起動した background session（tmux_pane が NULL）を picker から選択、その worktree の tmux session に window が開いて `claude attach` される（popup を開いた session には増えない）
 - [ ] worktree のサブディレクトリで起動した session が、picker の 2 列目に worktree 名で並ぶ
+- [ ] `tmux_pane` が NULL の interactive session（他 pane の同 tmux server 上に存在するもの）を picker から選ぶと、`claude attach` ではなく再解決した pane へ直接 switch される
+- [ ] `SessionEnd` 後に `claude --resume` した session が picker に再び現れる
 - [ ] 同 pane で `/clear` 後、旧 session が view から消える（L3）
 - [ ] `CLAUDE_QUEUE_ASCII=1` で `[!]1` 等に切替
 - [ ] 2 pane 並行で approve 連打、busy_timeout 超過しない

--- a/src/claude-queue/internal/hook/dispatch.go
+++ b/src/claude-queue/internal/hook/dispatch.go
@@ -42,6 +42,9 @@ func Dispatch(d *Deps, event string, in *Input) error {
 		}
 	}
 
+	// Must stay after upsertSession, which clears terminated_at on every event
+	// (see its doc comment). Same transaction, so the order alone decides whether
+	// a SessionEnd leaves the row closed.
 	if event == "SessionEnd" {
 		if _, err := tx.Exec(
 			"UPDATE sessions SET terminated_at = unixepoch() WHERE session_id = ?",
@@ -69,6 +72,15 @@ func Dispatch(d *Deps, event string, in *Input) error {
 	return nil
 }
 
+// upsertSession creates or refreshes the session row.
+//
+// terminated_at is cleared on EVERY event, not just SessionStart: a live hook
+// event is itself the disproof of a recorded end. `claude --resume <uuid>` keeps
+// the session id, so without this a session that ended once would stay filtered
+// out of the queue view (WHERE terminated_at IS NULL) forever.
+//
+// Dispatch relies on running this BEFORE it re-sets terminated_at for SessionEnd
+// -- both happen in the same transaction, so a genuine end still lands closed.
 func upsertSession(tx *sql.Tx, in *Input, pane string) error {
 	var paneVal interface{}
 	if pane != "" {
@@ -80,7 +92,8 @@ func upsertSession(tx *sql.Tx, in *Input, pane string) error {
 		ON CONFLICT(session_id) DO UPDATE SET
 			tmux_pane       = COALESCE(excluded.tmux_pane, sessions.tmux_pane),
 			cwd             = COALESCE(excluded.cwd, sessions.cwd),
-			transcript_path = COALESCE(excluded.transcript_path, sessions.transcript_path)
+			transcript_path = COALESCE(excluded.transcript_path, sessions.transcript_path),
+			terminated_at   = NULL
 	`, in.SessionID, paneVal, nullIfEmpty(in.Cwd), nullIfEmpty(in.TranscriptPath))
 	if err != nil {
 		return fmt.Errorf("upsert session: %w", err)

--- a/src/claude-queue/internal/hook/dispatch_test.go
+++ b/src/claude-queue/internal/hook/dispatch_test.go
@@ -155,6 +155,62 @@ func TestDispatch_SessionEnd_SetsTerminated(t *testing.T) {
 	}
 }
 
+// `claude --resume <uuid>` keeps the session id, so a session that already
+// ended once comes back under the same primary key. Unless the upsert clears
+// terminated_at, the row stays closed forever and the queue view -- which
+// filters on terminated_at IS NULL -- never shows the resumed session again.
+func TestDispatch_SessionStartAfterEnd_Resurrects(t *testing.T) {
+	d := openTestDB(t)
+	for _, ev := range []string{"SessionStart", "SessionEnd", "SessionStart"} {
+		in := &Input{SessionID: "s", HookEventName: ev, Cwd: "/work"}
+		if err := Dispatch(d, ev, in); err != nil {
+			t.Fatalf("%s: %v", ev, err)
+		}
+	}
+
+	var terminated sql.NullInt64
+	if err := d.DB.QueryRow(
+		"SELECT terminated_at FROM sessions WHERE session_id = 's'",
+	).Scan(&terminated); err != nil {
+		t.Fatalf("query terminated_at: %v", err)
+	}
+	if terminated.Valid {
+		t.Errorf("terminated_at = %d after resume, want NULL", terminated.Int64)
+	}
+
+	var rows int
+	if err := d.DB.QueryRow(
+		"SELECT COUNT(*) FROM queue WHERE session_id = 's'",
+	).Scan(&rows); err != nil {
+		t.Fatalf("count queue: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("queue rows for the resumed session = %d, want 1", rows)
+	}
+}
+
+// The resurrect above must not leak into SessionEnd itself: that event upserts
+// (clearing terminated_at) before setting it, so the ordering inside Dispatch is
+// what keeps a genuine end closed.
+func TestDispatch_SessionEndStillTerminatesAfterResurrect(t *testing.T) {
+	d := openTestDB(t)
+	for _, ev := range []string{"SessionStart", "SessionEnd", "SessionStart", "SessionEnd"} {
+		in := &Input{SessionID: "s", HookEventName: ev}
+		if err := Dispatch(d, ev, in); err != nil {
+			t.Fatalf("%s: %v", ev, err)
+		}
+	}
+	var terminated sql.NullInt64
+	if err := d.DB.QueryRow(
+		"SELECT terminated_at FROM sessions WHERE session_id = 's'",
+	).Scan(&terminated); err != nil {
+		t.Fatalf("query terminated_at: %v", err)
+	}
+	if !terminated.Valid {
+		t.Error("terminated_at is NULL after the second SessionEnd, want it set")
+	}
+}
+
 func TestDispatch_NonSessionStart_BackfillsTmuxPane(t *testing.T) {
 	// Simulates the real bug: SessionStart hook was missed, so the session
 	// row exists with NULL tmux_pane (created defensively by a later event

--- a/src/claude-queue/internal/multiplexer/multiplexer.go
+++ b/src/claude-queue/internal/multiplexer/multiplexer.go
@@ -21,6 +21,12 @@ type Multiplexer interface {
 	// there. cwd is the window's working directory. Returns an error when
 	// there is no multiplexer to open a session in.
 	OpenSession(name, cwd string, argv []string) error
+	// FindPane returns the pane pid is running in, walking up the process
+	// tree until a pane matches, so a process started deeper than the pane's
+	// own shell is still located. Reports false when there is no such pane --
+	// including when the multiplexer cannot be queried at all, since neither
+	// case gives the caller a pane to switch to.
+	FindPane(pid int) (string, bool)
 }
 
 // Detect selects an implementation based on environment variables.
@@ -47,3 +53,7 @@ func (noopImpl) Switch(target string) error { return nil }
 func (noopImpl) OpenSession(name, cwd string, argv []string) error {
 	return errors.New("no multiplexer detected")
 }
+
+// FindPane has no panes to search without a multiplexer. Unlike OpenSession this
+// needs no error: "not found" is already the answer the caller acts on.
+func (noopImpl) FindPane(pid int) (string, bool) { return "", false }

--- a/src/claude-queue/internal/multiplexer/tmux.go
+++ b/src/claude-queue/internal/multiplexer/tmux.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -122,4 +123,85 @@ func windowName(argv []string) string {
 // identical. claude-worktree already uses "_" as its separator for this reason.
 func sanitizeSessionName(name string) string {
 	return strings.NewReplacer(".", "_", ":", "_").Replace(name)
+}
+
+// maxPaneWalk bounds how far up the process tree FindPane looks. A claude
+// process sits a handful of levels below its pane (pane shell -> wrappers ->
+// node), so the limit is generous; it is here to keep a cycle or a mis-reported
+// parent from spinning, not to reject legitimate depth.
+const maxPaneWalk = 10
+
+// FindPane locates the tmux pane pid belongs to, across every session on the
+// server (-a), not just the client's own.
+func (tmuxImpl) FindPane(pid int) (string, bool) {
+	panes, err := listPanes()
+	if err != nil {
+		return "", false
+	}
+	return findPane(pid, panes, parentPID)
+}
+
+// findPane is the walk itself, taking the pane table and the parent lookup as
+// arguments so it can be tested with neither tmux nor ps running.
+//
+// Bailing out at pid <= 1 rather than at 0 alone matters: reaching init means the
+// walk left the pane's subtree, and pid 1's parent is itself on some systems.
+func findPane(pid int, panes map[int]string, parent func(int) (int, bool)) (string, bool) {
+	for depth := 0; depth < maxPaneWalk; depth++ {
+		if pid <= 1 {
+			return "", false
+		}
+		if pane, ok := panes[pid]; ok {
+			return pane, true
+		}
+		next, ok := parent(pid)
+		if !ok {
+			return "", false
+		}
+		pid = next
+	}
+	return "", false
+}
+
+// listPanes maps each pane's pid to its pane id for the whole server.
+func listPanes() (map[int]string, error) {
+	out, err := exec.Command("tmux", "list-panes", "-a", "-F", "#{pane_pid} #{pane_id}").Output()
+	if err != nil {
+		return nil, err
+	}
+	return parsePanes(string(out)), nil
+}
+
+// parsePanes reads the "#{pane_pid} #{pane_id}" lines listPanes asks for.
+// Unparseable lines are skipped rather than failed on: one odd pane must not
+// cost the caller the rest of the table.
+func parsePanes(out string) map[int]string {
+	panes := map[int]string{}
+	for _, line := range strings.Split(out, "\n") {
+		pidStr, paneID, ok := strings.Cut(strings.TrimSpace(line), " ")
+		if !ok {
+			continue
+		}
+		pid, err := strconv.Atoi(pidStr)
+		if err != nil {
+			continue
+		}
+		panes[pid] = paneID
+	}
+	return panes
+}
+
+// parentPID returns pid's parent. This asks ps instead of reading /proc so the
+// walk also works where /proc does not exist (macOS); the cost is a subprocess
+// per level, which the maxPaneWalk bound keeps small.
+func parentPID(pid int) (int, bool) {
+	out, err := exec.Command("ps", "-o", "ppid=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, false
+	}
+	ppid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, false
+	}
+	return ppid, true
 }

--- a/src/claude-queue/internal/multiplexer/tmux_test.go
+++ b/src/claude-queue/internal/multiplexer/tmux_test.go
@@ -201,3 +201,88 @@ func TestWindowName(t *testing.T) {
 		})
 	}
 }
+
+// findPane is exercised through its injected lookups so the walk is asserted
+// without a tmux server or a real process tree.
+func TestFindPane(t *testing.T) {
+	panes := map[int]string{100: "%3", 200: "%7"}
+
+	// chain models `ps -o ppid=`: 104 -> 103 -> 102 -> 100 (a pane pid).
+	chain := map[int]int{104: 103, 103: 102, 102: 100, 300: 1}
+	parent := func(pid int) (int, bool) {
+		ppid, ok := chain[pid]
+		return ppid, ok
+	}
+
+	t.Run("the pane pid itself matches", func(t *testing.T) {
+		got, ok := findPane(200, panes, parent)
+		if !ok || got != "%7" {
+			t.Errorf("findPane(200) = (%q, %v), want (%%7, true)", got, ok)
+		}
+	})
+
+	t.Run("a descendant matches via its ancestor", func(t *testing.T) {
+		// This is the case the picker depends on: the claude process is several
+		// levels below the shell tmux recorded as the pane's pid.
+		got, ok := findPane(104, panes, parent)
+		if !ok || got != "%3" {
+			t.Errorf("findPane(104) = (%q, %v), want (%%3, true)", got, ok)
+		}
+	})
+
+	t.Run("no pane in the ancestry", func(t *testing.T) {
+		// Walking out to init means the process is not under any pane.
+		if got, ok := findPane(300, panes, parent); ok {
+			t.Errorf("findPane(300) = (%q, true), want not found", got)
+		}
+	})
+
+	t.Run("an unknown parent stops the walk", func(t *testing.T) {
+		if got, ok := findPane(999, panes, parent); ok {
+			t.Errorf("findPane(999) = (%q, true), want not found", got)
+		}
+	})
+
+	t.Run("pid at or below init is never searched", func(t *testing.T) {
+		for _, pid := range []int{1, 0, -1} {
+			if got, ok := findPane(pid, map[int]string{1: "%1", 0: "%0"}, parent); ok {
+				t.Errorf("findPane(%d) = (%q, true), want not found", pid, got)
+			}
+		}
+	})
+
+	t.Run("the depth limit cuts a long chain off", func(t *testing.T) {
+		// A parent chain that only reaches the pane beyond maxPaneWalk must be
+		// abandoned rather than followed forever.
+		deep := func(pid int) (int, bool) { return pid + 1, true }
+		if got, ok := findPane(1000, map[int]string{1000 + maxPaneWalk: "%9"}, deep); ok {
+			t.Errorf("findPane past the depth limit = (%q, true), want not found", got)
+		}
+		// One step inside the limit still resolves, which is what shows the
+		// cutoff above is the limit and not an off-by-one that never matches.
+		if got, ok := findPane(1000, map[int]string{1000 + maxPaneWalk - 1: "%9"}, deep); !ok || got != "%9" {
+			t.Errorf("findPane at the last allowed depth = (%q, %v), want (%%9, true)", got, ok)
+		}
+	})
+}
+
+func TestParsePanes(t *testing.T) {
+	// Real `tmux list-panes -a -F "#{pane_pid} #{pane_id}"` output, plus the
+	// trailing newline it always ends with.
+	got := parsePanes("2249851 %0\n198617 %12\n")
+	want := map[int]string{2249851: "%0", 198617: "%12"}
+	if len(got) != len(want) {
+		t.Fatalf("parsePanes = %v, want %v", got, want)
+	}
+	for pid, pane := range want {
+		if got[pid] != pane {
+			t.Errorf("parsePanes[%d] = %q, want %q", pid, got[pid], pane)
+		}
+	}
+
+	// Lines tmux would never emit must be skipped, not turned into a 0 pid that
+	// the walk could then match against.
+	if got := parsePanes("junk\n\nnotapid %1\n42 %2\n"); len(got) != 1 || got[42] != "%2" {
+		t.Errorf("parsePanes with junk lines = %v, want only 42:%%2", got)
+	}
+}

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -166,6 +166,24 @@ func paneForSession(agents []roster.Agent, sessionID string, find func(int) (str
 	return ""
 }
 
+// switchTo performs the tmux switch to a picked pane and decides whether a
+// failure should terminate the row in the ledger. Pulled out of Run's
+// "switch" case so the decision -- the part with a branch worth testing --
+// can be exercised without tmux; sw is mux.Switch in production.
+func switchTo(sw func(string) error, pane string, paneResolved bool) (err error, terminate bool) {
+	err = sw(pane)
+	if err == nil {
+		return nil, false
+	}
+	// A pane resolvePane found was confirmed live moments ago via both the
+	// process roster and the current tmux pane table -- a failed switch to it
+	// says nothing about the session's liveness (same reasoning as the attach
+	// path below, which never terminates on a failed open). Only the
+	// ledger-recorded pane, whose staleness is exactly what "pane likely gone"
+	// is diagnosing, still warrants terminating on failure.
+	return err, !paneResolved
+}
+
 // Run is the CLI entrypoint for `claude-queue picker`.
 func Run(args []string) {
 	fs := flag.NewFlagSet("picker", flag.ExitOnError)
@@ -234,16 +252,9 @@ func Run(args []string) {
 	}
 	switch act := DecideAction(sessionID, pane, cwd); act.Kind {
 	case "switch":
-		if err := mux.Switch(act.Pane); err != nil {
-			fmt.Fprintf(os.Stderr, "switch failed (pane likely gone): %v\n", err)
-			// A pane resolvePane found was confirmed live moments ago via both
-			// the process roster and the current tmux pane table -- a failed
-			// switch to it says nothing about the session's liveness (same
-			// reasoning as the attach path below, which never terminates on a
-			// failed open). Only the ledger-recorded pane, whose staleness is
-			// exactly what "pane likely gone" is diagnosing, still warrants
-			// terminating on failure.
-			if !paneResolved {
+		if switchErr, terminate := switchTo(mux.Switch, act.Pane, paneResolved); switchErr != nil {
+			fmt.Fprintf(os.Stderr, "switch failed (pane likely gone): %v\n", switchErr)
+			if terminate {
 				if termErr := db.TerminateSession(conn, sessionID); termErr != nil {
 					fmt.Fprintln(os.Stderr, "terminate:", termErr)
 				}

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -227,15 +227,26 @@ func Run(args []string) {
 	cwd := strings.TrimSpace(fields[6])
 
 	mux := multiplexer.Detect()
+	paneResolved := false
 	if pane == "" {
 		pane = resolvePane(mux, sessionID)
+		paneResolved = pane != ""
 	}
 	switch act := DecideAction(sessionID, pane, cwd); act.Kind {
 	case "switch":
 		if err := mux.Switch(act.Pane); err != nil {
 			fmt.Fprintf(os.Stderr, "switch failed (pane likely gone): %v\n", err)
-			if termErr := db.TerminateSession(conn, sessionID); termErr != nil {
-				fmt.Fprintln(os.Stderr, "terminate:", termErr)
+			// A pane resolvePane found was confirmed live moments ago via both
+			// the process roster and the current tmux pane table -- a failed
+			// switch to it says nothing about the session's liveness (same
+			// reasoning as the attach path below, which never terminates on a
+			// failed open). Only the ledger-recorded pane, whose staleness is
+			// exactly what "pane likely gone" is diagnosing, still warrants
+			// terminating on failure.
+			if !paneResolved {
+				if termErr := db.TerminateSession(conn, sessionID); termErr != nil {
+					fmt.Fprintln(os.Stderr, "terminate:", termErr)
+				}
 			}
 		}
 	case "attach":

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/multiplexer"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/reconcile"
+	"github.com/knagiri/dotrc/src/claude-queue/internal/roster"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/summary"
 )
 
@@ -118,6 +119,53 @@ func DecideAction(sessionID, pane, cwd string) Action {
 	return Action{Kind: "attach", Short: short, Cwd: cwd}
 }
 
+// resolvePane re-derives the tmux pane of a picked row the ledger recorded none
+// for, by locating the live agent's process in the current tmux server.
+//
+// The pane column is not authoritative: it goes NULL for reasons not yet pinned
+// down, and an interactive session whose row lost its pane cannot be reached by
+// the attach fallback at all. `claude attach` only knows background jobs and
+// answers "No job matching <id>", while `tmux new-window` reports the exit status
+// of the window creation and not of the command inside it -- so the window opens,
+// the command fails, the window closes, and the pick looks like a no-op with
+// nothing printed. Walking the process tree recovers the pane instead; measured
+// against sessions that did record one, it agrees exactly.
+//
+// Called for the single picked row only, never for the whole list: roster.List
+// costs a subprocess and the panes of rows the user did not select are never
+// needed. An unreadable roster leaves the pane empty, which drops back to the
+// attach path -- the behaviour before this lookup existed.
+func resolvePane(mux multiplexer.Multiplexer, sessionID string) string {
+	if sessionID == "" {
+		return ""
+	}
+	agents, err := roster.List()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "pane lookup skipped:", err)
+		return ""
+	}
+	return paneForSession(agents, sessionID, mux.FindPane)
+}
+
+// paneForSession is the lookup itself, taking the pane finder as an argument so
+// the roster-to-pane wiring can be tested without tmux.
+func paneForSession(agents []roster.Agent, sessionID string, find func(int) (string, bool)) string {
+	for _, a := range agents {
+		if a.SessionID != sessionID {
+			continue
+		}
+		if pane, ok := find(a.PID); ok {
+			return pane
+		}
+		// The session is live but outside this tmux server (a session that
+		// outlived the server it started in, or a background agent that never
+		// had a pane). Looking at later entries cannot help: session ids are
+		// unique in the roster.
+		return ""
+	}
+	return ""
+}
+
 // Run is the CLI entrypoint for `claude-queue picker`.
 func Run(args []string) {
 	fs := flag.NewFlagSet("picker", flag.ExitOnError)
@@ -179,6 +227,9 @@ func Run(args []string) {
 	cwd := strings.TrimSpace(fields[6])
 
 	mux := multiplexer.Detect()
+	if pane == "" {
+		pane = resolvePane(mux, sessionID)
+	}
 	switch act := DecideAction(sessionID, pane, cwd); act.Kind {
 	case "switch":
 		if err := mux.Switch(act.Pane); err != nil {

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
+	"github.com/knagiri/dotrc/src/claude-queue/internal/roster"
 )
 
 func nowUnix() int64         { return 1_800_000_000 }
@@ -119,5 +120,56 @@ func TestDecideAction(t *testing.T) {
 	got = DecideAction("abc", "", "")
 	if got.Kind != "attach" || got.Short != "abc" {
 		t.Errorf("short session id: got %+v, want attach abc", got)
+	}
+}
+
+// A row whose tmux_pane went NULL still has a live process, and when that
+// process runs in the current tmux server the picker must switch to its pane
+// rather than fall through to `claude attach` -- which only serves background
+// jobs and would silently close a fresh window for an interactive session.
+func TestPaneForSession(t *testing.T) {
+	agents := []roster.Agent{
+		{SessionID: "bg", PID: 100, Kind: "background"},
+		{SessionID: "live", PID: 200, Kind: "interactive"},
+	}
+	// Only pid 200 sits under a pane; 100 is a background agent with none.
+	find := func(pid int) (string, bool) {
+		if pid == 200 {
+			return "%7", true
+		}
+		return "", false
+	}
+
+	if got := paneForSession(agents, "live", find); got != "%7" {
+		t.Errorf("paneForSession(live) = %q, want %%7", got)
+	}
+	// A live agent with no pane must stay empty so DecideAction routes it to
+	// attach, which is the correct path for a background session.
+	if got := paneForSession(agents, "bg", find); got != "" {
+		t.Errorf("paneForSession(bg) = %q, want empty", got)
+	}
+	// A session the roster does not list is already gone; nothing to resolve.
+	if got := paneForSession(agents, "missing", find); got != "" {
+		t.Errorf("paneForSession(missing) = %q, want empty", got)
+	}
+	if got := paneForSession(nil, "live", find); got != "" {
+		t.Errorf("paneForSession over an empty roster = %q, want empty", got)
+	}
+}
+
+// The resolved pane has to reach DecideAction as if it had come from the ledger,
+// so the pick lands on the switch path. This pins the composition the wiring in
+// Run relies on.
+func TestResolvedPaneRoutesToSwitch(t *testing.T) {
+	agents := []roster.Agent{{SessionID: "live", PID: 200, Kind: "interactive"}}
+	find := func(int) (string, bool) { return "%7", true }
+
+	pane := paneForSession(agents, "live", find)
+	if act := DecideAction("live", pane, "/w/a"); act.Kind != "switch" || act.Pane != "%7" {
+		t.Errorf("DecideAction with a resolved pane = %+v, want switch to %%7", act)
+	}
+	// Without the resolution the same row goes to attach, which is the bug.
+	if act := DecideAction("live", "", "/w/a"); act.Kind != "attach" {
+		t.Errorf("DecideAction without a pane = %+v, want attach", act)
 	}
 }

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -2,6 +2,7 @@ package picker
 
 import (
 	"database/sql"
+	"errors"
 	"strings"
 	"testing"
 
@@ -171,5 +172,27 @@ func TestResolvedPaneRoutesToSwitch(t *testing.T) {
 	// Without the resolution the same row goes to attach, which is the bug.
 	if act := DecideAction("live", "", "/w/a"); act.Kind != "attach" {
 		t.Errorf("DecideAction without a pane = %+v, want attach", act)
+	}
+}
+
+// A failed switch to a resolved pane (paneResolved=true) must not terminate
+// the row: the pane was just confirmed live via the process roster, so the
+// failure says nothing about the session. Only a failed switch to the
+// ledger-recorded pane (paneResolved=false) still warrants it -- that pane's
+// staleness is exactly what the failure is diagnosing. This pins the fix in
+// commit 41eaf2f, which regressed on a live session being terminated after a
+// resolved pane's switch failed.
+func TestSwitchTo(t *testing.T) {
+	failing := func(string) error { return errors.New("no such pane") }
+	okay := func(string) error { return nil }
+
+	if err, terminate := switchTo(failing, "%9", true); err == nil || terminate {
+		t.Errorf("failed switch to a resolved pane: err=%v terminate=%v, want non-nil err, terminate=false", err, terminate)
+	}
+	if err, terminate := switchTo(failing, "%9", false); err == nil || !terminate {
+		t.Errorf("failed switch to a ledger pane: err=%v terminate=%v, want non-nil err, terminate=true", err, terminate)
+	}
+	if err, terminate := switchTo(okay, "%9", false); err != nil || terminate {
+		t.Errorf("successful switch: err=%v terminate=%v, want nil err, terminate=false", err, terminate)
 	}
 }

--- a/src/claude-queue/internal/reconcile/reconcile.go
+++ b/src/claude-queue/internal/reconcile/reconcile.go
@@ -15,13 +15,12 @@ package reconcile
 
 import (
 	"database/sql"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
+	"github.com/knagiri/dotrc/src/claude-queue/internal/roster"
 )
 
 // ToClose returns the tracked session ids that the live roster does not list,
@@ -43,25 +42,28 @@ func ToClose(tracked, live []string) []string {
 	return out
 }
 
-// roster returns the session ids reported by `claude agents --json`.
-func roster() ([]string, error) {
-	out, err := exec.Command("claude", "agents", "--json").Output()
+// liveIDs returns the session ids of the live agent roster. The error from
+// roster.List is passed through untouched: Sweep's contract turns on being able
+// to tell "the roster is empty" from "the roster could not be read".
+func liveIDs() ([]string, error) {
+	agents, err := roster.List()
 	if err != nil {
-		return nil, fmt.Errorf("claude agents --json: %w", err)
+		return nil, err
 	}
-	var agents []struct {
-		SessionID string `json:"sessionId"`
-	}
-	if err := json.Unmarshal(out, &agents); err != nil {
-		return nil, fmt.Errorf("parse roster: %w", err)
-	}
+	return sessionIDs(agents), nil
+}
+
+// sessionIDs projects the roster onto its session ids, dropping entries that
+// carry none -- an id-less agent can never match a tracked row, and letting ""
+// through would make it match every row whose id failed to be recorded.
+func sessionIDs(agents []roster.Agent) []string {
 	ids := make([]string, 0, len(agents))
 	for _, a := range agents {
 		if a.SessionID != "" {
 			ids = append(ids, a.SessionID)
 		}
 	}
-	return ids, nil
+	return ids
 }
 
 // Sweep matches the ledger against the live roster and terminates every tracked
@@ -72,7 +74,7 @@ func roster() ([]string, error) {
 // died, and treating it as one would terminate every tracked session at once.
 // Callers are expected to skip the pass on error rather than fail.
 func Sweep(conn *sql.DB) (int, error) {
-	live, err := roster()
+	live, err := liveIDs()
 	if err != nil {
 		return 0, err
 	}

--- a/src/claude-queue/internal/reconcile/reconcile_test.go
+++ b/src/claude-queue/internal/reconcile/reconcile_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
+	"github.com/knagiri/dotrc/src/claude-queue/internal/roster"
 )
 
 func TestToClose(t *testing.T) {
@@ -105,5 +106,22 @@ func TestTerminateSessionRemovesRowFromQueue(t *testing.T) {
 	}
 	if !reflect.DeepEqual(remaining, []string{"alive"}) {
 		t.Errorf("queue after sweep = %v, want [alive]", remaining)
+	}
+}
+
+// The projection Sweep feeds to ToClose. An agent without a session id has to be
+// dropped rather than passed through as "": ToClose matches on equality, so a ""
+// in the live set would spare any tracked row that also lost its id.
+func TestSessionIDs(t *testing.T) {
+	got := sessionIDs([]roster.Agent{
+		{SessionID: "a", PID: 1},
+		{SessionID: "", PID: 2},
+		{SessionID: "b", PID: 3},
+	})
+	if !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Errorf("sessionIDs = %v, want [a b]", got)
+	}
+	if got := sessionIDs(nil); len(got) != 0 {
+		t.Errorf("sessionIDs(nil) = %v, want empty", got)
 	}
 }

--- a/src/claude-queue/internal/roster/roster.go
+++ b/src/claude-queue/internal/roster/roster.go
@@ -1,0 +1,46 @@
+// Package roster reads the live agent roster from `claude agents --json`.
+//
+// It exists because two callers need the same list for different reasons:
+// reconcile treats the roster as the authoritative set of live session ids, and
+// the picker needs a picked session's pid to re-derive the tmux pane it runs in.
+// Keeping the exec and the JSON contract in one place means the field names are
+// stated once.
+package roster
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+)
+
+// Agent is one entry of the roster. The json tags are the contract with
+// `claude agents --json`; fields the callers do not use are left out.
+type Agent struct {
+	SessionID string `json:"sessionId"`
+	PID       int    `json:"pid"`
+	Kind      string `json:"kind"` // "interactive" | "background"
+	Cwd       string `json:"cwd"`
+}
+
+// List runs `claude agents --json` and returns the agents it reports.
+//
+// An error is always a failure to read the roster, never "nothing is running":
+// reconcile relies on that distinction to avoid terminating every tracked
+// session when the command itself breaks.
+func List() ([]Agent, error) {
+	out, err := exec.Command("claude", "agents", "--json").Output()
+	if err != nil {
+		return nil, fmt.Errorf("claude agents --json: %w", err)
+	}
+	return parse(out)
+}
+
+// parse is split out from List so the JSON contract can be asserted against
+// fixture bytes, with no claude binary in the loop.
+func parse(data []byte) ([]Agent, error) {
+	var agents []Agent
+	if err := json.Unmarshal(data, &agents); err != nil {
+		return nil, fmt.Errorf("parse roster: %w", err)
+	}
+	return agents, nil
+}

--- a/src/claude-queue/internal/roster/roster_test.go
+++ b/src/claude-queue/internal/roster/roster_test.go
@@ -1,0 +1,63 @@
+package roster
+
+import "testing"
+
+// The fixture is trimmed real output of `claude agents --json`: the field names
+// here are the only thing standing between the picker and a zero pid.
+const fixture = `[
+  {
+    "pid": 2249851,
+    "cwd": "/home/x/ghq/github.com/knagiri/dotrc",
+    "kind": "interactive",
+    "startedAt": 1776422217714,
+    "sessionId": "2d6f9783-fc23-4dbf-ba51-5c7d1c1a4804"
+  },
+  {
+    "pid": 198617,
+    "cwd": "/home/x/ghq/github.com/knagiri/dotrc_wt",
+    "kind": "background",
+    "startedAt": 1781669179831,
+    "sessionId": "7a1fe262-2f1a-458c-b9bb-ca3d777d9d45",
+    "status": "idle"
+  }
+]`
+
+func TestParse(t *testing.T) {
+	agents, err := parse([]byte(fixture))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(agents) != 2 {
+		t.Fatalf("len = %d, want 2", len(agents))
+	}
+	want := Agent{
+		SessionID: "2d6f9783-fc23-4dbf-ba51-5c7d1c1a4804",
+		PID:       2249851,
+		Kind:      "interactive",
+		Cwd:       "/home/x/ghq/github.com/knagiri/dotrc",
+	}
+	if agents[0] != want {
+		t.Errorf("agents[0] = %+v, want %+v", agents[0], want)
+	}
+	if agents[1].Kind != "background" || agents[1].PID != 198617 {
+		t.Errorf("agents[1] = %+v, want the background entry with pid 198617", agents[1])
+	}
+}
+
+func TestParse_Empty(t *testing.T) {
+	agents, err := parse([]byte(`[]`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(agents) != 0 {
+		t.Errorf("len = %d, want 0", len(agents))
+	}
+}
+
+// Garbage must surface as an error, not as an empty roster: reconcile terminates
+// everything tracked when handed an empty one.
+func TestParse_Invalid(t *testing.T) {
+	if _, err := parse([]byte(`not json`)); err == nil {
+		t.Error("parse err = nil, want non-nil")
+	}
+}


### PR DESCRIPTION
## Summary

`claude-queue` の picker（`C-q q`）が、生きている tmux pane を持つ interactive session に到達できない問題と、resume した session が二度と picker に出てこない問題を直す。独立した 2 バグなので commit も 2 つに分けている。

### 1. SessionStart で `terminated_at` を戻す（`8936769`）

`internal/hook/dispatch.go` の `upsertSession` の `ON CONFLICT DO UPDATE SET` に `terminated_at = NULL` を追加。

`claude --resume <uuid>` は session id を変えない。一方 `queue` view は `WHERE s.terminated_at IS NULL` で絞っており、従来の `upsertSession` は `terminated_at` を戻さなかった。そのため一度 SessionEnd を受けた session を resume すると、行は永久に閉じたままで picker に現れなかった。

戻すのは SessionStart に限らず全 event。live な hook event が届いた時点で「終了済み」という記録は反証されているため。SessionEnd は `Dispatch` の中で upsert の**後**に `terminated_at` を再設定するので、同一トランザクション内で正しく終了扱いのまま残る（この順序依存は `upsertSession` と `Dispatch` の両側にコメントを置いた）。

### 2. pick 時の tmux pane 再解決（`9c06cf6`）

`sessions.tmux_pane` は散発的に NULL になる（原因は未特定）。picker の `DecideAction` は「pane が空 ⇒ background session」と決め打ちして `claude attach <short-id>` を新 window で走らせるが、

- `claude attach` は background session 専用で、interactive session には `No job matching <id>` を返して exit 1 する
- `tmux new-window` は中で走らせたコマンドの失敗を返さない（exit 0）

ため、window が即座に閉じるだけで picker は何も報告しない silent failure になっていた。

そこで pane 列を唯一の権威にせず、pick した時点でプロセスの祖先を辿って現行 tmux server の pane を再解決する。

- 新 package `internal/roster`: `claude agents --json` の実行と parse を集約する（`Agent{SessionID, PID, Kind, Cwd}`）。parse は fixture に対してテストできるよう `List` から切り出した。`internal/reconcile` の private な `roster()` はこれに差し替え、`Sweep` の挙動は変えていない（特に「空 roster」と「読めない roster」を区別する既存の error 契約を保持）。
- `Multiplexer` interface に `FindPane(pid int) (string, bool)` を追加。tmux 実装は `tmux list-panes -a -F "#{pane_pid} #{pane_id}"` で pane_pid → pane_id の map を作り、渡された pid から親を辿って最初に一致した pane_id を返す。親の取得は移植性のため /proc を直接読まず `ps -o ppid= -p <pid>`。深さ上限 10、pid が 1 以下になったら打ち切り。探索本体は tmux も ps も無しでテストできる純関数 `findPane` へ切り出した。`noopImpl` は `("", false)`。
- picker は fzf で行が選ばれた**後**、`pane` が空のときだけ `roster.List()` → `mux.FindPane(agent.PID)` を試し、解決できたらその pane を `DecideAction` に渡す（既存の switch 経路に乗る）。全行の先読みはしない。`DecideAction` のシグネチャと純粋性は変えていない。解決できなければ従来どおり attach 経路へ落ちる。

## Why

pane 再解決という遠回りをするのは、`tmux_pane` が NULL になる根本原因が未特定な一方、そのプロセスが現行 tmux server の pane 内で生きているケースが実測で確認できたため。原因究明を待たずに到達性だけ回復できる。

実測で、祖先辿りで得た pane は DB に記録済みの pane と完全に一致した（`%1` / `%54` / `%68` / `%70` の 4 セッション）。同時点で live かつ `tmux_pane` が NULL の行は 44 件あり、これが picker から到達できなくなっていた母数。

`claude agents --json` の追加実行を「選択後かつ pane が空」に限るのは、subprocess 1 本のコストを、ユーザーが選ばなかった行のために払わないため。

### この PR でやらないこと

別 PR に分ける。

- interactive session を SIGTERM で止めてから `claude --resume` で起こし直す経路
- attach 失敗時の明示メッセージ、および `kind` による分岐
- 解決した pane を DB へ書き戻すこと

## Tests

- `TestDispatch_SessionStartAfterEnd_Resurrects` — SessionEnd → SessionStart で `terminated_at` が NULL に戻り、`queue` view に行が現れること。**修正前のコードで実際に落ちることを確認済み**（`terminated_at = 1787815639 after resume, want NULL` / `queue rows for the resumed session = 0, want 1`）。
- `TestDispatch_SessionEndStillTerminatesAfterResurrect` — resurrect が SessionEnd 自体に漏れないこと（`Dispatch` 内の順序依存のガード）。
- `TestFindPane` — 「pane pid 自身が一致」「祖先で一致」「一致しない」「未知の親で打ち切り」「pid <= 1」「深さ上限で打ち切り（上限の 1 歩内側は解決する対比つき）」。
- `TestParsePanes` / `TestParse`（roster）/ `TestSessionIDs`（reconcile の projection）。
- `TestPaneForSession` / `TestResolvedPaneRoutesToSwitch` — 解決した pane が switch 経路へ、解決できない background は従来どおり attach 経路へ乗ること。

`make fmt` / `make vet` / `make test` すべて通過。
