### PR TITLE
feat(claude-queue): pane に到達できない session へ resume で到達する

### DIFF
--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -164,35 +164,23 @@ worktree の滞留も同様に残る — ①はどちらの経路でも走り、
 `terminated_at IS NULL` と state だけで絞るので background も普通に乗る。
 
 ジャンプ側は **pane を到達手段の第一候補に留め、当てにはしない**。`tmux_pane` は NULL になるだけで
-なく、既に置き換わった tmux server の pane を指し続ける（実測では live 48 行のうち 44 行がこの状態）。
-そこで picker は列の値を現行 server の pane 表と照合し、実在しなければ `claude agents --json` の pid
-からプロセス祖先を辿って再解決する。
+なく、既に置き換わった tmux server の pane を指し続けることがある — pane id は tmux server 単位の
+カウンタで、新しい server は `%0` から振り直すため、列の値が現行 server に実在するというだけでは
+同一 session の pane だと確認したことにならない。到達順の詳細（pane → background の attach →
+interactive の resume → roster に無い session の直接 resume → transcript/cwd の実在確認）は
+README.md「picker の到達手段」節に一本化してあるので、そちらを参照する。
 
-再解決しても pane に到達できない session は、種別で到達手段が分かれる。
-
-- **background**: `claude attach <short-id>` を、その worktree の tmux session（session 名 =
-  worktree ディレクトリ名。`gts` / `claude-worktree` と同じ慣習）を単位に開く。無ければ session ごと
-  作成、既にあれば window を足して client をそこへ移す。popup を開いた時点の current session には
-  作らない — これが「1 worktree = 1 tmux session」を守る理由で、承認待ちで止まった background
-  委譲先へ入る経路はこれだけなので picker から隠さず出す
-- **interactive**: `claude attach` は background 専用（interactive に投げると `No job matching` で
-  exit 1）なので、到達単位が pane から **transcript** へ移る。`claude --resume <uuid>` は session id を
-  変えないので、③の row は差し替わらずそのまま復元される
+interactive session を resume の前に終わらせてよいかは、**判定不能を orphan 扱いしない安全側の
+判断**に立つ。pane が別 tmux server にあると確定できたときだけ終わらせ、確定できない（`TMUX` を
+持たない、`/proc` が読めない等）ときは何もしない — 別端末で使用中の可能性を「たぶん大丈夫」で
+押し切らないため。SIGTERM だけを使い SIGKILL へ上げないのも同じ側の判断で、居座るプロセスは
+transcript を掴んだままなので、強制排除は復元しようとしている会話自体を失うリスクを取ることになる。
 
 resume が pane への switch と決定的に違うのは、**元プロセスを引き継がず別プロセスを立てる**点で、
-同一 transcript を 2 プロセスが掴む状態になる。そこで resume の前にプロセスを終わらせるが、
-終わらせてよいのは **pane が別 tmux server にあると確定した場合だけ**とする（`/proc/<pid>/environ` の
-`TMUX` から server pid を取り、現行 server の pid と比較する）。確定できない場合 — `TMUX` を持たない
-（tmux 外で起動した）、`/proc` が読めない、比較相手の server pid が取れない — は別端末で使用中の
-可能性が残るので、何もせず理由を出す。判定不能を orphan 扱いしないのが安全側。SIGTERM だけを使い
-SIGKILL へ上げないのも同じ側で、居座るプロセスは transcript を掴んだままなので、強制排除は復元
-しようとしている会話自体を失うリスクを取ることになる。
-
-resume には transcript と cwd の実在確認が要る。存在しない uuid を `--resume` に渡してもエラーには
-ならず、その id で空の新規 session が立ってしまうため、確認を欠いた resume は「成功したように見えて
-会話を失う」。短命 session は jsonl を書かないので `transcript_path` があってもファイルが無いことが
-あり（実測 12 行中 3 件）、reap 済み worktree の session は resume が transcript を引く基準の cwd 側が
-消えている（同 3 件）。
+同一 transcript を 2 プロセスが掴む状態になる。だから resume の前にプロセスを終わらせる必要があり、
+終わらせ方は上の安全側の判断に従う。resume には transcript と cwd の実在確認も要る — 存在しない
+uuid を `--resume` に渡してもエラーにはならず、その id で空の新規 session が立ってしまうため、
+確認を欠いた resume は「成功したように見えて会話を失う」。
 
 flag レベルの詳細（`-d` の要否が経路で逆になる理由、`-t` の `=` 接頭辞・末尾 `:`・`-S` による window
 再利用）は `internal/multiplexer/tmux.go` のコメントに一本化してあるので、そちらを参照

--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -79,11 +79,13 @@ worktree dir は ghq 配下の兄弟ディレクトリとして `ghq list` に�
 - `settings.json` の hooks が Claude ライフサイクル各イベントで `claude-queue hook <event>` を呼び、
   `$TMUX_PANE` をキーに状態を SQLite（`~/.claude/session-queue.db`）へ記録
 - tmux `status-right` に `claude-queue status`（working/awaiting_approval/idle_done のカウント）
-- `C-q q` で popup → fzf picker → 選択 session の pane へ `tmux switch-client`
+- `C-q q` で popup → fzf picker → 選択 session へ到達（pane への `tmux switch-client` / `claude attach` /
+  `claude --resume` を後述の順で選ぶ）
 - **L3 自己修復**: 新規 `SessionStart` 時、同一 `$TMUX_PANE` 上の生存 session を `ForcedEnd`
   （`/exit`・`/clear` で `SessionEnd` が飛ばないバグの後始末）
 
-→ ③は **pane を ID とする**。この前提が④の設計（後述）を縛る。
+→ ③は **記録のキーとして pane を使う**。この前提が④の設計（後述）を縛る。ただし到達手段としては
+当てにしない（後述の「③との噛み合わせ」）。
 
 ### ④ claude-worktree（`bin/claude-worktree`）
 
@@ -159,17 +161,42 @@ worktree の滞留も同様に残る — ①はどちらの経路でも走り、
 委譲のためで、退避路ではない。
 
 ③との噛み合わせは「pane 無し = 追跡は完全、ジャンプだけ不能」になる。status-right のカウントは
-`terminated_at IS NULL` と state だけで絞るので background も普通に乗る。ジャンプは picker が
-`tmux_pane` の有無で分岐し、NULL のときはまず現行 tmux server 上の pane を再解決し、見つかれば
-そちらへ switch する。再解決できなかった（background session、または pane がこの tmux server の
-外にある）場合のみ、その worktree の tmux session（session 名 = worktree ディレクトリ名。`gts` /
-`claude-worktree` と同じ慣習）を単位に開く。無ければ session ごと作成、既にあれば window を足して
-client をそこへ移す（`claude attach` は short id しか受けない）。
-popup を開いた時点の current session には作らない — これが「1 worktree = 1 tmux session」を
-守る理由で、承認待ちで止まった background 委譲先へ入る経路はこれだけなので picker から隠さず
-出す。flag レベルの詳細（`-d` の要否が経路で逆になる理由、`-t` の `=` 接頭辞・末尾 `:`・`-S` に
-よる window 再利用）は `internal/multiplexer/tmux.go` のコメントに一本化してあるので、そちらを
-参照（README.md は挙動レベルの説明に留め、flag レベルは書かない）。
+`terminated_at IS NULL` と state だけで絞るので background も普通に乗る。
+
+ジャンプ側は **pane を到達手段の第一候補に留め、当てにはしない**。`tmux_pane` は NULL になるだけで
+なく、既に置き換わった tmux server の pane を指し続ける（実測では live 48 行のうち 44 行がこの状態）。
+そこで picker は列の値を現行 server の pane 表と照合し、実在しなければ `claude agents --json` の pid
+からプロセス祖先を辿って再解決する。
+
+再解決しても pane に到達できない session は、種別で到達手段が分かれる。
+
+- **background**: `claude attach <short-id>` を、その worktree の tmux session（session 名 =
+  worktree ディレクトリ名。`gts` / `claude-worktree` と同じ慣習）を単位に開く。無ければ session ごと
+  作成、既にあれば window を足して client をそこへ移す。popup を開いた時点の current session には
+  作らない — これが「1 worktree = 1 tmux session」を守る理由で、承認待ちで止まった background
+  委譲先へ入る経路はこれだけなので picker から隠さず出す
+- **interactive**: `claude attach` は background 専用（interactive に投げると `No job matching` で
+  exit 1）なので、到達単位が pane から **transcript** へ移る。`claude --resume <uuid>` は session id を
+  変えないので、③の row は差し替わらずそのまま復元される
+
+resume が pane への switch と決定的に違うのは、**元プロセスを引き継がず別プロセスを立てる**点で、
+同一 transcript を 2 プロセスが掴む状態になる。そこで resume の前にプロセスを終わらせるが、
+終わらせてよいのは **pane が別 tmux server にあると確定した場合だけ**とする（`/proc/<pid>/environ` の
+`TMUX` から server pid を取り、現行 server の pid と比較する）。確定できない場合 — `TMUX` を持たない
+（tmux 外で起動した）、`/proc` が読めない、比較相手の server pid が取れない — は別端末で使用中の
+可能性が残るので、何もせず理由を出す。判定不能を orphan 扱いしないのが安全側。SIGTERM だけを使い
+SIGKILL へ上げないのも同じ側で、居座るプロセスは transcript を掴んだままなので、強制排除は復元
+しようとしている会話自体を失うリスクを取ることになる。
+
+resume には transcript と cwd の実在確認が要る。存在しない uuid を `--resume` に渡してもエラーには
+ならず、その id で空の新規 session が立ってしまうため、確認を欠いた resume は「成功したように見えて
+会話を失う」。短命 session は jsonl を書かないので `transcript_path` があってもファイルが無いことが
+あり（実測 12 行中 3 件）、reap 済み worktree の session は resume が transcript を引く基準の cwd 側が
+消えている（同 3 件）。
+
+flag レベルの詳細（`-d` の要否が経路で逆になる理由、`-t` の `=` 接頭辞・末尾 `:`・`-S` による window
+再利用）は `internal/multiplexer/tmux.go` のコメントに一本化してあるので、そちらを参照
+（README.md は挙動レベルの説明に留め、flag レベルは書かない）。
 
 ### ④は **メイン** toplevel 基準でパスを作る
 

--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -171,12 +171,18 @@ interactive の resume → roster に無い session の直接 resume → transcr
 README.md「picker の到達手段」節に一本化してあるので、そちらを参照する。
 
 interactive session を resume の前に終わらせてよいかは、**判定不能を orphan 扱いしない安全側の
-判断**に立つ。確定条件は「別 tmux server にある」だけでなく「その server が既に無い」まで含む
-（tmux server は socket 単位なので、別 server が生きている限り別端末からの attach が起こり得る）。
-どちらかが確定できないときは何もしない — 別端末で使用中の可能性を「たぶん大丈夫」で押し切らない
-ため。条件の詳細（`/proc` の参照箇所、分類の全パターン）は README.md「picker の到達手段」節に
+判断**に立つ。確定条件を「その server が到達不能であること」に置き、**プロセスの生死では測らない**。
+tmux server は socket 単位なので、自分が switch-client できない server でも socket を持っていれば
+別端末から attach して使用中でありうる。逆に socket を別 server に明け渡した server は、プロセスが
+残っていても新しい client を受け付けない。生死で測ると前者を殺し後者を助けられない — 到達可能性を
+決めているのは socket の所有者のほうだから、そちらを見る。確定できないときは何もしない — 別端末で
+使用中の可能性を「たぶん大丈夫」で押し切らないため。条件の詳細は README.md「picker の到達手段」節に
 一本化してある。SIGTERM だけを使い SIGKILL へ上げないのも同じ側の判断で、居座るプロセスは
 transcript を掴んだままなので、強制排除は復元しようとしている会話自体を失うリスクを取ることになる。
+
+残余リスクとして、socket が明け渡される前から attach していた client は既存の接続で動き続けるが、
+その socket はもう別 server のものなので列挙する手段が無い。それでも kill に踏み切るのは、踏み切ら
+なければその会話が恒久的に到達不能になるためで、天秤の反対側を明示しておく。
 
 resume が pane への switch と決定的に違うのは、**元プロセスを引き継がず別プロセスを立てる**点で、
 同一 transcript を 2 プロセスが掴む状態になる。だから resume の前にプロセスを終わらせる必要があり、

--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -171,9 +171,11 @@ interactive の resume → roster に無い session の直接 resume → transcr
 README.md「picker の到達手段」節に一本化してあるので、そちらを参照する。
 
 interactive session を resume の前に終わらせてよいかは、**判定不能を orphan 扱いしない安全側の
-判断**に立つ。pane が別 tmux server にあると確定できたときだけ終わらせ、確定できない（`TMUX` を
-持たない、`/proc` が読めない等）ときは何もしない — 別端末で使用中の可能性を「たぶん大丈夫」で
-押し切らないため。SIGTERM だけを使い SIGKILL へ上げないのも同じ側の判断で、居座るプロセスは
+判断**に立つ。確定条件は「別 tmux server にある」だけでなく「その server が既に無い」まで含む
+（tmux server は socket 単位なので、別 server が生きている限り別端末からの attach が起こり得る）。
+どちらかが確定できないときは何もしない — 別端末で使用中の可能性を「たぶん大丈夫」で押し切らない
+ため。条件の詳細（`/proc` の参照箇所、分類の全パターン）は README.md「picker の到達手段」節に
+一本化してある。SIGTERM だけを使い SIGKILL へ上げないのも同じ側の判断で、居座るプロセスは
 transcript を掴んだままなので、強制排除は復元しようとしている会話自体を失うリスクを取ることになる。
 
 resume が pane への switch と決定的に違うのは、**元プロセスを引き継がず別プロセスを立てる**点で、

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -39,7 +39,7 @@ make install
 |---|---|
 | `claude-queue hook <event>` | stdin JSON を受け取り SQLite に状態書き込み（Claude Code hook 経由で呼ばれる） |
 | `claude-queue status` | tmux status-right 用のカウンタ文字列を stdout に出力 |
-| `claude-queue picker` | fzf を popup で起動し、選択 session の pane に `tmux switch-client`。pane 列が空の行はまず `claude agents --json` とプロセス祖先辿りで現行 tmux server 上の pane を再解決し、見つかればそちらへ switch する。再解決できなかった（background session、または pane がこの tmux server の外にある）場合のみ、その worktree の tmux session（無ければ作成）に window を開いて `claude attach <short-id>` を起動し、client をそこへ移す。session 名 = worktree ディレクトリ名（`gts` / `claude-worktree` と同じ慣習） |
+| `claude-queue picker` | fzf を popup で起動し、選択 session へ到達する（到達手段の決定は後述） |
 | `claude-queue reconcile` | `claude agents --json` に載っていない生存扱いの row を terminated にする（picker 起動時に自動実行される） |
 | `claude-queue reset [--force]` | DB (`~/.claude/session-queue.db`) を削除、対話 y/N |
 | `claude-queue --version` | バージョン表示 |
@@ -51,6 +51,34 @@ make install
 | `CLAUDE_QUEUE_DB` | DB パス override（既定 `~/.claude/session-queue.db`） |
 | `CLAUDE_QUEUE_ASCII=1` | アイコンを ASCII フォールバック `[!] [.] [*] [X]` に切替 |
 | `CLAUDE_QUEUE_DEBUG=1` | エラーを `~/.claude/session-queue.log` に追記 |
+
+### picker の到達手段
+
+選択された session への到達手段を次の順で決める。
+
+1. **到達できる pane があれば `tmux switch-client`**。ledger の `tmux_pane` は現行 tmux
+   server に実在するときだけ使い、実在しなければ `claude agents --json` の pid から
+   プロセス祖先を辿って再解決する（`tmux_pane` が NULL の行も同じ経路）。switch が失敗しても
+   row は terminate しない — pane の実在は直前に確認済みなので、失敗は session の死を意味しない
+2. **background session は `claude attach <short-id>`**。その worktree の tmux session
+   （無ければ作成）に window を開き、client をそこへ移す。承認待ちで止まった background
+   委譲先へ入る経路はこれだけ
+3. **pane に到達できない interactive session は `claude --resume <uuid>`**。`claude attach` は
+   background 専用で、interactive に投げると `No job matching` で失敗する。resume は元プロセスを
+   引き継がず別プロセスを立てるので、先にプロセスを終わらせる必要がある。終わらせてよいのは
+   **pane が別 tmux server にあると確定した場合だけ**（`/proc/<pid>/environ` の `TMUX` から
+   server pid を取り、現行 server の pid と比較する）。`TMUX` が無い（tmux 外で起動）・`/proc`
+   が読めない等で確定できないときは、別端末で使用中の可能性があるので何もせず理由を出す。
+   確定したときは SIGTERM を送り roster から消えるまで最大 10 秒待つ。消えなければ resume せず
+   報告して終わる（SIGKILL へは上げない）
+4. **roster に居ない session はそのまま `claude --resume`**。止めるプロセスが無い
+5. **resume は transcript と cwd が実在するときだけ行う**。存在しない uuid を `--resume` に
+   渡してもエラーにならず、その id で空の新規 session が立ってしまう。短命 session は jsonl を
+   書かないので `transcript_path` があってもファイルが無いことがあり、reap 済み worktree の
+   session は cwd 側が消えている。どちらが欠けたかを stderr に出して終わる
+
+session 名 = worktree ディレクトリ名（`gts` / `claude-worktree` と同じ慣習）。popup を開いた
+時点の current session には作らない。
 
 ## State machine
 
@@ -91,7 +119,7 @@ prefix (`C-q`) のあと `q` で popup → fzf → Enter でジャンプ。
 |---|---|
 | status-right が更新されない | `~/.claude/session-queue.db` 存在確認、`claude-queue status` 単体起動 |
 | hook が動かない | `CLAUDE_QUEUE_DEBUG=1` で `~/.claude/session-queue.log` 確認 |
-| picker から jump できない | `sqlite3 ~/.claude/session-queue.db "SELECT tmux_pane FROM sessions WHERE terminated_at IS NULL"` で確認。`tmux_pane` が NULL でも picker は pane 再解決を試みるので、これだけでは jump 不能と断定できない。`claude agents --json` で該当 session が生存扱いか、`tmux list-panes -a` にプロセスが実在するかも合わせて見る |
+| picker から jump できない | picker が理由を stderr に出す（resume できない場合は transcript / cwd のどちらが欠けているかまで出る）。`tmux_pane` 列は NULL でも stale でも picker が再解決を試みるので、DB を見るだけでは jump 不能と断定できない。`claude agents --json` の生存扱いと `tmux list-panes -a` のプロセス実在を合わせて見る |
 | DB が壊れた | `claude-queue reset` |
 
 ## Manual verification checklist
@@ -108,6 +136,9 @@ PR 作成時に description に貼って確認：
 - [ ] `claude --bg` で起動した background session（tmux_pane が NULL）を picker から選択、その worktree の tmux session に window が開いて `claude attach` される（popup を開いた session には増えない）
 - [ ] worktree のサブディレクトリで起動した session が、picker の 2 列目に worktree 名で並ぶ
 - [ ] `tmux_pane` が NULL の interactive session（他 pane の同 tmux server 上に存在するもの）を picker から選ぶと、`claude attach` ではなく再解決した pane へ直接 switch される
+- [ ] `tmux_pane` が別 tmux server の pane を指す interactive session を picker から選ぶと、SIGTERM 後に `claude --resume` で同じ session id のまま会話が復元される
+- [ ] tmux 外で起動した（`TMUX` を持たない）interactive session を picker から選ぶと、kill されず「別端末で使用中の可能性」の理由が出る
+- [ ] transcript が無い / cwd が reap 済みの session を picker から選ぶと、resume されずどちらが欠けたかが出る
 - [ ] `SessionEnd` 後に `claude --resume` した session が picker に再び現れる
 - [ ] 同 pane で `/clear` 後、旧 session が view から消える（L3）
 - [ ] `CLAUDE_QUEUE_ASCII=1` で `[!]1` 等に切替

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -56,10 +56,14 @@ make install
 
 選択された session への到達手段を次の順で決める。
 
-1. **到達できる pane があれば `tmux switch-client`**。ledger の `tmux_pane` は現行 tmux
-   server に実在するときだけ使い、実在しなければ `claude agents --json` の pid から
-   プロセス祖先を辿って再解決する（`tmux_pane` が NULL の行も同じ経路）。switch が失敗しても
-   row は terminate しない — pane の実在は直前に確認済みなので、失敗は session の死を意味しない
+1. **到達できる pane があれば `tmux switch-client`**。roster に該当 session があれば
+   `claude agents --json` の pid からプロセス祖先を辿って pane を解決する（identity 込みの
+   確認）。roster に無いとき（読み取り失敗時など）だけ、ledger の `tmux_pane` が現行 tmux
+   server に実在するかを最後の手段として見る — pane id は server 単位のカウンタで新しい
+   server は `%0` から振り直すため、実在するだけでは同一 session の pane だと確認したことに
+   ならない。switch が失敗しても row は terminate しない — 直前に確認したのは pane の実在
+   （かつ可能なら identity）であって、失敗は switch 自体の問題（client 未接続等）であり
+   session の死を意味しない
 2. **background session は `claude attach <short-id>`**。その worktree の tmux session
    （無ければ作成）に window を開き、client をそこへ移す。承認待ちで止まった background
    委譲先へ入る経路はこれだけ

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -58,23 +58,25 @@ make install
 
 1. **到達できる pane があれば `tmux switch-client`**。roster に該当 session があれば
    `claude agents --json` の pid からプロセス祖先を辿って pane を解決する（identity 込みの
-   確認）。roster に無いとき（読み取り失敗時など）だけ、ledger の `tmux_pane` が現行 tmux
-   server に実在するかを最後の手段として見る — pane id は server 単位のカウンタで新しい
-   server は `%0` から振り直すため、実在するだけでは同一 session の pane だと確認したことに
-   ならない。switch が失敗しても row は terminate しない — 直前に確認したのは pane の実在
-   （かつ可能なら identity）であって、失敗は switch 自体の問題（client 未接続等）であり
-   session の死を意味しない
+   確認）。ledger の `tmux_pane` を最後の手段として見るのは **roster を読めなかったときだけ**
+   （roster は読めたが該当 session が無い場合は含まない — それはプロセス終了の証拠なので
+   使わない）。pane id は server 単位のカウンタで新しい server は `%0` から振り直すため、
+   実在するだけでは同一 session の pane だと確認したことにならない。switch が失敗しても row は
+   terminate しない — 直前に確認したのは pane の実在（かつ可能なら identity）であって、失敗は
+   switch 自体の問題（client 未接続等）であり session の死を意味しない
 2. **background session は `claude attach <short-id>`**。その worktree の tmux session
    （無ければ作成）に window を開き、client をそこへ移す。承認待ちで止まった background
    委譲先へ入る経路はこれだけ
 3. **pane に到達できない interactive session は `claude --resume <uuid>`**。`claude attach` は
    background 専用で、interactive に投げると `No job matching` で失敗する。resume は元プロセスを
    引き継がず別プロセスを立てるので、先にプロセスを終わらせる必要がある。終わらせてよいのは
-   **pane が別 tmux server にあると確定した場合だけ**（`/proc/<pid>/environ` の `TMUX` から
-   server pid を取り、現行 server の pid と比較する）。`TMUX` が無い（tmux 外で起動）・`/proc`
-   が読めない等で確定できないときは、別端末で使用中の可能性があるので何もせず理由を出す。
-   確定したときは SIGTERM を送り roster から消えるまで最大 10 秒待つ。消えなければ resume せず
-   報告して終わる（SIGKILL へは上げない）
+   **別 tmux server にあると確定し、かつその server が既に無いと確定した場合だけ**
+   （`/proc/<pid>/environ` の `TMUX` から server pid を取り現行 server の pid と比較したうえで、
+   その server pid が `/proc` に残っているかで生死を見る）。tmux server は socket 単位なので、
+   別 server の pid が生きている限り別端末からそこに attach して使用中の可能性が残る。`TMUX` が
+   無い（tmux 外で起動）・`/proc` が読めない・別 server の生死を確定できない等、いずれかが
+   確定できないときは何もせず理由を出す。確定したときは SIGTERM を送り roster から消えるまで
+   最大 10 秒待つ。消えなければ resume せず報告して終わる（SIGKILL へは上げない）
 4. **roster に居ない session はそのまま `claude --resume`**。止めるプロセスが無い
 5. **resume は transcript と cwd が実在するときだけ行う**。存在しない uuid を `--resume` に
    渡してもエラーにならず、その id で空の新規 session が立ってしまう。短命 session は jsonl を

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -70,13 +70,19 @@ make install
 3. **pane に到達できない interactive session は `claude --resume <uuid>`**。`claude attach` は
    background 専用で、interactive に投げると `No job matching` で失敗する。resume は元プロセスを
    引き継がず別プロセスを立てるので、先にプロセスを終わらせる必要がある。終わらせてよいのは
-   **別 tmux server にあると確定し、かつその server が既に無いと確定した場合だけ**
-   （`/proc/<pid>/environ` の `TMUX` から server pid を取り現行 server の pid と比較したうえで、
-   その server pid が `/proc` に残っているかで生死を見る）。tmux server は socket 単位なので、
-   別 server の pid が生きている限り別端末からそこに attach して使用中の可能性が残る。`TMUX` が
-   無い（tmux 外で起動）・`/proc` が読めない・別 server の生死を確定できない等、いずれかが
-   確定できないときは何もせず理由を出す。確定したときは SIGTERM を送り roster から消えるまで
-   最大 10 秒待つ。消えなければ resume せず報告して終わる（SIGKILL へは上げない）
+   **その session の tmux server がもう誰からも到達できないと確定した場合だけ**。
+   `/proc/<pid>/environ` の `TMUX=<socket>,<serverpid>,<n>` から socket と server pid を取り、
+   (a) server pid が現行 server と異なり、(b) その socket の現在の所有者が記録された server pid
+   ではない（別 server に置き換わっている、または socket 自体が無い）ことを確認する。tmux server は
+   socket 単位なので、自分が switch-client できない server でも socket を持っていれば別端末から
+   `tmux -L other attach` で使用中でありうる — 判断材料はプロセスの生死ではなく socket の所有者。
+   `TMUX` が無い（tmux 外で起動）・`/proc` が読めない・socket を問い合わせられない等、確定できない
+   ときは何もせず理由を出す。確定したときは SIGTERM を送り roster から消えるまで最大 10 秒待つ。
+   消えなければ resume せず報告して終わる（SIGKILL へは上げない）。
+
+   socket が置き換わる前から attach していた client は既存の接続で動き続けるが、その socket は
+   もう別 server のものなので列挙する手段が無い。この残余リスクを取るのは、取らなければ会話が
+   恒久的に到達不能になるため
 4. **roster に居ない session はそのまま `claude --resume`**。止めるプロセスが無い
 5. **resume は transcript と cwd が実在するときだけ行う**。存在しない uuid を `--resume` に
    渡してもエラーにならず、その id で空の新規 session が立ってしまう。短命 session は jsonl を
@@ -142,7 +148,8 @@ PR 作成時に description に貼って確認：
 - [ ] `claude --bg` で起動した background session（tmux_pane が NULL）を picker から選択、その worktree の tmux session に window が開いて `claude attach` される（popup を開いた session には増えない）
 - [ ] worktree のサブディレクトリで起動した session が、picker の 2 列目に worktree 名で並ぶ
 - [ ] `tmux_pane` が NULL の interactive session（他 pane の同 tmux server 上に存在するもの）を picker から選ぶと、`claude attach` ではなく再解決した pane へ直接 switch される
-- [ ] `tmux_pane` が別 tmux server の pane を指す interactive session を picker から選ぶと、SIGTERM 後に `claude --resume` で同じ session id のまま会話が復元される
+- [ ] `tmux_pane` が「socket を別 server に明け渡した tmux server」の pane を指す interactive session を picker から選ぶと、SIGTERM 後に `claude --resume` で同じ session id のまま会話が復元される
+- [ ] 別 socket（`tmux -L other`）で稼働中の server 上の interactive session を picker から選ぶと、kill されず理由が出る
 - [ ] tmux 外で起動した（`TMUX` を持たない）interactive session を picker から選ぶと、kill されず「別端末で使用中の可能性」の理由が出る
 - [ ] transcript が無い / cwd が reap 済みの session を picker から選ぶと、resume されずどちらが欠けたかが出る
 - [ ] `SessionEnd` 後に `claude --resume` した session が picker に再び現れる

--- a/src/claude-queue/internal/db/queries.go
+++ b/src/claude-queue/internal/db/queries.go
@@ -111,8 +111,9 @@ func LiveSessionIDs(conn *sql.DB) ([]string, error) {
 }
 
 // TerminateSession marks a session ended (terminated_at + ForcedEnd event),
-// matching the cleanup pattern in hook.forcedEndSiblings. Used by the picker
-// when tmux switch-client fails because the recorded pane no longer exists.
+// matching the cleanup pattern in hook.forcedEndSiblings. The reconcile sweep is
+// the only caller that decides to close a row: it does so from the live agent
+// roster, which is authoritative, rather than from a failed tmux command.
 func TerminateSession(conn *sql.DB, sessionID string) error {
 	tx, err := conn.Begin()
 	if err != nil {

--- a/src/claude-queue/internal/multiplexer/multiplexer.go
+++ b/src/claude-queue/internal/multiplexer/multiplexer.go
@@ -27,6 +27,14 @@ type Multiplexer interface {
 	// including when the multiplexer cannot be queried at all, since neither
 	// case gives the caller a pane to switch to.
 	FindPane(pid int) (string, bool)
+	// PaneExists reports whether target is still a pane of the server this
+	// process talks to. False also covers "could not ask", for the same reason
+	// as FindPane: either way the caller has no pane it can switch to.
+	PaneExists(target string) bool
+	// ServerPID returns the pid of the multiplexer server process, so a
+	// caller can tell a pane of this server from a pane of another one.
+	// Reports false when there is no server to ask.
+	ServerPID() (int, bool)
 }
 
 // Detect selects an implementation based on environment variables.
@@ -57,3 +65,12 @@ func (noopImpl) OpenSession(name, cwd string, argv []string) error {
 // FindPane has no panes to search without a multiplexer. Unlike OpenSession this
 // needs no error: "not found" is already the answer the caller acts on.
 func (noopImpl) FindPane(pid int) (string, bool) { return "", false }
+
+// PaneExists is false for the same reason: with no server to ask, no pane the
+// caller was handed can be confirmed to still be there.
+func (noopImpl) PaneExists(target string) bool { return false }
+
+// ServerPID has no server, which is exactly what the false reports. Callers use
+// it to decide whether a session's pane lives elsewhere; without a server of our
+// own there is nothing to compare against.
+func (noopImpl) ServerPID() (int, bool) { return 0, false }

--- a/src/claude-queue/internal/multiplexer/multiplexer_test.go
+++ b/src/claude-queue/internal/multiplexer/multiplexer_test.go
@@ -56,8 +56,10 @@ func TestPaneListed(t *testing.T) {
 	if !paneListed(panes, "%7") {
 		t.Error("paneListed(%7) = false, want true")
 	}
-	// A pane of a tmux server that has since been replaced: this is the state
-	// 44 of 48 measured live rows were in.
+	// A pane of a tmux server that has since been replaced: this is common
+	// because the pane id column keeps whatever value it had when the server
+	// that owned it was still running, and a fresh server restarts pane ids
+	// from %0.
 	if paneListed(panes, "%99") {
 		t.Error("paneListed(%99) = true, want false")
 	}

--- a/src/claude-queue/internal/multiplexer/multiplexer_test.go
+++ b/src/claude-queue/internal/multiplexer/multiplexer_test.go
@@ -33,4 +33,39 @@ func TestDetect_NoMultiplexer(t *testing.T) {
 	if err := m.OpenSession("dotrc_wt", "/w/a", []string{"claude", "attach", "abc"}); err == nil {
 		t.Errorf("noop OpenSession err = nil, want non-nil")
 	}
+	// With no server there is no pane to confirm and no server pid to compare
+	// against, which is what keeps the picker off the kill-and-resume path
+	// outside tmux.
+	if _, ok := m.FindPane(4242); ok {
+		t.Error("noop FindPane reported a pane, want none")
+	}
+	if m.PaneExists("%3") {
+		t.Error("noop PaneExists = true, want false")
+	}
+	if _, ok := m.ServerPID(); ok {
+		t.Error("noop ServerPID reported a server, want none")
+	}
+}
+
+// The picker checks a ledger-recorded pane before switching to it, so "is this
+// pane still here" has to be answerable from the pane table listPanes already
+// builds -- no second tmux call, and no tmux at all in the test.
+func TestPaneListed(t *testing.T) {
+	panes := map[int]string{4242: "%3", 4243: "%7"}
+
+	if !paneListed(panes, "%7") {
+		t.Error("paneListed(%7) = false, want true")
+	}
+	// A pane of a tmux server that has since been replaced: this is the state
+	// 44 of 48 measured live rows were in.
+	if paneListed(panes, "%99") {
+		t.Error("paneListed(%99) = true, want false")
+	}
+	// "" is what an unrecorded pane looks like, and must not match anything.
+	if paneListed(panes, "") {
+		t.Error(`paneListed("") = true, want false`)
+	}
+	if paneListed(nil, "%7") {
+		t.Error("paneListed over an empty table = true, want false")
+	}
 }

--- a/src/claude-queue/internal/multiplexer/tmux.go
+++ b/src/claude-queue/internal/multiplexer/tmux.go
@@ -163,6 +163,47 @@ func findPane(pid int, panes map[int]string, parent func(int) (int, bool)) (stri
 	return "", false
 }
 
+// PaneExists reports whether target is listed by the current server, across
+// every session on it (-a). The ledger's pane column is not authoritative -- a
+// recorded pane can belong to a tmux server that has since been replaced -- so
+// the picker checks a pane before trusting it rather than switching blind and
+// reading the failure as "the session died".
+func (tmuxImpl) PaneExists(target string) bool {
+	panes, err := listPanes()
+	if err != nil {
+		return false
+	}
+	return paneListed(panes, target)
+}
+
+// paneListed is the membership test, over the same pid -> pane map listPanes
+// already builds, so no second tmux call is needed. Taking the map as an
+// argument keeps it testable without a tmux server.
+func paneListed(panes map[int]string, target string) bool {
+	if target == "" {
+		return false
+	}
+	for _, pane := range panes {
+		if pane == target {
+			return true
+		}
+	}
+	return false
+}
+
+// ServerPID returns the pid of the tmux server this process talks to.
+func (tmuxImpl) ServerPID() (int, bool) {
+	out, err := exec.Command("tmux", "display", "-p", "#{pid}").Output()
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
 // listPanes maps each pane's pid to its pane id for the whole server.
 func listPanes() (map[int]string, error) {
 	out, err := exec.Command("tmux", "list-panes", "-a", "-F", "#{pane_pid} #{pane_id}").Output()

--- a/src/claude-queue/internal/picker/origin.go
+++ b/src/claude-queue/internal/picker/origin.go
@@ -1,7 +1,10 @@
 package picker
 
 import (
+	"errors"
+	"io/fs"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 )
@@ -21,9 +24,8 @@ const (
 	// /proc is unreadable (a non-Linux host, a process owned by someone else,
 	// a process that exited mid-check), the TMUX value does not parse, we have
 	// no server pid of our own to compare against, or (see originForeignLive)
-	// the other server's liveness itself could not be checked. It is
-	// deliberately the zero value, so a Target left unfilled defaults to "do
-	// not kill".
+	// the other server's socket could not be queried. It is deliberately the
+	// zero value, so a Target left unfilled defaults to "do not kill".
 	originUnknown serverOrigin = iota
 	// originOutside means the process has no TMUX in its environment: it was
 	// started outside a multiplexer altogether. Not an orphan -- there is a
@@ -33,19 +35,23 @@ const (
 	// pane should have been found by FindPane; seeing this alongside an
 	// unreachable pane means the pane closed while the process lived on.
 	originCurrent
-	// originOrphan means the process belongs to a tmux server that is not
-	// ours, and that other server is confirmed gone (its pid is no longer
-	// running). No client -- ours or anyone else's -- can still be attached to
-	// it, so the conversation is only recoverable by ending the process and
-	// resuming the transcript.
+	// originOrphan means the process belongs to a tmux server that no longer
+	// owns the socket it was started on: either the socket is gone, or another
+	// server has taken the path over. Nobody can open a new client onto it, so
+	// the conversation is only recoverable by ending the process and resuming
+	// the transcript.
+	//
+	// A client that was already attached when the socket changed hands keeps
+	// working over its existing connection, and there is no way left to
+	// enumerate it -- the socket that would answer the question now belongs to
+	// someone else. That residual risk is what the whole path trades against
+	// leaving the conversation unreachable forever.
 	originOrphan
 	// originForeignLive means the process belongs to a tmux server that is not
-	// ours, but that server's pid is still running. tmux servers are scoped
-	// per socket (`tmux -L`/`-S`), so a live server we cannot switch-client
-	// into may still have a human attached to it from another terminal. Not
-	// killable: the safety this package exists to provide (never end a
-	// session someone may be using elsewhere) only holds if a still-running
-	// foreign server is treated the same as one we can see is in use.
+	// ours but still owns its socket. tmux servers are scoped per socket
+	// (`tmux -L` / `-S`), so a server we cannot switch-client into is perfectly
+	// reachable by `tmux -L other attach` from another terminal, and a human
+	// may be in it right now. Not killable.
 	originForeignLive
 )
 
@@ -58,9 +64,9 @@ func (o serverOrigin) String() string {
 	case originCurrent:
 		return "on this tmux server, but its pane is gone"
 	case originOrphan:
-		return "on another tmux server, which is no longer running"
+		return "on a tmux server that no longer owns its socket"
 	case originForeignLive:
-		return "on another tmux server that is still running"
+		return "on another tmux server that is still reachable through its own socket"
 	default:
 		return "on an unknown tmux server"
 	}
@@ -76,15 +82,15 @@ func originOf(pid, currentServerPID int) serverOrigin {
 	if !ok {
 		return originUnknown
 	}
-	return classifyOrigin(environ, currentServerPID, processAlive)
+	return classifyOrigin(environ, currentServerPID, socketServerPID)
 }
 
 // classifyOrigin is the rule itself, over the raw NUL-separated environment
-// block, so every branch can be exercised without a live process. The
-// liveness check for a foreign server's pid is injected rather than reading
-// /proc directly, so it too can be exercised without one.
-func classifyOrigin(environ string, currentServerPID int, alive func(int) bool) serverOrigin {
-	serverPID, ok := tmuxServerPID(environ)
+// block, so every branch can be exercised without a live process. The socket
+// lookup is injected rather than shelling out from here, so it too can be
+// exercised without a tmux server.
+func classifyOrigin(environ string, currentServerPID int, owner socketOwner) serverOrigin {
+	socket, serverPID, ok := tmuxServerPID(environ)
 	if !ok {
 		// No TMUX at all means "outside tmux"; a TMUX that does not parse
 		// means we simply do not know. tmuxServerPID reports both as false, so
@@ -102,53 +108,82 @@ func classifyOrigin(environ string, currentServerPID int, alive func(int) bool) 
 	}
 	// A different server pid than ours is not enough on its own: tmux servers
 	// are per-socket, so a server we cannot see (`tmux -L other`) can still be
-	// alive and have a human attached to it right now. Only a server that is
-	// confirmed gone may be treated as an orphan; if liveness cannot be
-	// checked, that is the same "cannot tell, so do not kill" answer as any
-	// other unsettled case.
-	if alive == nil {
+	// serving clients through its own socket. The question that decides
+	// killability is not whether that pid is running but whether anyone can
+	// still open a client onto it -- which is answered by asking the socket the
+	// session recorded who owns it now.
+	//
+	// Checking the pid alone would be both too strict and too lax: a server
+	// whose socket was taken over lingers as a live process that nobody can
+	// reach (the measured case this path exists for), while a pid that has been
+	// recycled onto an unrelated process would read as "gone".
+	if owner == nil {
 		return originUnknown
 	}
-	if alive(serverPID) {
+	ownerPID, ok := owner(socket)
+	if !ok {
+		return originUnknown
+	}
+	if ownerPID == serverPID {
 		return originForeignLive
 	}
 	return originOrphan
 }
 
-// processAlive reports whether pid names a process still running, by testing
-// for /proc/<pid>. Its one blind spot is pid reuse: if the original tmux
-// server already exited and the kernel handed its pid to an unrelated
-// process, this reports "alive" for the wrong process. That misreading still
-// lands on the safe side for classifyOrigin's caller -- do not kill -- so it
-// is left as is rather than chased with a start-time comparison /proc does
-// not expose cheaply.
-func processAlive(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	_, err := os.Stat("/proc/" + strconv.Itoa(pid))
-	return err == nil
-}
+// socketOwner reports the pid of the tmux server currently listening on a
+// socket path. A zero pid with ok means the socket is not there at all, i.e.
+// no server owns it; !ok means the question could not be answered, which
+// classifyOrigin turns into "do not kill".
+type socketOwner func(socket string) (int, bool)
 
-// tmuxServerPID pulls the server pid out of TMUX=<socket>,<serverpid>,<n>.
+// socketServerPID asks the server on socket for its pid.
 //
-// The pid is taken from the second-to-last comma-separated field rather than
-// index 1, so a socket path containing a comma does not shift the answer to a
-// path fragment.
-func tmuxServerPID(environ string) (int, bool) {
-	value, ok := environValue(environ, "TMUX")
-	if !ok {
+// A missing socket file is an answer, not a failure: nothing is listening, so
+// no client can be opened onto whatever process still holds the old pid. Any
+// other stat error, or a tmux invocation that does not yield a pid, leaves the
+// question unanswered.
+func socketServerPID(socket string) (int, bool) {
+	if socket == "" {
 		return 0, false
 	}
-	fields := strings.Split(value, ",")
-	if len(fields) < 3 {
+	if _, err := os.Stat(socket); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, true
+		}
 		return 0, false
 	}
-	pid, err := strconv.Atoi(fields[len(fields)-2])
+	out, err := exec.Command("tmux", "-S", socket, "display", "-p", "#{pid}").Output()
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
 	if err != nil || pid <= 0 {
 		return 0, false
 	}
 	return pid, true
+}
+
+// tmuxServerPID splits TMUX=<socket>,<serverpid>,<n> into the socket path and
+// the server pid.
+//
+// The pid is taken from the second-to-last comma-separated field rather than
+// index 1, and the socket from everything before it, so a socket path
+// containing a comma neither shifts the pid onto a path fragment nor loses its
+// tail.
+func tmuxServerPID(environ string) (socket string, pid int, ok bool) {
+	value, found := environValue(environ, "TMUX")
+	if !found {
+		return "", 0, false
+	}
+	fields := strings.Split(value, ",")
+	if len(fields) < 3 {
+		return "", 0, false
+	}
+	pid, err := strconv.Atoi(fields[len(fields)-2])
+	if err != nil || pid <= 0 {
+		return "", 0, false
+	}
+	return strings.Join(fields[:len(fields)-2], ","), pid, true
 }
 
 func hasTMUX(environ string) bool {

--- a/src/claude-queue/internal/picker/origin.go
+++ b/src/claude-queue/internal/picker/origin.go
@@ -1,0 +1,142 @@
+package picker
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// serverOrigin says where the tmux server of a live session's process is,
+// relative to the server the picker itself is talking to.
+//
+// It exists to answer one question: may this session be killed so its
+// conversation can be reopened with `claude --resume`? Only originOrphan may.
+// An interactive session whose pane cannot be reached is otherwise indistinguishable
+// from one a human is using in another terminal right now, and resuming a session
+// whose process is still alive leaves two processes writing one transcript.
+type serverOrigin int
+
+const (
+	// originUnknown is the answer whenever the question could not be settled:
+	// /proc is unreadable (a non-Linux host, a process owned by someone else,
+	// a process that exited mid-check), the TMUX value does not parse, or we
+	// have no server pid of our own to compare against. It is deliberately the
+	// zero value, so a Target left unfilled defaults to "do not kill".
+	originUnknown serverOrigin = iota
+	// originOutside means the process has no TMUX in its environment: it was
+	// started outside a multiplexer altogether. Not an orphan -- there is a
+	// terminal somewhere that owns it.
+	originOutside
+	// originCurrent means the process belongs to this very tmux server. Its
+	// pane should have been found by FindPane; seeing this alongside an
+	// unreachable pane means the pane closed while the process lived on.
+	originCurrent
+	// originOrphan means the process belongs to a tmux server that is not
+	// ours. No client of ours can ever reach it, so the conversation is only
+	// recoverable by ending the process and resuming the transcript.
+	originOrphan
+)
+
+// String renders the origin for the stderr message explaining why a pick did
+// not resume, which is the only place these values are shown.
+func (o serverOrigin) String() string {
+	switch o {
+	case originOutside:
+		return "started outside tmux"
+	case originCurrent:
+		return "on this tmux server, but its pane is gone"
+	case originOrphan:
+		return "on another tmux server"
+	default:
+		return "on an unknown tmux server"
+	}
+}
+
+// originOf classifies the tmux server of pid against currentServerPID, reading
+// the process environment from /proc.
+//
+// A read failure is originUnknown rather than an error: every caller would turn
+// the error into the same "cannot tell, so do not kill" decision anyway.
+func originOf(pid, currentServerPID int) serverOrigin {
+	environ, ok := readEnviron(pid)
+	if !ok {
+		return originUnknown
+	}
+	return classifyOrigin(environ, currentServerPID)
+}
+
+// classifyOrigin is the rule itself, over the raw NUL-separated environment
+// block, so every branch can be exercised without a live process.
+func classifyOrigin(environ string, currentServerPID int) serverOrigin {
+	serverPID, ok := tmuxServerPID(environ)
+	if !ok {
+		// No TMUX at all means "outside tmux"; a TMUX that does not parse
+		// means we simply do not know. tmuxServerPID reports both as false, so
+		// the two are told apart by whether the variable is present.
+		if hasTMUX(environ) {
+			return originUnknown
+		}
+		return originOutside
+	}
+	if currentServerPID <= 0 {
+		return originUnknown
+	}
+	if serverPID == currentServerPID {
+		return originCurrent
+	}
+	return originOrphan
+}
+
+// tmuxServerPID pulls the server pid out of TMUX=<socket>,<serverpid>,<n>.
+//
+// The pid is taken from the second-to-last comma-separated field rather than
+// index 1, so a socket path containing a comma does not shift the answer to a
+// path fragment.
+func tmuxServerPID(environ string) (int, bool) {
+	value, ok := environValue(environ, "TMUX")
+	if !ok {
+		return 0, false
+	}
+	fields := strings.Split(value, ",")
+	if len(fields) < 3 {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(fields[len(fields)-2])
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+func hasTMUX(environ string) bool {
+	_, ok := environValue(environ, "TMUX")
+	return ok
+}
+
+// environValue finds one variable in a NUL-separated environment block.
+//
+// The entries are matched whole, not by substring: TMUX_PANE also starts with
+// "TMUX" and would otherwise be read as the socket triple.
+func environValue(environ, key string) (string, bool) {
+	for _, entry := range strings.Split(environ, "\x00") {
+		name, value, ok := strings.Cut(entry, "=")
+		if ok && name == key {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+// readEnviron reads pid's environment block. False covers every reason it could
+// not be had -- no /proc on this platform, a process owned by another user, a
+// process that has already exited -- because the caller treats them alike.
+func readEnviron(pid int) (string, bool) {
+	if pid <= 0 {
+		return "", false
+	}
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/environ")
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}

--- a/src/claude-queue/internal/picker/origin.go
+++ b/src/claude-queue/internal/picker/origin.go
@@ -19,9 +19,11 @@ type serverOrigin int
 const (
 	// originUnknown is the answer whenever the question could not be settled:
 	// /proc is unreadable (a non-Linux host, a process owned by someone else,
-	// a process that exited mid-check), the TMUX value does not parse, or we
-	// have no server pid of our own to compare against. It is deliberately the
-	// zero value, so a Target left unfilled defaults to "do not kill".
+	// a process that exited mid-check), the TMUX value does not parse, we have
+	// no server pid of our own to compare against, or (see originForeignLive)
+	// the other server's liveness itself could not be checked. It is
+	// deliberately the zero value, so a Target left unfilled defaults to "do
+	// not kill".
 	originUnknown serverOrigin = iota
 	// originOutside means the process has no TMUX in its environment: it was
 	// started outside a multiplexer altogether. Not an orphan -- there is a
@@ -32,9 +34,19 @@ const (
 	// unreachable pane means the pane closed while the process lived on.
 	originCurrent
 	// originOrphan means the process belongs to a tmux server that is not
-	// ours. No client of ours can ever reach it, so the conversation is only
-	// recoverable by ending the process and resuming the transcript.
+	// ours, and that other server is confirmed gone (its pid is no longer
+	// running). No client -- ours or anyone else's -- can still be attached to
+	// it, so the conversation is only recoverable by ending the process and
+	// resuming the transcript.
 	originOrphan
+	// originForeignLive means the process belongs to a tmux server that is not
+	// ours, but that server's pid is still running. tmux servers are scoped
+	// per socket (`tmux -L`/`-S`), so a live server we cannot switch-client
+	// into may still have a human attached to it from another terminal. Not
+	// killable: the safety this package exists to provide (never end a
+	// session someone may be using elsewhere) only holds if a still-running
+	// foreign server is treated the same as one we can see is in use.
+	originForeignLive
 )
 
 // String renders the origin for the stderr message explaining why a pick did
@@ -46,7 +58,9 @@ func (o serverOrigin) String() string {
 	case originCurrent:
 		return "on this tmux server, but its pane is gone"
 	case originOrphan:
-		return "on another tmux server"
+		return "on another tmux server, which is no longer running"
+	case originForeignLive:
+		return "on another tmux server that is still running"
 	default:
 		return "on an unknown tmux server"
 	}
@@ -62,12 +76,14 @@ func originOf(pid, currentServerPID int) serverOrigin {
 	if !ok {
 		return originUnknown
 	}
-	return classifyOrigin(environ, currentServerPID)
+	return classifyOrigin(environ, currentServerPID, processAlive)
 }
 
 // classifyOrigin is the rule itself, over the raw NUL-separated environment
-// block, so every branch can be exercised without a live process.
-func classifyOrigin(environ string, currentServerPID int) serverOrigin {
+// block, so every branch can be exercised without a live process. The
+// liveness check for a foreign server's pid is injected rather than reading
+// /proc directly, so it too can be exercised without one.
+func classifyOrigin(environ string, currentServerPID int, alive func(int) bool) serverOrigin {
 	serverPID, ok := tmuxServerPID(environ)
 	if !ok {
 		// No TMUX at all means "outside tmux"; a TMUX that does not parse
@@ -84,7 +100,34 @@ func classifyOrigin(environ string, currentServerPID int) serverOrigin {
 	if serverPID == currentServerPID {
 		return originCurrent
 	}
+	// A different server pid than ours is not enough on its own: tmux servers
+	// are per-socket, so a server we cannot see (`tmux -L other`) can still be
+	// alive and have a human attached to it right now. Only a server that is
+	// confirmed gone may be treated as an orphan; if liveness cannot be
+	// checked, that is the same "cannot tell, so do not kill" answer as any
+	// other unsettled case.
+	if alive == nil {
+		return originUnknown
+	}
+	if alive(serverPID) {
+		return originForeignLive
+	}
 	return originOrphan
+}
+
+// processAlive reports whether pid names a process still running, by testing
+// for /proc/<pid>. Its one blind spot is pid reuse: if the original tmux
+// server already exited and the kernel handed its pid to an unrelated
+// process, this reports "alive" for the wrong process. That misreading still
+// lands on the safe side for classifyOrigin's caller -- do not kill -- so it
+// is left as is rather than chased with a start-time comparison /proc does
+// not expose cheaply.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	_, err := os.Stat("/proc/" + strconv.Itoa(pid))
+	return err == nil
 }
 
 // tmuxServerPID pulls the server pid out of TMUX=<socket>,<serverpid>,<n>.

--- a/src/claude-queue/internal/picker/origin_test.go
+++ b/src/claude-queue/internal/picker/origin_test.go
@@ -10,63 +10,81 @@ func environ(entries ...string) string {
 	return strings.Join(entries, "\x00") + "\x00"
 }
 
-// alwaysAlive and neverAlive are the liveness stubs the "another server"
-// cases exercise classifyOrigin with, so the rule is pinned without touching
-// a real /proc.
-func alwaysAlive(int) bool { return true }
-func neverAlive(int) bool  { return false }
+// ownedBy is the socket-lookup stub the "another server" cases exercise
+// classifyOrigin with, so the rule is pinned without a tmux server. pid 0
+// stands for "the socket is not there"; unknownOwner is the lookup that could
+// not answer at all.
+func ownedBy(pid int) socketOwner {
+	return func(string) (int, bool) { return pid, true }
+}
+
+func unknownOwner(string) (int, bool) { return 0, false }
 
 // classifyOrigin is what decides whether a live session may be killed to be
 // resumed, so every answer it can give is pinned here. The rule errs toward
 // originUnknown -- "do not kill" -- whenever the environment does not settle
 // the question, and toward originForeignLive -- also "do not kill" -- whenever
-// a different tmux server's liveness cannot be ruled out.
+// a different tmux server still owns the socket it was started on.
 func TestClassifyOrigin(t *testing.T) {
 	cases := []struct {
 		name             string
 		environ          string
 		currentServerPID int
-		alive            func(int) bool
+		owner            socketOwner
 		want             serverOrigin
 	}{{
 		name:             "same server",
 		environ:          environ("PATH=/usr/bin", "TMUX=/tmp/tmux-1000/default,1234,0", "TMUX_PANE=%3"),
 		currentServerPID: 1234,
-		alive:            neverAlive,
+		owner:            ownedBy(1234),
 		want:             originCurrent,
 	}, {
-		// The measured majority: the process outlived the tmux server it was
-		// started in, and that server's pid is confirmed gone, so no client --
-		// ours or anyone else's -- can ever reach its pane again.
-		name:             "another server, confirmed dead",
+		// The measured majority: the process outlived the server it was
+		// started in, and the socket it recorded now belongs to a different
+		// server. The old pid may well still be running, but nothing can open
+		// a client onto it any more.
+		name:             "another server, socket taken over",
 		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
 		currentServerPID: 5678,
-		alive:            neverAlive,
+		owner:            ownedBy(5678),
+		want:             originOrphan,
+	}, {
+		// pid 0 from the lookup means the socket is gone entirely: nothing is
+		// listening, so the same conclusion holds.
+		name:             "another server, socket gone",
+		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
+		currentServerPID: 5678,
+		owner:            ownedBy(0),
 		want:             originOrphan,
 	}, {
 		// tmux servers are per-socket: a different server pid does not by
-		// itself mean unreachable. If that server's pid is still running, a
-		// human may be attached to it from another terminal via `tmux -L`/`-S`
-		// right now, so it must not be killed.
-		name:             "another server, still running",
-		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
+		// itself mean unreachable. This one still owns its socket, so a human
+		// can `tmux -L other attach` into it right now.
+		name:             "another server, still owns its socket",
+		environ:          environ("TMUX=/tmp/tmux-1000/other,1234,0"),
 		currentServerPID: 5678,
-		alive:            alwaysAlive,
+		owner:            ownedBy(1234),
 		want:             originForeignLive,
 	}, {
-		// Liveness of the other server could not be determined at all: the
-		// safe answer is the same as "cannot tell", not "assume dead".
-		name:             "another server, liveness undeterminable",
+		// The socket could not be queried at all: the safe answer is "cannot
+		// tell", not "assume unreachable".
+		name:             "another server, socket unqueryable",
 		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
 		currentServerPID: 5678,
-		alive:            nil,
+		owner:            unknownOwner,
+		want:             originUnknown,
+	}, {
+		name:             "another server, no lookup available",
+		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
+		currentServerPID: 5678,
+		owner:            nil,
 		want:             originUnknown,
 	}, {
 		// No TMUX at all: a terminal somewhere owns this process.
 		name:             "no TMUX means outside tmux",
 		environ:          environ("PATH=/usr/bin", "TERM=xterm"),
 		currentServerPID: 5678,
-		alive:            neverAlive,
+		owner:            ownedBy(0),
 		want:             originOutside,
 	}, {
 		// TMUX_PANE also starts with "TMUX", and reading it as the socket
@@ -74,26 +92,26 @@ func TestClassifyOrigin(t *testing.T) {
 		name:             "TMUX_PANE alone is not TMUX",
 		environ:          environ("TMUX_PANE=%3"),
 		currentServerPID: 5678,
-		alive:            neverAlive,
+		owner:            ownedBy(0),
 		want:             originOutside,
 	}, {
 		name:             "unparseable TMUX",
 		environ:          environ("TMUX=nonsense"),
 		currentServerPID: 5678,
-		alive:            neverAlive,
+		owner:            ownedBy(0),
 		want:             originUnknown,
 	}, {
 		name:             "non-numeric server pid",
 		environ:          environ("TMUX=/tmp/tmux-1000/default,notapid,0"),
 		currentServerPID: 5678,
-		alive:            neverAlive,
+		owner:            ownedBy(0),
 		want:             originUnknown,
 	}, {
 		// Nothing to compare against, so nothing is provably an orphan.
 		name:             "no server pid of our own",
 		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
 		currentServerPID: 0,
-		alive:            neverAlive,
+		owner:            ownedBy(0),
 		want:             originUnknown,
 	}, {
 		// The pid is the second-to-last field, so a comma in the socket path
@@ -101,19 +119,19 @@ func TestClassifyOrigin(t *testing.T) {
 		name:             "socket path containing a comma",
 		environ:          environ("TMUX=/tmp/odd,dir/default,1234,0"),
 		currentServerPID: 1234,
-		alive:            neverAlive,
+		owner:            ownedBy(0),
 		want:             originCurrent,
 	}, {
 		name:             "empty environ",
 		environ:          "",
 		currentServerPID: 1234,
-		alive:            neverAlive,
+		owner:            ownedBy(0),
 		want:             originOutside,
 	}}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := classifyOrigin(c.environ, c.currentServerPID, c.alive); got != c.want {
+			if got := classifyOrigin(c.environ, c.currentServerPID, c.owner); got != c.want {
 				t.Errorf("classifyOrigin = %v, want %v", got, c.want)
 			}
 		})
@@ -162,5 +180,45 @@ func TestServerOriginString(t *testing.T) {
 			t.Errorf("origin %d reuses the description %q", o, s)
 		}
 		seen[s] = true
+	}
+}
+
+// The socket half of the TMUX triple is what the killability check queries, so
+// it has to survive a path containing the separator the triple is split on.
+func TestTmuxServerPID(t *testing.T) {
+	cases := []struct {
+		name       string
+		environ    string
+		wantSocket string
+		wantPID    int
+		wantOK     bool
+	}{{
+		name:       "plain path",
+		environ:    environ("TMUX=/tmp/tmux-1000/default,1234,0"),
+		wantSocket: "/tmp/tmux-1000/default",
+		wantPID:    1234,
+		wantOK:     true,
+	}, {
+		name:       "path containing a comma",
+		environ:    environ("TMUX=/tmp/odd,dir/default,1234,7"),
+		wantSocket: "/tmp/odd,dir/default",
+		wantPID:    1234,
+		wantOK:     true,
+	}, {
+		name:    "too few fields",
+		environ: environ("TMUX=/tmp/tmux-1000/default,1234"),
+	}, {
+		name:    "no TMUX",
+		environ: environ("TMUX_PANE=%3"),
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			socket, pid, ok := tmuxServerPID(c.environ)
+			if ok != c.wantOK || socket != c.wantSocket || pid != c.wantPID {
+				t.Errorf("tmuxServerPID = (%q, %d, %v), want (%q, %d, %v)",
+					socket, pid, ok, c.wantSocket, c.wantPID, c.wantOK)
+			}
+		})
 	}
 }

--- a/src/claude-queue/internal/picker/origin_test.go
+++ b/src/claude-queue/internal/picker/origin_test.go
@@ -10,33 +10,63 @@ func environ(entries ...string) string {
 	return strings.Join(entries, "\x00") + "\x00"
 }
 
+// alwaysAlive and neverAlive are the liveness stubs the "another server"
+// cases exercise classifyOrigin with, so the rule is pinned without touching
+// a real /proc.
+func alwaysAlive(int) bool { return true }
+func neverAlive(int) bool  { return false }
+
 // classifyOrigin is what decides whether a live session may be killed to be
 // resumed, so every answer it can give is pinned here. The rule errs toward
 // originUnknown -- "do not kill" -- whenever the environment does not settle
-// the question.
+// the question, and toward originForeignLive -- also "do not kill" -- whenever
+// a different tmux server's liveness cannot be ruled out.
 func TestClassifyOrigin(t *testing.T) {
 	cases := []struct {
 		name             string
 		environ          string
 		currentServerPID int
+		alive            func(int) bool
 		want             serverOrigin
 	}{{
 		name:             "same server",
 		environ:          environ("PATH=/usr/bin", "TMUX=/tmp/tmux-1000/default,1234,0", "TMUX_PANE=%3"),
 		currentServerPID: 1234,
+		alive:            neverAlive,
 		want:             originCurrent,
 	}, {
 		// The measured majority: the process outlived the tmux server it was
-		// started in, so no client of ours can ever reach its pane.
-		name:             "another server",
+		// started in, and that server's pid is confirmed gone, so no client --
+		// ours or anyone else's -- can ever reach its pane again.
+		name:             "another server, confirmed dead",
 		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
 		currentServerPID: 5678,
+		alive:            neverAlive,
 		want:             originOrphan,
+	}, {
+		// tmux servers are per-socket: a different server pid does not by
+		// itself mean unreachable. If that server's pid is still running, a
+		// human may be attached to it from another terminal via `tmux -L`/`-S`
+		// right now, so it must not be killed.
+		name:             "another server, still running",
+		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
+		currentServerPID: 5678,
+		alive:            alwaysAlive,
+		want:             originForeignLive,
+	}, {
+		// Liveness of the other server could not be determined at all: the
+		// safe answer is the same as "cannot tell", not "assume dead".
+		name:             "another server, liveness undeterminable",
+		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
+		currentServerPID: 5678,
+		alive:            nil,
+		want:             originUnknown,
 	}, {
 		// No TMUX at all: a terminal somewhere owns this process.
 		name:             "no TMUX means outside tmux",
 		environ:          environ("PATH=/usr/bin", "TERM=xterm"),
 		currentServerPID: 5678,
+		alive:            neverAlive,
 		want:             originOutside,
 	}, {
 		// TMUX_PANE also starts with "TMUX", and reading it as the socket
@@ -44,22 +74,26 @@ func TestClassifyOrigin(t *testing.T) {
 		name:             "TMUX_PANE alone is not TMUX",
 		environ:          environ("TMUX_PANE=%3"),
 		currentServerPID: 5678,
+		alive:            neverAlive,
 		want:             originOutside,
 	}, {
 		name:             "unparseable TMUX",
 		environ:          environ("TMUX=nonsense"),
 		currentServerPID: 5678,
+		alive:            neverAlive,
 		want:             originUnknown,
 	}, {
 		name:             "non-numeric server pid",
 		environ:          environ("TMUX=/tmp/tmux-1000/default,notapid,0"),
 		currentServerPID: 5678,
+		alive:            neverAlive,
 		want:             originUnknown,
 	}, {
 		// Nothing to compare against, so nothing is provably an orphan.
 		name:             "no server pid of our own",
 		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
 		currentServerPID: 0,
+		alive:            neverAlive,
 		want:             originUnknown,
 	}, {
 		// The pid is the second-to-last field, so a comma in the socket path
@@ -67,17 +101,19 @@ func TestClassifyOrigin(t *testing.T) {
 		name:             "socket path containing a comma",
 		environ:          environ("TMUX=/tmp/odd,dir/default,1234,0"),
 		currentServerPID: 1234,
+		alive:            neverAlive,
 		want:             originCurrent,
 	}, {
 		name:             "empty environ",
 		environ:          "",
 		currentServerPID: 1234,
+		alive:            neverAlive,
 		want:             originOutside,
 	}}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := classifyOrigin(c.environ, c.currentServerPID); got != c.want {
+			if got := classifyOrigin(c.environ, c.currentServerPID, c.alive); got != c.want {
 				t.Errorf("classifyOrigin = %v, want %v", got, c.want)
 			}
 		})
@@ -88,7 +124,7 @@ func TestClassifyOrigin(t *testing.T) {
 // value is ever added, this makes the omission visible rather than silently
 // widening the kill.
 func TestOnlyOrphanIsKillable(t *testing.T) {
-	for _, o := range []serverOrigin{originUnknown, originOutside, originCurrent} {
+	for _, o := range []serverOrigin{originUnknown, originOutside, originCurrent, originForeignLive} {
 		tgt := resumable()
 		tgt.InRoster, tgt.Kind, tgt.PID, tgt.Origin = true, "interactive", 4242, o
 		if act := DecideAction(tgt); act.KillPID != 0 {
@@ -117,7 +153,7 @@ func TestReadEnvironMissingPID(t *testing.T) {
 // so each value needs its own words.
 func TestServerOriginString(t *testing.T) {
 	seen := map[string]bool{}
-	for _, o := range []serverOrigin{originUnknown, originOutside, originCurrent, originOrphan} {
+	for _, o := range []serverOrigin{originUnknown, originOutside, originCurrent, originOrphan, originForeignLive} {
 		s := o.String()
 		if s == "" {
 			t.Errorf("origin %d has no description", o)

--- a/src/claude-queue/internal/picker/origin_test.go
+++ b/src/claude-queue/internal/picker/origin_test.go
@@ -1,0 +1,130 @@
+package picker
+
+import (
+	"strings"
+	"testing"
+)
+
+// environ builds the NUL-separated block /proc/<pid>/environ hands back.
+func environ(entries ...string) string {
+	return strings.Join(entries, "\x00") + "\x00"
+}
+
+// classifyOrigin is what decides whether a live session may be killed to be
+// resumed, so every answer it can give is pinned here. The rule errs toward
+// originUnknown -- "do not kill" -- whenever the environment does not settle
+// the question.
+func TestClassifyOrigin(t *testing.T) {
+	cases := []struct {
+		name             string
+		environ          string
+		currentServerPID int
+		want             serverOrigin
+	}{{
+		name:             "same server",
+		environ:          environ("PATH=/usr/bin", "TMUX=/tmp/tmux-1000/default,1234,0", "TMUX_PANE=%3"),
+		currentServerPID: 1234,
+		want:             originCurrent,
+	}, {
+		// The measured majority: the process outlived the tmux server it was
+		// started in, so no client of ours can ever reach its pane.
+		name:             "another server",
+		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
+		currentServerPID: 5678,
+		want:             originOrphan,
+	}, {
+		// No TMUX at all: a terminal somewhere owns this process.
+		name:             "no TMUX means outside tmux",
+		environ:          environ("PATH=/usr/bin", "TERM=xterm"),
+		currentServerPID: 5678,
+		want:             originOutside,
+	}, {
+		// TMUX_PANE also starts with "TMUX", and reading it as the socket
+		// triple would classify an outside-tmux session as unknown.
+		name:             "TMUX_PANE alone is not TMUX",
+		environ:          environ("TMUX_PANE=%3"),
+		currentServerPID: 5678,
+		want:             originOutside,
+	}, {
+		name:             "unparseable TMUX",
+		environ:          environ("TMUX=nonsense"),
+		currentServerPID: 5678,
+		want:             originUnknown,
+	}, {
+		name:             "non-numeric server pid",
+		environ:          environ("TMUX=/tmp/tmux-1000/default,notapid,0"),
+		currentServerPID: 5678,
+		want:             originUnknown,
+	}, {
+		// Nothing to compare against, so nothing is provably an orphan.
+		name:             "no server pid of our own",
+		environ:          environ("TMUX=/tmp/tmux-1000/default,1234,0"),
+		currentServerPID: 0,
+		want:             originUnknown,
+	}, {
+		// The pid is the second-to-last field, so a comma in the socket path
+		// does not shift the answer onto a path fragment.
+		name:             "socket path containing a comma",
+		environ:          environ("TMUX=/tmp/odd,dir/default,1234,0"),
+		currentServerPID: 1234,
+		want:             originCurrent,
+	}, {
+		name:             "empty environ",
+		environ:          "",
+		currentServerPID: 1234,
+		want:             originOutside,
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := classifyOrigin(c.environ, c.currentServerPID); got != c.want {
+				t.Errorf("classifyOrigin = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// Only originOrphan may be killed, and DecideAction leans on that. If a new
+// value is ever added, this makes the omission visible rather than silently
+// widening the kill.
+func TestOnlyOrphanIsKillable(t *testing.T) {
+	for _, o := range []serverOrigin{originUnknown, originOutside, originCurrent} {
+		tgt := resumable()
+		tgt.InRoster, tgt.Kind, tgt.PID, tgt.Origin = true, "interactive", 4242, o
+		if act := DecideAction(tgt); act.KillPID != 0 {
+			t.Errorf("origin %v: KillPID = %d, want 0", o, act.KillPID)
+		}
+	}
+}
+
+// readEnviron must report failure rather than an empty block for a pid that is
+// not there: an empty block would classify as originOutside, and "cannot tell"
+// is the only honest answer.
+func TestReadEnvironMissingPID(t *testing.T) {
+	if _, ok := readEnviron(0); ok {
+		t.Error("readEnviron(0) reported success, want failure")
+	}
+	if _, ok := readEnviron(-1); ok {
+		t.Error("readEnviron(-1) reported success, want failure")
+	}
+	// originOf turns any read failure into originUnknown.
+	if got := originOf(0, 1234); got != originUnknown {
+		t.Errorf("originOf with an unreadable pid = %v, want originUnknown", got)
+	}
+}
+
+// The origin appears in the stderr line explaining why a pick did not resume,
+// so each value needs its own words.
+func TestServerOriginString(t *testing.T) {
+	seen := map[string]bool{}
+	for _, o := range []serverOrigin{originUnknown, originOutside, originCurrent, originOrphan} {
+		s := o.String()
+		if s == "" {
+			t.Errorf("origin %d has no description", o)
+		}
+		if seen[s] {
+			t.Errorf("origin %d reuses the description %q", o, s)
+		}
+		seen[s] = true
+	}
+}

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
@@ -35,9 +36,11 @@ var ascii = map[string]string{
 // The worktree name comes right after the icon so it starts at a fixed
 // position and stays scannable; the variable-width summary is demoted behind
 // it and left untruncated.
-// Hidden columns: session_id (5), tmux_pane (6), full cwd (7). The full cwd is
-// carried separately from the worktree name because a background session is
-// opened in a window that needs a real working directory.
+// Hidden columns: session_id (5), tmux_pane (6), full cwd (7),
+// transcript_path (8). The full cwd is carried separately from the worktree
+// name because a background session is opened in a window that needs a real
+// working directory; the transcript path rides along because the resume path
+// must not run without confirming the conversation file is actually on disk.
 //
 // worktree is passed in rather than derived here: resolving it needs git (see
 // worktreeName), and keeping FormatLine pure is what lets the column contract
@@ -62,7 +65,10 @@ func FormatLine(row db.Row, worktree string, nowSec int64, asciiMode bool) strin
 		pane = row.TmuxPane.String
 	}
 
-	return strings.Join([]string{icon, worktree, sum, age, row.SessionID, pane, rowCwd(row)}, "\t")
+	return strings.Join([]string{
+		icon, worktree, sum, age,
+		row.SessionID, pane, rowCwd(row), rowTranscript(row),
+	}, "\t")
 }
 
 // rowCwd unwraps the nullable cwd column into the "" that the rest of the
@@ -70,6 +76,15 @@ func FormatLine(row db.Row, worktree string, nowSec int64, asciiMode bool) strin
 func rowCwd(row db.Row) string {
 	if row.Cwd.Valid {
 		return row.Cwd.String
+	}
+	return ""
+}
+
+// rowTranscript unwraps transcript_path the same way; "" means the ledger never
+// recorded one, which the resume path treats as "nothing to resume".
+func rowTranscript(row db.Row) string {
+	if row.TranscriptPath.Valid {
+		return row.TranscriptPath.String
 	}
 	return ""
 }
@@ -89,99 +104,224 @@ func formatAge(sec int64) string {
 	}
 }
 
-// Action is what selecting a picker row should do. Keeping the decision in a
-// pure function separates the routing rule -- which is the part with branches
-// worth testing -- from the exec calls that carry it out.
-type Action struct {
-	Kind   string // "switch" | "attach" | "none"
-	Pane   string // switch: tmux pane id
-	Short  string // attach: 8-char session id, the only form `claude attach` takes
-	Cwd    string // attach: working directory for the new window
-	Reason string // none: message for stderr
+// Target is everything DecideAction needs to know about a picked row: what the
+// ledger recorded, what the live roster says about the session's process, and
+// whether the two files a resume depends on are actually there.
+//
+// Gathering it costs subprocesses and stat calls, all of which stay in Run;
+// this struct is the seam that keeps the routing rule -- the part with branches
+// worth testing -- free of them.
+type Target struct {
+	SessionID      string // full UUID as the ledger holds it
+	Pane           string // pane confirmed reachable on this server, or ""
+	Cwd            string
+	TranscriptPath string
+
+	// RosterOK distinguishes "the roster says this session is not running"
+	// from "the roster could not be read", which is the same distinction
+	// reconcile.Sweep turns on. Only the former is evidence the process ended,
+	// and resuming a session whose process is still alive puts two of them on
+	// one transcript.
+	RosterOK bool
+	InRoster bool
+	Kind     string // roster kind: "interactive" | "background"
+	PID      int
+	Origin   serverOrigin
+
+	TranscriptExists bool
+	CwdExists        bool
 }
 
-// DecideAction routes a selected row. A session tracked with a tmux pane is
-// reached by switching to it. A background session has no pane (it does not
-// inherit $TMUX_PANE), so it is opened with `claude attach` in a fresh window
-// instead -- which is also how a background session blocked on a permission
-// prompt gets answered, since that prompt cannot be routed anywhere else.
-func DecideAction(sessionID, pane, cwd string) Action {
-	if pane != "" {
-		return Action{Kind: "switch", Pane: pane}
+// Action is what selecting a picker row should do.
+type Action struct {
+	Kind    string // "switch" | "attach" | "resume" | "none"
+	Pane    string // switch: tmux pane id
+	Short   string // attach: 8-char session id, the only form `claude attach` takes
+	Cwd     string // attach / resume: working directory for the new window
+	Resume  string // resume: full UUID, the form `claude --resume` needs
+	KillPID int    // resume: pid to SIGTERM first; 0 when no process is left
+	Reason  string // none: message for stderr
+}
+
+// DecideAction routes a selected row, in the order the four reachable states
+// were measured in:
+//
+//  1. A pane we can reach is always the answer -- the session is right there.
+//  2. A background session has no pane (it does not inherit $TMUX_PANE), so it
+//     is opened with `claude attach` in a fresh window. This is also the only
+//     way a background session blocked on a permission prompt gets answered.
+//  3. An interactive session with no reachable pane cannot be attached at all:
+//     `claude attach` serves background jobs only and answers "No job matching
+//     <id>", and because `tmux new-window` reports the status of creating the
+//     window rather than of the command inside it, the window opens, the
+//     command fails, the window closes, and the pick looks like a no-op. The
+//     conversation is recoverable by resuming its transcript instead -- but
+//     `claude --resume` does not take over the running process, it starts a
+//     second one on the same transcript. So the process has to end first, and
+//     that is only safe when its tmux server is provably not ours: anything
+//     else may be a session a human is using in another terminal.
+//  4. A session the roster does not list has no process to displace, so it
+//     resumes directly.
+//
+// Resuming needs the transcript and the working directory to exist, which is
+// checked last so it covers both paths that reach it. `claude --resume` with an
+// id it cannot find does not fail -- it silently starts an empty session under
+// that id -- so an unverified resume would look like success and lose the row.
+func DecideAction(t Target) Action {
+	if t.Pane != "" {
+		return Action{Kind: "switch", Pane: t.Pane}
 	}
-	if sessionID == "" {
+	if t.SessionID == "" {
 		return Action{Kind: "none", Reason: "no tmux pane and no session id recorded"}
 	}
-	short := sessionID
-	if len(short) > 8 {
-		short = short[:8]
+	if !t.RosterOK {
+		return Action{Kind: "none", Reason: "live agent roster unreadable, so the session may still be running: not resuming"}
 	}
-	return Action{Kind: "attach", Short: short, Cwd: cwd}
+	if t.InRoster {
+		if t.Kind == "background" {
+			return Action{Kind: "attach", Short: shortID(t.SessionID), Cwd: t.Cwd}
+		}
+		if t.Origin != originOrphan {
+			return Action{Kind: "none", Reason: fmt.Sprintf(
+				"session %s is running (pid %d, %s) and may be in use in another terminal: not resuming",
+				shortID(t.SessionID), t.PID, t.Origin)}
+		}
+		if t.PID <= 0 {
+			return Action{Kind: "none", Reason: "session runs on another tmux server but the roster recorded no pid to end it with"}
+		}
+	}
+	if reason := resumeBlocked(t); reason != "" {
+		return Action{Kind: "none", Reason: reason}
+	}
+	act := Action{Kind: "resume", Resume: t.SessionID, Cwd: t.Cwd}
+	if t.InRoster {
+		act.KillPID = t.PID
+	}
+	return act
 }
 
-// resolvePane re-derives the tmux pane of a picked row the ledger recorded none
-// for, by locating the live agent's process in the current tmux server.
-//
-// The pane column is not authoritative: it goes NULL for reasons not yet pinned
-// down, and an interactive session whose row lost its pane cannot be reached by
-// the attach fallback at all. `claude attach` only knows background jobs and
-// answers "No job matching <id>", while `tmux new-window` reports the exit status
-// of the window creation and not of the command inside it -- so the window opens,
-// the command fails, the window closes, and the pick looks like a no-op with
-// nothing printed. Walking the process tree recovers the pane instead; measured
-// against sessions that did record one, it agrees exactly.
-//
-// Called for the single picked row only, never for the whole list: roster.List
-// costs a subprocess and the panes of rows the user did not select are never
-// needed. An unreadable roster leaves the pane empty, which drops back to the
-// attach path -- the behaviour before this lookup existed.
-func resolvePane(mux multiplexer.Multiplexer, sessionID string) string {
-	if sessionID == "" {
-		return ""
-	}
-	agents, err := roster.List()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "pane lookup skipped:", err)
-		return ""
-	}
-	return paneForSession(agents, sessionID, mux.FindPane)
-}
-
-// paneForSession is the lookup itself, taking the pane finder as an argument so
-// the roster-to-pane wiring can be tested without tmux.
-func paneForSession(agents []roster.Agent, sessionID string, find func(int) (string, bool)) string {
-	for _, a := range agents {
-		if a.SessionID != sessionID {
-			continue
-		}
-		if pane, ok := find(a.PID); ok {
-			return pane
-		}
-		// The session is live but outside this tmux server (a session that
-		// outlived the server it started in, or a background agent that never
-		// had a pane). Looking at later entries cannot help: session ids are
-		// unique in the roster.
-		return ""
+// resumeBlocked names the missing precondition for a resume, or "" when there
+// is none. Both are on disk rather than in the ledger, so the ledger having
+// recorded a path is only half the check.
+func resumeBlocked(t Target) string {
+	switch {
+	case t.TranscriptPath == "":
+		return "cannot resume: the ledger recorded no transcript path for this session"
+	case !t.TranscriptExists:
+		return "cannot resume: transcript " + t.TranscriptPath + " is not on disk (the session ended before writing one)"
+	case t.Cwd == "":
+		return "cannot resume: the ledger recorded no working directory for this session"
+	case !t.CwdExists:
+		return "cannot resume: working directory " + t.Cwd + " no longer exists (its worktree was reaped)"
 	}
 	return ""
 }
 
-// switchTo performs the tmux switch to a picked pane and decides whether a
-// failure should terminate the row in the ledger. Pulled out of Run's
-// "switch" case so the decision -- the part with a branch worth testing --
-// can be exercised without tmux; sw is mux.Switch in production.
-func switchTo(sw func(string) error, pane string, paneResolved bool) (err error, terminate bool) {
-	err = sw(pane)
-	if err == nil {
-		return nil, false
+// shortID truncates a session id to the 8 chars `claude attach` takes, and the
+// form every message about a session uses.
+func shortID(sessionID string) string {
+	if len(sessionID) > 8 {
+		return sessionID[:8]
 	}
-	// A pane resolvePane found was confirmed live moments ago via both the
-	// process roster and the current tmux pane table -- a failed switch to it
-	// says nothing about the session's liveness (same reasoning as the attach
-	// path below, which never terminates on a failed open). Only the
-	// ledger-recorded pane, whose staleness is exactly what "pane likely gone"
-	// is diagnosing, still warrants terminating on failure.
-	return err, !paneResolved
+	return sessionID
+}
+
+// reachablePane returns a pane of the current server the picked row can be
+// switched to, preferring the one the ledger recorded and falling back to
+// re-deriving it from the live process. "" means neither is reachable.
+//
+// The pane column is not authoritative in either direction. It goes NULL for
+// reasons not yet pinned down, and it also keeps pointing at panes of a tmux
+// server that has since been replaced -- 44 of 48 live rows measured were in
+// that state. So a recorded pane is checked against the server's pane table
+// before being trusted, rather than switched to blind: a failed switch used to
+// be read as "the session died" and closed a row whose session was fine.
+//
+// Walking the process tree recovers the pane where the recorded one is unusable;
+// measured against sessions that did record a valid one, it agrees exactly.
+func reachablePane(mux multiplexer.Multiplexer, agents []roster.Agent, sessionID, ledgerPane string) string {
+	if ledgerPane != "" && mux.PaneExists(ledgerPane) {
+		return ledgerPane
+	}
+	return paneForSession(agents, sessionID, mux.FindPane)
+}
+
+// paneForSession is the process-tree lookup itself, taking the pane finder as an
+// argument so the roster-to-pane wiring can be tested without tmux.
+func paneForSession(agents []roster.Agent, sessionID string, find func(int) (string, bool)) string {
+	a, ok := agentFor(agents, sessionID)
+	if !ok {
+		return ""
+	}
+	if pane, found := find(a.PID); found {
+		return pane
+	}
+	// The session is live but outside this tmux server (a session that
+	// outlived the server it started in, or a background agent that never had
+	// a pane). Which of the two it is decides whether the session may be
+	// killed and resumed, and that is originOf's question, not this one's.
+	return ""
+}
+
+// agentFor finds a session in the roster. Session ids are unique there, so the
+// first match is the only one.
+func agentFor(agents []roster.Agent, sessionID string) (roster.Agent, bool) {
+	if sessionID == "" {
+		return roster.Agent{}, false
+	}
+	for _, a := range agents {
+		if a.SessionID == sessionID {
+			return a, true
+		}
+	}
+	return roster.Agent{}, false
+}
+
+// killPollAttempts and killPollInterval bound the wait for a SIGTERM'd session
+// to leave the roster: 10s in half-second steps. Claude flushes its transcript
+// on the way out, so resuming before it is gone would reopen a half-written
+// conversation -- and would also be the two-processes-one-transcript state the
+// kill exists to avoid.
+const (
+	killPollAttempts = 20
+	killPollInterval = 500 * time.Millisecond
+)
+
+// endSession asks pid to exit and waits for the roster to stop listing
+// sessionID.
+//
+// SIGTERM only, never SIGKILL: a session that ignores the signal is a session
+// still holding its transcript, and forcing it out risks losing the very
+// conversation the resume is trying to recover. Refusing to resume is the
+// conservative answer -- the user keeps a live process and an intact transcript
+// and can decide what to do with them.
+func endSession(pid int, sessionID string) error {
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		return fmt.Errorf("SIGTERM to pid %d: %w", pid, err)
+	}
+	if !waitGone(sessionID, roster.List, func() { time.Sleep(killPollInterval) }, killPollAttempts) {
+		return fmt.Errorf("session %s is still in the roster after SIGTERM to pid %d", shortID(sessionID), pid)
+	}
+	return nil
+}
+
+// waitGone polls until the roster stops listing sessionID, with the roster read
+// and the sleep injected so the loop is testable without a process to kill.
+//
+// A roster that cannot be read counts as "still there": it is not evidence the
+// session ended, and the whole point of the wait is to be sure it did.
+func waitGone(sessionID string, list func() ([]roster.Agent, error), tick func(), attempts int) bool {
+	for i := 0; i < attempts; i++ {
+		tick()
+		agents, err := list()
+		if err != nil {
+			continue
+		}
+		if _, ok := agentFor(agents, sessionID); !ok {
+			return true
+		}
+	}
+	return false
 }
 
 // Run is the CLI entrypoint for `claude-queue picker`.
@@ -237,28 +377,26 @@ func Run(args []string) {
 	}
 
 	fields := strings.Split(selected, "\t")
-	if len(fields) < 7 {
+	if len(fields) < 8 {
 		return
 	}
 	sessionID := strings.TrimSpace(fields[4])
-	pane := strings.TrimSpace(fields[5])
+	ledgerPane := strings.TrimSpace(fields[5])
 	cwd := strings.TrimSpace(fields[6])
+	transcript := strings.TrimSpace(fields[7])
 
 	mux := multiplexer.Detect()
-	paneResolved := false
-	if pane == "" {
-		pane = resolvePane(mux, sessionID)
-		paneResolved = pane != ""
-	}
-	switch act := DecideAction(sessionID, pane, cwd); act.Kind {
+
+	switch act := DecideAction(describeTarget(mux, sessionID, ledgerPane, cwd, transcript)); act.Kind {
 	case "switch":
-		if switchErr, terminate := switchTo(mux.Switch, act.Pane, paneResolved); switchErr != nil {
-			fmt.Fprintf(os.Stderr, "switch failed (pane likely gone): %v\n", switchErr)
-			if terminate {
-				if termErr := db.TerminateSession(conn, sessionID); termErr != nil {
-					fmt.Fprintln(os.Stderr, "terminate:", termErr)
-				}
-			}
+		// A failed switch does not terminate the row. Every pane that reaches
+		// here was confirmed present in this server's pane table moments ago
+		// (see reachablePane), so a failure is about the switch itself -- no
+		// client attached, a pane closed in between -- and not evidence that
+		// the session died. Closing rows is reconcile.Sweep's job, and it
+		// decides from the authoritative roster instead of from a guess.
+		if err := mux.Switch(act.Pane); err != nil {
+			fmt.Fprintf(os.Stderr, "switch to %s failed: %v\n", act.Pane, err)
 		}
 	case "attach":
 		// Open the session belonging to the row's worktree, not whichever
@@ -273,9 +411,75 @@ func Run(args []string) {
 		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, []string{"claude", "attach", act.Short}); err != nil {
 			fmt.Fprintf(os.Stderr, "open session failed: %v\nrun: claude attach %s\n", err, act.Short)
 		}
+	case "resume":
+		// Reopen the conversation from its transcript. `claude --resume` keeps
+		// the session id, so the ledger row survives the restart rather than
+		// being replaced by a second one. The full UUID is required: the short
+		// form is what `claude attach` takes, not this.
+		if act.KillPID != 0 {
+			if err := endSession(act.KillPID, act.Resume); err != nil {
+				fmt.Fprintf(os.Stderr, "not resuming: %v\n", err)
+				return
+			}
+		}
+		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, []string{"claude", "--resume", act.Resume}); err != nil {
+			fmt.Fprintf(os.Stderr, "open session failed: %v\nrun: cd %s && claude --resume %s\n", err, act.Cwd, act.Resume)
+		}
 	default:
 		fmt.Fprintln(os.Stderr, act.Reason)
 	}
+}
+
+// describeTarget gathers the state DecideAction routes on: the reachable pane,
+// the live roster's view of the session, and whether the resume preconditions
+// hold on disk.
+//
+// The roster is read once here for both the pane lookup and the routing, since
+// each read costs a subprocess. It is read for the single picked row only: the
+// panes of rows the user did not select are never needed.
+func describeTarget(mux multiplexer.Multiplexer, sessionID, ledgerPane, cwd, transcript string) Target {
+	agents, err := roster.List()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "roster lookup skipped:", err)
+	}
+	pane := reachablePane(mux, agents, sessionID, ledgerPane)
+
+	t := Target{
+		SessionID:      sessionID,
+		Pane:           pane,
+		Cwd:            cwd,
+		TranscriptPath: transcript,
+		RosterOK:       err == nil,
+
+		TranscriptExists: isFile(transcript),
+		CwdExists:        isDir(cwd),
+	}
+	if a, ok := agentFor(agents, sessionID); ok {
+		t.InRoster, t.Kind, t.PID = true, a.Kind, a.PID
+		if pane == "" {
+			// Only asked when the pane is unreachable: that is the one case
+			// where the process's tmux server changes what we may do to it.
+			serverPID, _ := mux.ServerPID()
+			t.Origin = originOf(a.PID, serverPID)
+		}
+	}
+	return t
+}
+
+func isFile(path string) bool {
+	if path == "" {
+		return false
+	}
+	fi, err := os.Stat(path)
+	return err == nil && fi.Mode().IsRegular()
+}
+
+func isDir(path string) bool {
+	if path == "" {
+		return false
+	}
+	fi, err := os.Stat(path)
+	return err == nil && fi.IsDir()
 }
 
 func runFzf(input string) (string, error) {

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -259,14 +259,22 @@ func shortID(sessionID string) string {
 // collision as true. So whenever the roster can identify the session's actual
 // process, its pane is re-derived by walking that process's ancestry
 // (paneForSession) instead -- an identity check the ledger id cannot offer.
-// The ledger pane is used as-is only as a last resort, when the roster has no
-// entry to check identity against (including when it could not be read at
-// all): there is nothing better to fall back to.
-func reachablePane(mux multiplexer.Multiplexer, agents []roster.Agent, sessionID, ledgerPane string) string {
+//
+// The ledger pane is used as-is only when the roster could not be consulted
+// at all (rosterOK is false): there is nothing better to fall back to, and an
+// unreadable roster is not evidence the session ended. It is deliberately
+// NOT used when the roster was read successfully but simply has no entry for
+// sessionID -- that absence is itself evidence the process ended (the same
+// signal reconcile.Sweep acts on), so a ledger pane surviving under a
+// since-replaced server is never that session's pane and trusting it would
+// switch to an unrelated live pane that happens to share the stale id.
+// Returning "" here instead routes DecideAction to the resume path, which is
+// the correct outcome for a session the roster no longer lists.
+func reachablePane(mux multiplexer.Multiplexer, agents []roster.Agent, sessionID, ledgerPane string, rosterOK bool) string {
 	if len(agentsFor(agents, sessionID)) > 0 {
 		return paneForSession(agents, sessionID, mux.FindPane)
 	}
-	if ledgerPane != "" && mux.PaneExists(ledgerPane) {
+	if !rosterOK && ledgerPane != "" && mux.PaneExists(ledgerPane) {
 		return ledgerPane
 	}
 	return ""
@@ -474,7 +482,7 @@ func describeTarget(mux multiplexer.Multiplexer, sessionID, ledgerPane, cwd, tra
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "roster lookup skipped:", err)
 	}
-	pane := reachablePane(mux, agents, sessionID, ledgerPane)
+	pane := reachablePane(mux, agents, sessionID, ledgerPane, err == nil)
 
 	t := Target{
 		SessionID:      sessionID,

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -128,6 +128,17 @@ type Target struct {
 	PID      int
 	Origin   serverOrigin
 
+	// RosterMatches is how many roster entries carry SessionID. `claude agents
+	// --json` has been observed to list the same session id under two pids
+	// (a resume that raced a still-running process onto the same transcript,
+	// which is exactly the state this package must not create). >1 means
+	// identity is ambiguous: acting on "the" pid would pick one of the two
+	// arbitrarily, so DecideAction refuses instead of guessing.
+	RosterMatches int
+	// DuplicatePIDs holds every pid RosterMatches counted, for the "none"
+	// message when RosterMatches > 1.
+	DuplicatePIDs []int
+
 	TranscriptExists bool
 	CwdExists        bool
 }
@@ -176,6 +187,16 @@ func DecideAction(t Target) Action {
 	}
 	if !t.RosterOK {
 		return Action{Kind: "none", Reason: "live agent roster unreadable, so the session may still be running: not resuming"}
+	}
+	if t.RosterMatches > 1 {
+		// The roster already has two processes on this session id -- the
+		// duplicate-transcript state a resume must not create. There is no
+		// single pid a kill or an attach can target without guessing which
+		// entry is the "real" one, so the conservative answer is to leave
+		// both alone and report what was seen.
+		return Action{Kind: "none", Reason: fmt.Sprintf(
+			"session %s appears %d times in the live roster (pids %v): not touching it",
+			shortID(t.SessionID), t.RosterMatches, t.DuplicatePIDs)}
 	}
 	if t.InRoster {
 		if t.Kind == "background" {
@@ -227,34 +248,42 @@ func shortID(sessionID string) string {
 }
 
 // reachablePane returns a pane of the current server the picked row can be
-// switched to, preferring the one the ledger recorded and falling back to
-// re-deriving it from the live process. "" means neither is reachable.
+// switched to. "" means none is reachable.
 //
-// The pane column is not authoritative in either direction. It goes NULL for
-// reasons not yet pinned down, and it also keeps pointing at panes of a tmux
-// server that has since been replaced -- 44 of 48 live rows measured were in
-// that state. So a recorded pane is checked against the server's pane table
-// before being trusted, rather than switched to blind: a failed switch used to
-// be read as "the session died" and closed a row whose session was fine.
-//
-// Walking the process tree recovers the pane where the recorded one is unusable;
-// measured against sessions that did record a valid one, it agrees exactly.
+// The ledger's pane column is never trusted on its own. `PaneExists` is only a
+// membership test against the current server's pane table -- it does not
+// confirm the pane belongs to *this* session -- and tmux pane ids are a
+// per-server counter that a fresh server restarts from %0. A stale id
+// recorded under a since-replaced server therefore collides with an unrelated
+// live pane on the current one almost certainly, and PaneExists reports that
+// collision as true. So whenever the roster can identify the session's actual
+// process, its pane is re-derived by walking that process's ancestry
+// (paneForSession) instead -- an identity check the ledger id cannot offer.
+// The ledger pane is used as-is only as a last resort, when the roster has no
+// entry to check identity against (including when it could not be read at
+// all): there is nothing better to fall back to.
 func reachablePane(mux multiplexer.Multiplexer, agents []roster.Agent, sessionID, ledgerPane string) string {
+	if len(agentsFor(agents, sessionID)) > 0 {
+		return paneForSession(agents, sessionID, mux.FindPane)
+	}
 	if ledgerPane != "" && mux.PaneExists(ledgerPane) {
 		return ledgerPane
 	}
-	return paneForSession(agents, sessionID, mux.FindPane)
+	return ""
 }
 
 // paneForSession is the process-tree lookup itself, taking the pane finder as an
 // argument so the roster-to-pane wiring can be tested without tmux.
+//
+// It tries every roster entry for sessionID, not just the first: `claude
+// agents --json` has been observed to list the same session id twice (see
+// Target.RosterMatches), and stopping at the first entry risks missing the
+// one pid that actually resolves to a pane.
 func paneForSession(agents []roster.Agent, sessionID string, find func(int) (string, bool)) string {
-	a, ok := agentFor(agents, sessionID)
-	if !ok {
-		return ""
-	}
-	if pane, found := find(a.PID); found {
-		return pane
+	for _, a := range agentsFor(agents, sessionID) {
+		if pane, found := find(a.PID); found {
+			return pane
+		}
 	}
 	// The session is live but outside this tmux server (a session that
 	// outlived the server it started in, or a background agent that never had
@@ -263,18 +292,21 @@ func paneForSession(agents []roster.Agent, sessionID string, find func(int) (str
 	return ""
 }
 
-// agentFor finds a session in the roster. Session ids are unique there, so the
-// first match is the only one.
-func agentFor(agents []roster.Agent, sessionID string) (roster.Agent, bool) {
+// agentsFor returns every roster entry for sessionID. Session ids are not
+// guaranteed unique there -- see Target.RosterMatches -- so callers that act
+// on identity (pane resolution, kill, resume) need to see all of them rather
+// than assume the first is the only one.
+func agentsFor(agents []roster.Agent, sessionID string) []roster.Agent {
 	if sessionID == "" {
-		return roster.Agent{}, false
+		return nil
 	}
+	var matches []roster.Agent
 	for _, a := range agents {
 		if a.SessionID == sessionID {
-			return a, true
+			matches = append(matches, a)
 		}
 	}
-	return roster.Agent{}, false
+	return matches
 }
 
 // killPollAttempts and killPollInterval bound the wait for a SIGTERM'd session
@@ -317,7 +349,7 @@ func waitGone(sessionID string, list func() ([]roster.Agent, error), tick func()
 		if err != nil {
 			continue
 		}
-		if _, ok := agentFor(agents, sessionID); !ok {
+		if len(agentsFor(agents, sessionID)) == 0 {
 			return true
 		}
 	}
@@ -454,7 +486,15 @@ func describeTarget(mux multiplexer.Multiplexer, sessionID, ledgerPane, cwd, tra
 		TranscriptExists: isFile(transcript),
 		CwdExists:        isDir(cwd),
 	}
-	if a, ok := agentFor(agents, sessionID); ok {
+	matches := agentsFor(agents, sessionID)
+	t.RosterMatches = len(matches)
+	if t.RosterMatches > 1 {
+		for _, a := range matches {
+			t.DuplicatePIDs = append(t.DuplicatePIDs, a.PID)
+		}
+	}
+	if len(matches) > 0 {
+		a := matches[0]
 		t.InRoster, t.Kind, t.PID = true, a.Kind, a.PID
 		if pane == "" {
 			// Only asked when the pane is unreachable: that is the one case

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -188,6 +188,17 @@ func TestDecideAction(t *testing.T) {
 		kind:  "attach",
 		short: "abc",
 	}, {
+		// `claude agents --json` has been observed to list the same session id
+		// under two pids at once -- the duplicate-transcript state a resume
+		// must not create. There is no single pid to act on without guessing,
+		// so this refuses rather than kill one of the two arbitrarily.
+		name: "duplicate roster entries are not touched",
+		target: withPane(func(tg *Target) {
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originOrphan
+			tg.RosterMatches, tg.DuplicatePIDs = 2, []int{4242, 5252}
+		}),
+		kind: "none",
+	}, {
 		// The one case that may kill: the process provably belongs to a tmux
 		// server no client of ours can reach.
 		name: "orphan interactive session is ended then resumed",
@@ -344,48 +355,93 @@ func (f *fakeMux) FindPane(pid int) (string, bool) {
 func (f *fakeMux) PaneExists(target string) bool { return f.panes[target] }
 func (f *fakeMux) ServerPID() (int, bool)        { return f.serverPID, f.serverPID > 0 }
 
-// The ledger's pane column keeps pointing at panes of tmux servers that have
-// since been replaced, so a recorded pane is only usable if this server still
-// lists it. When it does not, the pane is re-derived from the live process --
-// otherwise a stale pane would be switched to and its failure misread as the
-// session having died.
+// The ledger's pane column is not identity-checked: PaneExists only proves
+// *some* pane on this server has that id, not that it belongs to the picked
+// session. tmux pane ids are a per-server counter that restarts from %0 on a
+// fresh server, so a stale id from a since-replaced server can collide with
+// an unrelated live pane. Whenever the roster can name the session's actual
+// process, its pane is re-derived by walking that process's ancestry instead
+// -- an identity check PaneExists cannot offer -- and the ledger column is
+// used as-is only when the roster has nothing to check identity against.
 func TestReachablePane(t *testing.T) {
-	agents := []roster.Agent{{SessionID: "live", PID: 200, Kind: "interactive"}}
+	live := []roster.Agent{{SessionID: "live", PID: 200, Kind: "interactive"}}
+	dup := []roster.Agent{
+		{SessionID: "dup", PID: 200, Kind: "interactive"},
+		{SessionID: "dup", PID: 201, Kind: "interactive"},
+	}
 
 	cases := []struct {
 		name       string
+		agents     []roster.Agent
 		mux        *fakeMux
 		sessionID  string
 		ledgerPane string
 		want       string
 	}{{
-		name:       "live ledger pane is used as is",
+		// Gate (a): once the roster names the session's process, its
+		// identity-verified pane wins even over a ledger pane that also
+		// exists on this server -- the ledger id may be an unrelated pane
+		// that happens to collide.
+		name:       "roster-verified pane wins over a live ledger pane",
+		agents:     live,
 		mux:        &fakeMux{panes: map[string]bool{"%3": true}, find: map[int]string{200: "%7"}},
 		sessionID:  "live",
 		ledgerPane: "%3",
-		want:       "%3",
+		want:       "%7",
 	}, {
-		// Gate (b): a non-empty pane column is no longer trusted on its own.
 		name:       "stale ledger pane falls back to re-resolution",
+		agents:     live,
 		mux:        &fakeMux{find: map[int]string{200: "%7"}},
 		sessionID:  "live",
 		ledgerPane: "%3",
 		want:       "%7",
 	}, {
-		name:       "stale ledger pane with no live pane resolves to nothing",
-		mux:        &fakeMux{},
+		// The roster names the process but its ancestry resolves to no pane
+		// at all (e.g. it lives on another server). Even though the ledger id
+		// happens to exist on this server, it must not be trusted: the roster
+		// already had identity to check and it did not confirm this pane.
+		name:       "ledger pane collision with an unrelated live pane is not trusted",
+		agents:     live,
+		mux:        &fakeMux{panes: map[string]bool{"%3": true}},
 		sessionID:  "live",
 		ledgerPane: "%3",
 		want:       "",
 	}, {
 		name:      "empty ledger pane re-resolves",
+		agents:    live,
 		mux:       &fakeMux{find: map[int]string{200: "%7"}},
 		sessionID: "live",
 		want:      "%7",
 	}, {
+		// Gate (b): the ledger pane is the fallback of last resort, used only
+		// when the roster has no entry for this session to check identity
+		// against.
+		name:       "session absent from roster falls back to the ledger pane",
+		agents:     live,
+		mux:        &fakeMux{panes: map[string]bool{"%9": true}},
+		sessionID:  "gone",
+		ledgerPane: "%9",
+		want:       "%9",
+	}, {
+		name:       "session absent from roster and ledger pane not on this server",
+		agents:     live,
+		mux:        &fakeMux{},
+		sessionID:  "gone",
+		ledgerPane: "%9",
+		want:       "",
+	}, {
+		// A roster entry duplicated under two pids (see Target.RosterMatches)
+		// must not stop pane resolution at the first pid tried.
+		name:      "duplicate roster entries try every pid for a pane",
+		agents:    dup,
+		mux:       &fakeMux{find: map[int]string{201: "%8"}},
+		sessionID: "dup",
+		want:      "%8",
+	}, {
 		// Nothing to look the process up by, and an empty pane column: the row
 		// is not reachable by any pane.
 		name:       "no session id and no ledger pane",
+		agents:     live,
 		mux:        &fakeMux{find: map[int]string{200: "%7"}},
 		ledgerPane: "",
 		want:       "",
@@ -393,7 +449,7 @@ func TestReachablePane(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := reachablePane(c.mux, agents, c.sessionID, c.ledgerPane); got != c.want {
+			if got := reachablePane(c.mux, c.agents, c.sessionID, c.ledgerPane); got != c.want {
 				t.Errorf("reachablePane = %q, want %q", got, c.want)
 			}
 		})

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -215,6 +215,15 @@ func TestDecideAction(t *testing.T) {
 		}),
 		kind: "none",
 	}, {
+		// A different tmux server pid is not enough: if that server is
+		// confirmed still running, a human may be attached to it from another
+		// terminal (a different socket entirely), so it must not be killed.
+		name: "interactive session on a still-running foreign server is left alone",
+		target: withPane(func(tg *Target) {
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originForeignLive
+		}),
+		kind: "none",
+	}, {
 		// /proc unreadable, TMUX unparseable, or no server pid of our own: the
 		// safe answer is the same as for a session in use elsewhere.
 		name: "unknown origin is left alone",
@@ -362,7 +371,10 @@ func (f *fakeMux) ServerPID() (int, bool)        { return f.serverPID, f.serverP
 // an unrelated live pane. Whenever the roster can name the session's actual
 // process, its pane is re-derived by walking that process's ancestry instead
 // -- an identity check PaneExists cannot offer -- and the ledger column is
-// used as-is only when the roster has nothing to check identity against.
+// used as-is only when the roster itself could not be read (rosterOK is
+// false), never when it was read successfully but simply lists no entry for
+// the session: that absence is evidence the process ended, not a reason to
+// trust a stale id.
 func TestReachablePane(t *testing.T) {
 	live := []roster.Agent{{SessionID: "live", PID: 200, Kind: "interactive"}}
 	dup := []roster.Agent{
@@ -376,6 +388,7 @@ func TestReachablePane(t *testing.T) {
 		mux        *fakeMux
 		sessionID  string
 		ledgerPane string
+		rosterOK   bool
 		want       string
 	}{{
 		// Gate (a): once the roster names the session's process, its
@@ -387,6 +400,7 @@ func TestReachablePane(t *testing.T) {
 		mux:        &fakeMux{panes: map[string]bool{"%3": true}, find: map[int]string{200: "%7"}},
 		sessionID:  "live",
 		ledgerPane: "%3",
+		rosterOK:   true,
 		want:       "%7",
 	}, {
 		name:       "stale ledger pane falls back to re-resolution",
@@ -394,6 +408,7 @@ func TestReachablePane(t *testing.T) {
 		mux:        &fakeMux{find: map[int]string{200: "%7"}},
 		sessionID:  "live",
 		ledgerPane: "%3",
+		rosterOK:   true,
 		want:       "%7",
 	}, {
 		// The roster names the process but its ancestry resolves to no pane
@@ -405,29 +420,46 @@ func TestReachablePane(t *testing.T) {
 		mux:        &fakeMux{panes: map[string]bool{"%3": true}},
 		sessionID:  "live",
 		ledgerPane: "%3",
+		rosterOK:   true,
 		want:       "",
 	}, {
 		name:      "empty ledger pane re-resolves",
 		agents:    live,
 		mux:       &fakeMux{find: map[int]string{200: "%7"}},
 		sessionID: "live",
+		rosterOK:  true,
 		want:      "%7",
 	}, {
 		// Gate (b): the ledger pane is the fallback of last resort, used only
-		// when the roster has no entry for this session to check identity
-		// against.
-		name:       "session absent from roster falls back to the ledger pane",
+		// when the roster itself could not be read -- there is nothing better
+		// to check identity against.
+		name:       "roster unreadable falls back to the ledger pane",
 		agents:     live,
 		mux:        &fakeMux{panes: map[string]bool{"%9": true}},
 		sessionID:  "gone",
 		ledgerPane: "%9",
+		rosterOK:   false,
 		want:       "%9",
+	}, {
+		// The roster was read successfully and simply has no entry for this
+		// session: that is evidence the process ended, not a reason to trust
+		// a ledger pane that may belong to a since-replaced server. "" here
+		// is what routes DecideAction to the resume path instead of a
+		// possibly-unrelated live pane.
+		name:       "roster read but session absent does not use the ledger pane",
+		agents:     live,
+		mux:        &fakeMux{panes: map[string]bool{"%9": true}},
+		sessionID:  "gone",
+		ledgerPane: "%9",
+		rosterOK:   true,
+		want:       "",
 	}, {
 		name:       "session absent from roster and ledger pane not on this server",
 		agents:     live,
 		mux:        &fakeMux{},
 		sessionID:  "gone",
 		ledgerPane: "%9",
+		rosterOK:   false,
 		want:       "",
 	}, {
 		// A roster entry duplicated under two pids (see Target.RosterMatches)
@@ -436,6 +468,7 @@ func TestReachablePane(t *testing.T) {
 		agents:    dup,
 		mux:       &fakeMux{find: map[int]string{201: "%8"}},
 		sessionID: "dup",
+		rosterOK:  true,
 		want:      "%8",
 	}, {
 		// Nothing to look the process up by, and an empty pane column: the row
@@ -444,12 +477,13 @@ func TestReachablePane(t *testing.T) {
 		agents:     live,
 		mux:        &fakeMux{find: map[int]string{200: "%7"}},
 		ledgerPane: "",
+		rosterOK:   true,
 		want:       "",
 	}}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if got := reachablePane(c.mux, c.agents, c.sessionID, c.ledgerPane); got != c.want {
+			if got := reachablePane(c.mux, c.agents, c.sessionID, c.ledgerPane, c.rosterOK); got != c.want {
 				t.Errorf("reachablePane = %q, want %q", got, c.want)
 			}
 		})
@@ -465,7 +499,7 @@ func TestReachablePaneRoutesToSwitch(t *testing.T) {
 
 	tgt := resumable()
 	tgt.InRoster, tgt.Kind, tgt.PID, tgt.Origin = true, "interactive", 200, originOrphan
-	tgt.Pane = reachablePane(mux, agents, testUUID, "%stale")
+	tgt.Pane = reachablePane(mux, agents, testUUID, "%stale", true)
 
 	if act := DecideAction(tgt); act.Kind != "switch" || act.Pane != "%7" {
 		t.Errorf("DecideAction with a re-derived pane = %+v, want switch to %%7", act)

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -19,13 +19,14 @@ func TestFormatLine_AwaitingApproval(t *testing.T) {
 		TmuxPane:       sql.NullString{String: "%1", Valid: true},
 		Cwd:            sql.NullString{String: "/home/x/projects/everysteel-api", Valid: true},
 		EffectiveState: "awaiting_approval",
+		TranscriptPath: sql.NullString{String: "/home/x/.claude/projects/enc/s1.jsonl", Valid: true},
 		Payload:        sql.NullString{String: `{"tool_name":"Bash","tool_input":{"command":"pnpm prisma migrate"}}`, Valid: true},
 		CreatedAt:      nowMinus(120),
 	}
 	got := FormatLine(row, "everysteel-api", nowUnix(), false)
 	fields := strings.Split(got, "\t")
-	if len(fields) != 7 {
-		t.Fatalf("want 7 tab-separated fields, got %d: %q", len(fields), got)
+	if len(fields) != 8 {
+		t.Fatalf("want 8 tab-separated fields, got %d: %q", len(fields), got)
 	}
 	if fields[0] != "⏳" {
 		t.Errorf("icon = %q, want ⏳", fields[0])
@@ -47,6 +48,24 @@ func TestFormatLine_AwaitingApproval(t *testing.T) {
 	}
 	if fields[6] != "/home/x/projects/everysteel-api" {
 		t.Errorf("hidden cwd = %q, want the full path", fields[6])
+	}
+	// The resume path refuses to run without a transcript, so the path has to
+	// reach the pick through this hidden column.
+	if fields[7] != "/home/x/.claude/projects/enc/s1.jsonl" {
+		t.Errorf("hidden transcript_path = %q, want the full path", fields[7])
+	}
+}
+
+// A row the ledger has no transcript for still renders; the column is empty,
+// which is what resumeBlocked reads as "nothing to resume".
+func TestFormatLine_NoTranscript(t *testing.T) {
+	row := db.Row{SessionID: "s3", EffectiveState: "idle_done", CreatedAt: nowMinus(10)}
+	fields := strings.Split(FormatLine(row, "wt", nowUnix(), false), "\t")
+	if len(fields) != 8 {
+		t.Fatalf("want 8 fields, got %d", len(fields))
+	}
+	if fields[7] != "" {
+		t.Errorf("hidden transcript_path = %q, want empty", fields[7])
 	}
 }
 
@@ -92,35 +111,182 @@ func TestFormatAge(t *testing.T) {
 	}
 }
 
-// A background session has no tmux pane, so the picker cannot switch to it --
-// it has to open the session with `claude attach` instead. These cases pin the
-// routing, which is the only part with branching worth testing; the exec calls
-// themselves are one-liners in the multiplexer.
+const testUUID = "61c846eb-8205-4a8e-8a0d-7772410051c9"
+
+// resumable is a Target whose resume preconditions all hold, so each case below
+// can state only the field it is about.
+func resumable() Target {
+	return Target{
+		SessionID:        testUUID,
+		Cwd:              "/w/a",
+		TranscriptPath:   "/t/a.jsonl",
+		RosterOK:         true,
+		TranscriptExists: true,
+		CwdExists:        true,
+	}
+}
+
+// DecideAction is the whole routing rule, and every one of its branches decides
+// whether a live process gets a SIGTERM -- so all of them are covered here
+// rather than only the interesting ones. The exec calls they route to are
+// one-liners in the multiplexer.
 func TestDecideAction(t *testing.T) {
-	const uuid = "61c846eb-8205-4a8e-8a0d-7772410051c9"
-
-	got := DecideAction(uuid, "%12", "/w/a")
-	if got.Kind != "switch" || got.Pane != "%12" {
-		t.Errorf("with a pane: got %+v, want switch to %%12", got)
+	withPane := func(f func(*Target)) Target {
+		tgt := resumable()
+		f(&tgt)
+		return tgt
 	}
 
-	// `claude attach` only accepts the 8-char short id; passing the full UUID
-	// fails with "No job matching".
-	got = DecideAction(uuid, "", "/w/a")
-	if got.Kind != "attach" || got.Short != "61c846eb" || got.Cwd != "/w/a" {
-		t.Errorf("without a pane: got %+v, want attach 61c846eb in /w/a", got)
-	}
+	cases := []struct {
+		name    string
+		target  Target
+		kind    string
+		short   string
+		pane    string
+		resume  string
+		killPID int
+	}{{
+		// A reachable pane wins over everything else: the session is right there.
+		name:   "reachable pane switches",
+		target: withPane(func(tg *Target) { tg.Pane = "%12" }),
+		kind:   "switch",
+		pane:   "%12",
+	}, {
+		// Even a live interactive session on another server: if its pane came
+		// back reachable, nothing may be killed.
+		name: "reachable pane beats an orphan process",
+		target: withPane(func(tg *Target) {
+			tg.Pane, tg.InRoster, tg.Kind, tg.PID, tg.Origin = "%12", true, "interactive", 4242, originOrphan
+		}),
+		kind: "switch",
+		pane: "%12",
+	}, {
+		name:   "no session id is not actionable",
+		target: withPane(func(tg *Target) { tg.SessionID = "" }),
+		kind:   "none",
+	}, {
+		// An unreadable roster is not evidence the process ended, and resuming
+		// a live session puts two of them on one transcript.
+		name:   "unreadable roster refuses to resume",
+		target: withPane(func(tg *Target) { tg.RosterOK = false }),
+		kind:   "none",
+	}, {
+		// `claude attach` only accepts the 8-char short id; the full UUID
+		// fails with "No job matching".
+		name: "background session attaches by short id",
+		target: withPane(func(tg *Target) {
+			tg.InRoster, tg.Kind, tg.PID = true, "background", 100
+		}),
+		kind:  "attach",
+		short: "61c846eb",
+	}, {
+		// Short ids that are already <= 8 chars must not be sliced out of range.
+		name: "short session id is not truncated",
+		target: withPane(func(tg *Target) {
+			tg.SessionID, tg.InRoster, tg.Kind, tg.PID = "abc", true, "background", 100
+		}),
+		kind:  "attach",
+		short: "abc",
+	}, {
+		// The one case that may kill: the process provably belongs to a tmux
+		// server no client of ours can reach.
+		name: "orphan interactive session is ended then resumed",
+		target: withPane(func(tg *Target) {
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originOrphan
+		}),
+		kind:    "resume",
+		resume:  testUUID,
+		killPID: 4242,
+	}, {
+		name: "session started outside tmux is left alone",
+		target: withPane(func(tg *Target) {
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originOutside
+		}),
+		kind: "none",
+	}, {
+		// /proc unreadable, TMUX unparseable, or no server pid of our own: the
+		// safe answer is the same as for a session in use elsewhere.
+		name: "unknown origin is left alone",
+		target: withPane(func(tg *Target) {
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originUnknown
+		}),
+		kind: "none",
+	}, {
+		name: "same-server session with a closed pane is left alone",
+		target: withPane(func(tg *Target) {
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originCurrent
+		}),
+		kind: "none",
+	}, {
+		name: "orphan with no pid cannot be ended, so is left alone",
+		target: withPane(func(tg *Target) {
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 0, originOrphan
+		}),
+		kind: "none",
+	}, {
+		// Nothing to displace, so no kill: this is the plain resume.
+		name:   "session absent from the roster resumes directly",
+		target: resumable(),
+		kind:   "resume",
+		resume: testUUID,
+	}, {
+		name:   "no recorded transcript blocks the resume",
+		target: withPane(func(tg *Target) { tg.TranscriptPath, tg.TranscriptExists = "", false }),
+		kind:   "none",
+	}, {
+		// Short-lived sessions never write a jsonl, so a recorded path is only
+		// half the check. `claude --resume` with an id it cannot find starts an
+		// empty session under that id instead of failing.
+		name:   "transcript missing on disk blocks the resume",
+		target: withPane(func(tg *Target) { tg.TranscriptExists = false }),
+		kind:   "none",
+	}, {
+		name:   "no recorded cwd blocks the resume",
+		target: withPane(func(tg *Target) { tg.Cwd, tg.CwdExists = "", false }),
+		kind:   "none",
+	}, {
+		// A reaped worktree takes the cwd resume resolves transcripts against.
+		name:   "reaped cwd blocks the resume",
+		target: withPane(func(tg *Target) { tg.CwdExists = false }),
+		kind:   "none",
+	}, {
+		// The preconditions gate the kill path too: an orphan whose transcript
+		// is gone must not be killed for a resume that cannot happen.
+		name: "orphan with no transcript is not killed",
+		target: withPane(func(tg *Target) {
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originOrphan
+			tg.TranscriptExists = false
+		}),
+		kind: "none",
+	}}
 
-	// A row with neither a pane nor a usable id is not actionable.
-	got = DecideAction("", "", "/w/a")
-	if got.Kind != "none" || got.Reason == "" {
-		t.Errorf("empty session id: got %+v, want none with a reason", got)
-	}
-
-	// Short ids that are already <= 8 chars must not be sliced out of range.
-	got = DecideAction("abc", "", "")
-	if got.Kind != "attach" || got.Short != "abc" {
-		t.Errorf("short session id: got %+v, want attach abc", got)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := DecideAction(c.target)
+			if got.Kind != c.kind {
+				t.Fatalf("Kind = %q, want %q (%+v)", got.Kind, c.kind, got)
+			}
+			if got.Pane != c.pane {
+				t.Errorf("Pane = %q, want %q", got.Pane, c.pane)
+			}
+			if got.Short != c.short {
+				t.Errorf("Short = %q, want %q", got.Short, c.short)
+			}
+			if got.Resume != c.resume {
+				t.Errorf("Resume = %q, want %q", got.Resume, c.resume)
+			}
+			if got.KillPID != c.killPID {
+				t.Errorf("KillPID = %d, want %d", got.KillPID, c.killPID)
+			}
+			if c.kind == "none" && got.Reason == "" {
+				t.Error("none without a reason: the pick would look like a no-op")
+			}
+			if c.kind == "attach" || c.kind == "resume" {
+				if got.Cwd != c.target.Cwd {
+					t.Errorf("Cwd = %q, want %q", got.Cwd, c.target.Cwd)
+				}
+			}
+		})
 	}
 }
 
@@ -158,41 +324,146 @@ func TestPaneForSession(t *testing.T) {
 	}
 }
 
-// The resolved pane has to reach DecideAction as if it had come from the ledger,
-// so the pick lands on the switch path. This pins the composition the wiring in
-// Run relies on.
-func TestResolvedPaneRoutesToSwitch(t *testing.T) {
-	agents := []roster.Agent{{SessionID: "live", PID: 200, Kind: "interactive"}}
-	find := func(int) (string, bool) { return "%7", true }
+// fakeMux is a Multiplexer whose pane answers are set per test. Only the
+// lookups reachablePane makes are wired; Switch and OpenSession are the exec
+// one-liners this package does not test.
+type fakeMux struct {
+	panes     map[string]bool // PaneExists
+	find      map[int]string  // FindPane
+	serverPID int             // ServerPID; 0 means "no server"
+}
 
-	pane := paneForSession(agents, "live", find)
-	if act := DecideAction("live", pane, "/w/a"); act.Kind != "switch" || act.Pane != "%7" {
-		t.Errorf("DecideAction with a resolved pane = %+v, want switch to %%7", act)
-	}
-	// Without the resolution the same row goes to attach, which is the bug.
-	if act := DecideAction("live", "", "/w/a"); act.Kind != "attach" {
-		t.Errorf("DecideAction without a pane = %+v, want attach", act)
+func (f *fakeMux) PaneID() string                                 { return "" }
+func (f *fakeMux) RefreshStatus()                                 {}
+func (f *fakeMux) Switch(target string) error                     { return nil }
+func (f *fakeMux) OpenSession(name, cwd string, a []string) error { return nil }
+func (f *fakeMux) FindPane(pid int) (string, bool) {
+	pane, ok := f.find[pid]
+	return pane, ok
+}
+func (f *fakeMux) PaneExists(target string) bool { return f.panes[target] }
+func (f *fakeMux) ServerPID() (int, bool)        { return f.serverPID, f.serverPID > 0 }
+
+// The ledger's pane column keeps pointing at panes of tmux servers that have
+// since been replaced, so a recorded pane is only usable if this server still
+// lists it. When it does not, the pane is re-derived from the live process --
+// otherwise a stale pane would be switched to and its failure misread as the
+// session having died.
+func TestReachablePane(t *testing.T) {
+	agents := []roster.Agent{{SessionID: "live", PID: 200, Kind: "interactive"}}
+
+	cases := []struct {
+		name       string
+		mux        *fakeMux
+		sessionID  string
+		ledgerPane string
+		want       string
+	}{{
+		name:       "live ledger pane is used as is",
+		mux:        &fakeMux{panes: map[string]bool{"%3": true}, find: map[int]string{200: "%7"}},
+		sessionID:  "live",
+		ledgerPane: "%3",
+		want:       "%3",
+	}, {
+		// Gate (b): a non-empty pane column is no longer trusted on its own.
+		name:       "stale ledger pane falls back to re-resolution",
+		mux:        &fakeMux{find: map[int]string{200: "%7"}},
+		sessionID:  "live",
+		ledgerPane: "%3",
+		want:       "%7",
+	}, {
+		name:       "stale ledger pane with no live pane resolves to nothing",
+		mux:        &fakeMux{},
+		sessionID:  "live",
+		ledgerPane: "%3",
+		want:       "",
+	}, {
+		name:      "empty ledger pane re-resolves",
+		mux:       &fakeMux{find: map[int]string{200: "%7"}},
+		sessionID: "live",
+		want:      "%7",
+	}, {
+		// Nothing to look the process up by, and an empty pane column: the row
+		// is not reachable by any pane.
+		name:       "no session id and no ledger pane",
+		mux:        &fakeMux{find: map[int]string{200: "%7"}},
+		ledgerPane: "",
+		want:       "",
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := reachablePane(c.mux, agents, c.sessionID, c.ledgerPane); got != c.want {
+				t.Errorf("reachablePane = %q, want %q", got, c.want)
+			}
+		})
 	}
 }
 
-// A failed switch to a resolved pane (paneResolved=true) must not terminate
-// the row: the pane was just confirmed live via the process roster, so the
-// failure says nothing about the session. Only a failed switch to the
-// ledger-recorded pane (paneResolved=false) still warrants it -- that pane's
-// staleness is exactly what the failure is diagnosing. This pins the fix in
-// commit 41eaf2f, which regressed on a live session being terminated after a
-// resolved pane's switch failed.
-func TestSwitchTo(t *testing.T) {
-	failing := func(string) error { return errors.New("no such pane") }
-	okay := func(string) error { return nil }
+// The re-derived pane has to reach DecideAction as if it had come from the
+// ledger, so the pick lands on the switch path rather than on a resume that
+// would kill a session whose pane is right here.
+func TestReachablePaneRoutesToSwitch(t *testing.T) {
+	agents := []roster.Agent{{SessionID: testUUID, PID: 200, Kind: "interactive"}}
+	mux := &fakeMux{find: map[int]string{200: "%7"}}
 
-	if err, terminate := switchTo(failing, "%9", true); err == nil || terminate {
-		t.Errorf("failed switch to a resolved pane: err=%v terminate=%v, want non-nil err, terminate=false", err, terminate)
+	tgt := resumable()
+	tgt.InRoster, tgt.Kind, tgt.PID, tgt.Origin = true, "interactive", 200, originOrphan
+	tgt.Pane = reachablePane(mux, agents, testUUID, "%stale")
+
+	if act := DecideAction(tgt); act.Kind != "switch" || act.Pane != "%7" {
+		t.Errorf("DecideAction with a re-derived pane = %+v, want switch to %%7", act)
 	}
-	if err, terminate := switchTo(failing, "%9", false); err == nil || !terminate {
-		t.Errorf("failed switch to a ledger pane: err=%v terminate=%v, want non-nil err, terminate=true", err, terminate)
-	}
-	if err, terminate := switchTo(okay, "%9", false); err != nil || terminate {
-		t.Errorf("successful switch: err=%v terminate=%v, want nil err, terminate=false", err, terminate)
-	}
+}
+
+// The wait after a SIGTERM is what keeps a resume from opening a transcript the
+// dying process is still flushing. It has to be sure the session ended, so an
+// unreadable roster counts as "still there" rather than as "gone".
+func TestWaitGone(t *testing.T) {
+	present := []roster.Agent{{SessionID: "s", PID: 1}}
+	rosterErr := errors.New("claude agents --json: exit 1")
+
+	t.Run("absent immediately", func(t *testing.T) {
+		ticks := 0
+		ok := waitGone("s", func() ([]roster.Agent, error) { return nil, nil }, func() { ticks++ }, 5)
+		if !ok || ticks != 1 {
+			t.Errorf("got (%v, %d ticks), want (true, 1 tick)", ok, ticks)
+		}
+	})
+
+	t.Run("leaves partway through", func(t *testing.T) {
+		reads := 0
+		list := func() ([]roster.Agent, error) {
+			reads++
+			if reads < 3 {
+				return present, nil
+			}
+			return nil, nil
+		}
+		if !waitGone("s", list, func() {}, 5) {
+			t.Error("waitGone = false, want true once the session leaves the roster")
+		}
+	})
+
+	t.Run("never leaves", func(t *testing.T) {
+		ticks := 0
+		ok := waitGone("s", func() ([]roster.Agent, error) { return present, nil }, func() { ticks++ }, 4)
+		if ok || ticks != 4 {
+			t.Errorf("got (%v, %d ticks), want (false, 4 ticks)", ok, ticks)
+		}
+	})
+
+	t.Run("unreadable roster is not proof of death", func(t *testing.T) {
+		if waitGone("s", func() ([]roster.Agent, error) { return nil, rosterErr }, func() {}, 3) {
+			t.Error("waitGone = true on an unreadable roster, want false")
+		}
+	})
+
+	// Another session leaving does not stand in for this one.
+	t.Run("other sessions do not count", func(t *testing.T) {
+		other := []roster.Agent{{SessionID: "t", PID: 2}}
+		if !waitGone("s", func() ([]roster.Agent, error) { return other, nil }, func() {}, 2) {
+			t.Error("waitGone = false when only another session is listed, want true")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

picker が「tmux pane に到達できない session」へ `claude --resume` で到達できるようにする。PR #54 の続きで、そこで gate に残した medium 3 件も畳む。

`DecideAction` を `Target` 入力の純関数に組み替え、到達手段を次の順で決める。

1. 到達できる pane があれば `tmux switch-client`
2. roster に居て `kind == background` なら `claude attach <short-id>`
3. roster に居て `kind == interactive` で pane に到達できない場合、**別 tmux server 上にあると確定したときだけ** SIGTERM 後に `claude --resume <full-uuid>`。確定できなければ kill せず「別端末で使用中の可能性」を出して終わる
4. roster に居なければそのまま `claude --resume`
5. transcript / cwd が実在しなければ resume せず、どちらが欠けたかを出して終わる

判断は 3 つの純関数に切り出してある（`DecideAction` / `classifyOrigin` / `resumeBlocked`）。exec を伴う収集は `describeTarget` 側に寄せ、`DecideAction` の全経路を table-driven test で covering した。

### orphan 判定

`/proc/<pid>/environ` の `TMUX=<socket>,<serverpid>,<n>` から socket path と server pid を取り、
現行 server の pid と比較する。判定は 5 状態に分かれ、**kill を許すのは orphan だけ**である。

- `TMUX` が無い → tmux 外で起動。kill しない
- server pid が現行と一致 → 現行 server 上（pane だけが消えている）。kill しない
- server pid が異なり、**その socket の現所有者が記録された server pid** → 別 server がまだ
  自分の socket を持っており、別端末から attach されて使用中でありうる。kill しない
- server pid が異なり、socket の所有者が別プロセスに替わっている → **orphan**。到達手段が無い
  ことが確定するので kill を許す
- `/proc` が読めない・`TMUX` が unparseable・比較相手が取れない → 判定不能。kill しない

server の生死では測らない。実測で旧 server は生存したまま socket だけが新 server へ移っており、
生死で測ると到達不能な 54 件すべてが kill 不可に落ちて機能が空振りする。socket の所有権が
「その server にまだ到達できるか」を直接表す。

server pid は末尾から 2 番目の comma-separated field として取るので、socket path に comma が
あってもずれない。

残余リスク: socket の明け渡し前から attach 済みの client が居る場合、orphan と判定した server
にも人間が到達できている可能性がある。

### kill

roster が持つ pid へ SIGTERM を送り、roster から消えるまで 0.5 秒間隔で最大 10 秒 poll する。消えなければ resume せず理由を報告して終わる。SIGKILL へは上げない。roster の読み取り失敗は「まだ居る」として扱う（読めないことは死んだ証拠ではないため）。

### gate 残件 (b)(c)

`tmux_pane` 列が非空でも、現行 server の pane 表に実在しなければ再解決へフォールバックする。(c)（tmux 外で `--resume` した session が stale pane 付きで復活しうる）はこの対処に含まれる — pane 列の値をそのまま信じる経路が無くなるため。

あわせて switch 失敗時の `TerminateSession` を落とした。switch する pane は直前に pane 表で実在を確認済みなので、失敗は switch 側の事情（client 不在など）であって session が死んだ証拠にならない。これは PR #54 が resolved pane について直したのと同じ理由が ledger pane 側にも成立するようになったため。row を閉じるのは `reconcile.Sweep` だけになり、判断は roster という一次情報からのみ行われる。

## Why

実測で確定した前提（本 PR の設計はこれに従っている）:

- `claude attach` / `claude stop` は background session 専用。interactive に投げると `No job matching <id>` で exit 1 する
- `tmux new-window` は中で走らせたコマンドが失敗しても exit 0。window が即閉じても呼び出し側はエラーを検出できない（silent failure）。**これが「pane に到達できない interactive session を pick すると無反応に見える」の正体**
- `claude --resume <uuid>` は session id を変えず会話を完全復元する。逆に元プロセスが生きたまま resume すると同一 transcript を 2 プロセスが掴む
- 存在しない UUID を `--resume` に渡してもエラーにならず、その id で空の新規 session が立つ。だから resume 前の transcript 実在確認が必須
- 短命 session は jsonl を書かないため、DB に `transcript_path` があってもファイルが無いことがある（実測 12 行中 3 件）。reap 済み worktree の session は cwd が消えていて resume できない（同 3 件）
- 現行の実データでは live 48 行のうち 44 行が「プロセスは生きているが pane が別の tmux server にある」状態。ledger の pane 列を信じる経路を残せない理由がこれ

`originOf` は実プロセスに対しても確認した。現行 server pid 4186831 に対し roster 71 件を分類すると、orphan 54 件 / 現行 server 上（pane 消滅）12 件 / tmux 外 5 件 / 別 server が socket を保持したまま生存 0 件となる。server の生死で測る規則なら旧 server 4129653 が生存しているため 54 件すべてが対象外に落ちる（検証は一時テストで行い commit していない）。

## この PR でやらないこと

- 再起動後の terminated 行を picker に出すこと（次の PR）
- SIGKILL へのエスカレーション
- 解決した pane を DB へ書き戻すこと

## テストについて

`DecideAction` は signature ごと変わったため、追加したテストを修正前のコードへそのまま掛けて落ちることを示す形にはできない（コンパイルが通らない）。代わりに新旧の挙動差を明示しておく: 修正前は pane を持たない interactive session が `attach` に routing され、それが silent failure の原因だった。追加した table のうち `orphan interactive session is ended then resumed` / `session absent from the roster resumes directly` / `session started outside tmux is left alone` がその routing を置き換えている。

**実機の kill 検証は本 PR に含まれない**（live session を実際に kill するため、別途 1 件だけ手で行う）。含まれるのは純関数のテストと、上記の read-only な orphan 分類の確認まで。

## Refs

- PR #54（pane 再解決 / switch 失敗で terminate しない修正）の続き
- `src/claude-queue/README.md` の「picker の到達手段」節、`docs/design/claude-tmux-worktree.md` の「③との噛み合わせ」を新挙動に追随させた

