### PR TITLE
feat(claude-queue): 再起動で閉じられた session を picker から resume できるようにする

### DIFF
--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -209,13 +209,22 @@ GC 保持期間ぶんの終了済み row を抱えて使いにくくなるのを
 
 resume できるかの確認を SQL と Go に分けるのは、条件の半分がファイルシステム側にあるため。
 transcript が記録されていても短命 session は jsonl を書かず、cwd は reap 済み worktree なら消えて
-いる。確認を欠いた `--resume` はエラーにならず空 session を作るので、**列挙の時点で**落としておく
-必要がある。案内に出す候補数もこの確認を通したあとの数にする — でなければ、実際には resume
-できない row を数えて勧めることになる。
+いる。確認を欠いた `--resume` はエラーにならず空 session を作るので、選択時ではなく**列挙の時点で**
+落とす。案内に出す候補数も同じ確認を通したあとの数にする — でなければ、実際には resume できない
+row を数えて勧めることになる。
 
 live な row が 0 件のときに候補数と flag を stderr に出すのは、再起動直後がまさにその状態で、
-popup の中には flag を知る経路が無いからである。既定 off の機能は、必要になる瞬間に自分から
-名乗らないと無いのと同じになる。
+popup の中には flag を知る経路が無いからである。ただし `display-popup -E` は command の exit で
+popup を閉じるため、この案内が読めるのは picker をシェルから直接起動した場合に限られる。既存の
+`no active sessions` も同じ構造だが、読ませる前提の操作案内をそこに置いたのはこの変更が最初なので、
+到達性は未解決の論点として残る。
+
+`tmux_pane` を resumable な row では運ばないのは、ledger がこの列を終了時にクリアしないためである。
+pane id は tmux server 単位のカウンタで新しい server は `%0` から振り直すので、終了したプロセスの
+pane id は再起動後の server では無関係な live pane に衝突する。picker は roster が読めないときだけ
+ledger の pane を信用する（roster が読めないことは session の死の証拠にならないから）が、
+`terminated_at` で選んだ row にはその前提が成り立たない — 死んでいる証拠を別に持っているので、
+信用すると会話の復元ではなく他人の pane への switch になる。
 
 ### ④は **メイン** toplevel 基準でパスを作る
 

--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -80,7 +80,8 @@ worktree dir は ghq 配下の兄弟ディレクトリとして `ghq list` に�
   `$TMUX_PANE` をキーに状態を SQLite（`~/.claude/session-queue.db`）へ記録
 - tmux `status-right` に `claude-queue status`（working/awaiting_approval/idle_done のカウント）
 - `C-q q` で popup → fzf picker → 選択 session へ到達（pane への `tmux switch-client` / `claude attach` /
-  `claude --resume` を後述の順で選ぶ）
+  `claude --resume` を後述の順で選ぶ）。`C-q Q` は絞り込みを外し、working / stale と、終了済みだが
+  resume で拾い直せる row（`--show-resumable`）も出す
 - **L3 自己修復**: 新規 `SessionStart` 時、同一 `$TMUX_PANE` 上の生存 session を `ForcedEnd`
   （`/exit`・`/clear` で `SessionEnd` が飛ばないバグの後始末）
 
@@ -193,6 +194,28 @@ uuid を `--resume` に渡してもエラーにはならず、その id で空�
 flag レベルの詳細（`-d` の要否が経路で逆になる理由、`-t` の `=` 接頭辞・末尾 `:`・`-S` による window
 再利用）は `internal/multiplexer/tmux.go` のコメントに一本化してあるので、そちらを参照
 （README.md は挙動レベルの説明に留め、flag レベルは書かない）。
+
+### 終了済み row は view を広げず別クエリで拾う
+
+ホストが落ちると全 session が閉じ、`queue` view（`terminated_at IS NULL`）は空になる。会話 jsonl は
+残っているので resume で戻せるが、そのために view の絞り込みを緩めることはしない。view は
+「今どこかで動いている session」の定義であり、status-right のカウントも reconcile も L3 自己修復も
+その定義に乗っている。終了済みを混ぜると、生きている session の数を数える手段が消える。
+
+代わりに終了済み側だけを別クエリ（`db.ResumableCandidates`）で引き、`resumable` という擬似 state を
+付けて live な row の後ろへ並べる。既定 off の `--show-resumable` に閉じるのは、平常時の picker が
+GC 保持期間ぶんの終了済み row を抱えて使いにくくなるのを避けるため。判定条件と並び順は README.md
+「終了済み session の掘り起こし」節に一本化してある。
+
+resume できるかの確認を SQL と Go に分けるのは、条件の半分がファイルシステム側にあるため。
+transcript が記録されていても短命 session は jsonl を書かず、cwd は reap 済み worktree なら消えて
+いる。確認を欠いた `--resume` はエラーにならず空 session を作るので、**列挙の時点で**落としておく
+必要がある。案内に出す候補数もこの確認を通したあとの数にする — でなければ、実際には resume
+できない row を数えて勧めることになる。
+
+live な row が 0 件のときに候補数と flag を stderr に出すのは、再起動直後がまさにその状態で、
+popup の中には flag を知る経路が無いからである。既定 off の機能は、必要になる瞬間に自分から
+名乗らないと無いのと同じになる。
 
 ### ④は **メイン** toplevel 基準でパスを作る
 

--- a/dot/tmux.conf
+++ b/dot/tmux.conf
@@ -35,4 +35,4 @@ set -g status-interval 5
 set -g status-right '#(claude-queue status) | #[fg=black,bold]#S#[default] | %H:%M'
 set -g status-right-length 80
 bind-key q display-popup -E -w 80% -h 60% "claude-queue picker"
-bind-key Q display-popup -E -w 80% -h 60% "claude-queue picker --show-working --show-stale"
+bind-key Q display-popup -E -w 80% -h 60% "claude-queue picker --show-working --show-stale --show-resumable"

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -39,7 +39,7 @@ make install
 |---|---|
 | `claude-queue hook <event>` | stdin JSON を受け取り SQLite に状態書き込み（Claude Code hook 経由で呼ばれる） |
 | `claude-queue status` | tmux status-right 用のカウンタ文字列を stdout に出力 |
-| `claude-queue picker` | fzf を popup で起動し、選択 session へ到達する（到達手段の決定は後述） |
+| `claude-queue picker` | fzf を popup で起動し、選択 session へ到達する（到達手段の決定は後述）。`--show-working` / `--show-stale` / `--show-resumable` で一覧を広げる |
 | `claude-queue reconcile` | `claude agents --json` に載っていない生存扱いの row を terminated にする（picker 起動時に自動実行される） |
 | `claude-queue reset [--force]` | DB (`~/.claude/session-queue.db`) を削除、対話 y/N |
 | `claude-queue --version` | バージョン表示 |
@@ -49,7 +49,7 @@ make install
 | Var | 意味 |
 |---|---|
 | `CLAUDE_QUEUE_DB` | DB パス override（既定 `~/.claude/session-queue.db`） |
-| `CLAUDE_QUEUE_ASCII=1` | アイコンを ASCII フォールバック `[!] [.] [*] [X]` に切替 |
+| `CLAUDE_QUEUE_ASCII=1` | アイコンを ASCII フォールバック `[!] [.] [*] [X] [~]` に切替 |
 | `CLAUDE_QUEUE_DEBUG=1` | エラーを `~/.claude/session-queue.log` に追記 |
 
 ### picker の到達手段
@@ -92,6 +92,37 @@ make install
 session 名 = worktree ディレクトリ名（`gts` / `claude-worktree` と同じ慣習）。popup を開いた
 時点の current session には作らない。
 
+### 終了済み session の掘り起こし（`--show-resumable`）
+
+ホスト再起動などで session が全部閉じると `queue` view は空になる（`terminated_at IS NULL`
+で絞るため）が、会話 jsonl は残っており `claude --resume <uuid>` で復元できる。`--show-resumable`
+はこの「terminated だが resume で拾い直せる row」を一覧に加える。既定 off、`C-q Q` 側だけに付ける。
+
+対象になる条件は 5 つで、SQL 側（`db.ResumableCandidates`）と Go 側（`picker.filterResumable`）に
+分かれる。
+
+- `terminated_at` がセット済みで、最後の event が `ended`
+- 最後の event が `SessionEnd` かつ payload の `reason` が `prompt_input_exit` **でない**。
+  `prompt_input_exit` は人が REPL を区切りで閉じた end なので除く。signal 経由の end（SIGTERM /
+  `claude stop` / ホスト停止）と、reconcile が合成した `ForcedEnd`（payload を持たない）が残る
+- `transcript_path` と `cwd` がどちらも記録済みで、**実際にファイル／ディレクトリとして存在する**。
+  短命 session は jsonl を書かず、reap 済み worktree は cwd が消えているため、記録の有無だけでは
+  足りない（存在しない uuid の `--resume` は空 session を作ってしまう）
+
+並び順は live な row の全部より後ろ。resumable 同士では、終了直前の state が `working` /
+`awaiting_approval` だったもの（作業途中で落ちた可能性が高い）を先に出し、その中では新しい順。
+summary は `resumable (was working)` のように終了直前の state を出す — payload には end の
+reason しか無く、raw state は全部 `ended` なので、row を見分けられるのはここだけ。
+
+**live な row が 0 件のときは、resumable の候補数と flag を stderr に出す。** 再起動直後は
+まさにこの状態で、popup の中から flag の存在に気づく経路が無いため。拾える窓は auto-GC の
+保持期間（7 日）と同じ。
+
+選択したときの到達手段は上の一覧と同じで、resumable 専用の分岐は無い。プロセスはもう無いので
+通常は「roster に居ない session の直接 resume」に落ちるが、reconcile が早めに閉じた等で実際には
+生きていた場合は roster を見て既存のロジック（switch / attach / orphan なら kill してから resume）に
+そのまま乗る。
+
 ## State machine
 
 | hook event | state |
@@ -104,6 +135,9 @@ session 名 = worktree ディレクトリ名（`gts` / `claude-worktree` と同�
 | `SessionEnd` | ended（view から除外） |
 
 Stale 閾値: working > 8h / awaiting_approval > 2h / idle_done > 4h 経過。
+
+`ended` は view から外れるが、`--show-resumable` はこの外れた row を別クエリで拾い直して
+`resumable` という擬似 state で並べる（前述）。hook が書く state ではない。
 
 ## L3 自己修復
 
@@ -121,9 +155,11 @@ events を削除。
 set -g status-interval 5
 set -g status-right '#(claude-queue status) | %H:%M'
 bind-key q display-popup -E -w 80% -h 60% "claude-queue picker"
+bind-key Q display-popup -E -w 80% -h 60% "claude-queue picker --show-working --show-stale --show-resumable"
 ```
 
-prefix (`C-q`) のあと `q` で popup → fzf → Enter でジャンプ。
+prefix (`C-q`) のあと `q` で popup → fzf → Enter でジャンプ。`Q` は絞り込みを外した全部入り
+（working / stale / resumable も出す）。
 
 ## Troubleshooting
 
@@ -153,6 +189,10 @@ PR 作成時に description に貼って確認：
 - [ ] tmux 外で起動した（`TMUX` を持たない）interactive session を picker から選ぶと、kill されず「別端末で使用中の可能性」の理由が出る
 - [ ] transcript が無い / cwd が reap 済みの session を picker から選ぶと、resume されずどちらが欠けたかが出る
 - [ ] `SessionEnd` 後に `claude --resume` した session が picker に再び現れる
+- [ ] ホスト再起動後（live 0 件）に `C-q q` を開くと、resumable の候補数と `--show-resumable` を案内する stderr が出る
+- [ ] `C-q Q` で resumable な row が live な row の後ろに並び、終了直前が `working` / `awaiting_approval` のものが先頭に来る
+- [ ] resumable な row を選ぶと同じ session id のまま会話が復元される（kill 段階を経ずに resume される）
+- [ ] `/exit` で閉じた session（`reason: prompt_input_exit`）は `--show-resumable` でも出ない
 - [ ] 同 pane で `/clear` 後、旧 session が view から消える（L3）
 - [ ] `CLAUDE_QUEUE_ASCII=1` で `[!]1` 等に切替
 - [ ] 2 pane 並行で approve 連打、busy_timeout 超過しない

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -98,25 +98,33 @@ session 名 = worktree ディレクトリ名（`gts` / `claude-worktree` と同�
 で絞るため）が、会話 jsonl は残っており `claude --resume <uuid>` で復元できる。`--show-resumable`
 はこの「terminated だが resume で拾い直せる row」を一覧に加える。既定 off、`C-q Q` 側だけに付ける。
 
-対象になる条件は 5 つで、SQL 側（`db.ResumableCandidates`）と Go 側（`picker.filterResumable`）に
-分かれる。
+対象になる条件は、SQL 側（`db.ResumableCandidates`）と Go 側（`picker.filterResumable`）に分かれる。
+後者がファイルシステムを見る必要があるため。
 
-- `terminated_at` がセット済みで、最後の event が `ended`
-- 最後の event が `SessionEnd` かつ payload の `reason` が `prompt_input_exit` **でない**。
-  `prompt_input_exit` は人が REPL を区切りで閉じた end なので除く。signal 経由の end（SIGTERM /
+SQL 側:
+
+- `terminated_at` がセット済み
+- 最後の event が `ended`（`SessionEnd` または `ForcedEnd`）
+- その event が `SessionEnd` なら payload の `reason` が `prompt_input_exit` **でない**。
+  `prompt_input_exit` は人が REPL を区切りで閉じた end。signal 経由の end（SIGTERM /
   `claude stop` / ホスト停止）と、reconcile が合成した `ForcedEnd`（payload を持たない）が残る
-- `transcript_path` と `cwd` がどちらも記録済みで、**実際にファイル／ディレクトリとして存在する**。
-  短命 session は jsonl を書かず、reap 済み worktree は cwd が消えているため、記録の有無だけでは
-  足りない（存在しない uuid の `--resume` は空 session を作ってしまう）
+
+Go 側:
+
+- `transcript_path` が空でなく、そのファイルが実在する（短命 session は jsonl を書かない）
+- `cwd` が空でなく、そのディレクトリが実在する（reap 済み worktree では消えている）
 
 並び順は live な row の全部より後ろ。resumable 同士では、終了直前の state が `working` /
 `awaiting_approval` だったもの（作業途中で落ちた可能性が高い）を先に出し、その中では新しい順。
 summary は `resumable (was working)` のように終了直前の state を出す — payload には end の
 reason しか無く、raw state は全部 `ended` なので、row を見分けられるのはここだけ。
 
-**live な row が 0 件のときは、resumable の候補数と flag を stderr に出す。** 再起動直後は
-まさにこの状態で、popup の中から flag の存在に気づく経路が無いため。拾える窓は auto-GC の
-保持期間（7 日）と同じ。
+`tmux_pane` は運ばない（クエリ側で NULL にする）。ledger はこの列を終了時にクリアせず持ち回るため、
+resumable な row の pane は必ず「終わったプロセスの pane」であり、pane id は server 単位のカウンタで
+新しい server は `%0` から振り直すので、再起動後は無関係な live pane に衝突する。
+
+live な row が 0 件のときは、resumable の候補数と flag を stderr に出す（理由は design doc 参照）。
+拾える窓は auto-GC の保持期間（7 日）と同じ。
 
 選択したときの到達手段は上の一覧と同じで、resumable 専用の分岐は無い。プロセスはもう無いので
 通常は「roster に居ない session の直接 resume」に落ちるが、reconcile が早めに閉じた等で実際には
@@ -161,6 +169,11 @@ bind-key Q display-popup -E -w 80% -h 60% "claude-queue picker --show-working --
 prefix (`C-q`) のあと `q` で popup → fzf → Enter でジャンプ。`Q` は絞り込みを外した全部入り
 （working / stale / resumable も出す）。
 
+`dot/tmux.conf` は `bin/deploy.sh` の symlink 経由なので pull した時点で反映されるが、
+`bin/claude-queue` は `.gitignore` 対象で `make install` でしか更新されない。flag が増えた
+バージョンを pull したら、tmux.conf を reload する前に `make install` を回す（古い binary は
+未知の flag で usage を出して exit するだけなので、popup が無反応に見える）。
+
 ## Troubleshooting
 
 | 症状 | 調べ方 |
@@ -189,10 +202,10 @@ PR 作成時に description に貼って確認：
 - [ ] tmux 外で起動した（`TMUX` を持たない）interactive session を picker から選ぶと、kill されず「別端末で使用中の可能性」の理由が出る
 - [ ] transcript が無い / cwd が reap 済みの session を picker から選ぶと、resume されずどちらが欠けたかが出る
 - [ ] `SessionEnd` 後に `claude --resume` した session が picker に再び現れる
-- [ ] ホスト再起動後（live 0 件）に `C-q q` を開くと、resumable の候補数と `--show-resumable` を案内する stderr が出る
+- [ ] live 0 件の状態で `claude-queue picker` を**シェルから直接**起動すると、resumable の候補数と `--show-resumable` を案内する stderr が出る（`display-popup -E` は command の exit で popup を閉じるので、`C-q q` 経路ではこの案内は読めない）
 - [ ] `C-q Q` で resumable な row が live な row の後ろに並び、終了直前が `working` / `awaiting_approval` のものが先頭に来る
 - [ ] resumable な row を選ぶと同じ session id のまま会話が復元される（kill 段階を経ずに resume される）
-- [ ] `/exit` で閉じた session（`reason: prompt_input_exit`）は `--show-resumable` でも出ない
+- [ ] `SessionEnd` が `reason: prompt_input_exit` で飛んだ session は `--show-resumable` でも出ない（`SessionEnd` が飛ばず L3 の `ForcedEnd` で閉じた `/exit` `/clear` は payload を持たないので出る）
 - [ ] 同 pane で `/clear` 後、旧 session が view から消える（L3）
 - [ ] `CLAUDE_QUEUE_ASCII=1` で `[!]1` 等に切替
 - [ ] 2 pane 並行で approve 連打、busy_timeout 超過しない

--- a/src/claude-queue/internal/db/db_test.go
+++ b/src/claude-queue/internal/db/db_test.go
@@ -367,8 +367,14 @@ func TestResumableCandidates_CarriesResumeInputs(t *testing.T) {
 		t.Errorf("cwd/transcript = %q/%q, want /w/a and /t/a.jsonl",
 			got[0].Cwd.String, got[0].TranscriptPath.String)
 	}
-	if got[0].TmuxPane.String != "%1" {
-		t.Errorf("tmux_pane = %q, want %%1", got[0].TmuxPane.String)
+	// The pane, by contrast, must NOT come through even though the ledger still
+	// holds one. It names a pane of a process that has ended, and the picker's
+	// last-resort fallback would trust it whenever the roster cannot be read --
+	// switching to whatever unrelated pane inherited that id on the new server
+	// instead of resuming the conversation.
+	if got[0].TmuxPane.Valid {
+		t.Errorf("tmux_pane = %q, want NULL: a terminated row's pane is never its own",
+			got[0].TmuxPane.String)
 	}
 }
 

--- a/src/claude-queue/internal/db/db_test.go
+++ b/src/claude-queue/internal/db/db_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -69,6 +70,27 @@ func insertEvent(t *testing.T, conn *sql.DB, sid, evType, state string, agoSec i
 	}
 }
 
+func insertEventPayload(t *testing.T, conn *sql.DB, sid, evType, state, payload string, agoSec int64) {
+	t.Helper()
+	_, err := conn.Exec(
+		"INSERT INTO events(session_id, event_type, state, payload, created_at) VALUES (?, ?, ?, ?, unixepoch() - ?)",
+		sid, evType, state, payload, agoSec,
+	)
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+}
+
+func terminate(t *testing.T, conn *sql.DB, sid string, agoSec int64) {
+	t.Helper()
+	_, err := conn.Exec(
+		"UPDATE sessions SET terminated_at = unixepoch() - ? WHERE session_id = ?", agoSec, sid,
+	)
+	if err != nil {
+		t.Fatalf("terminate %s: %v", sid, err)
+	}
+}
+
 func TestCounts(t *testing.T) {
 	conn, err := Open(filepath.Join(t.TempDir(), "c.db"))
 	if err != nil {
@@ -125,6 +147,228 @@ func TestListRows_SortsByPriorityThenRecency(t *testing.T) {
 	}
 	if rows[1].SessionID != "i" {
 		t.Errorf("rows[1] = %q, want i", rows[1].SessionID)
+	}
+}
+
+// The reason filter is the whole point of the candidate query: an end a human
+// typed at the REPL prompt is a stopping point, while a signal-driven end or a
+// ForcedEnd synthesised by reconcile is a session that was cut off.
+func TestResumableCandidates_FiltersByEndReason(t *testing.T) {
+	conn, err := Open(filepath.Join(t.TempDir(), "r.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	// The ends that should come back.
+	insertSession(t, conn, "signal", "%1")
+	insertEvent(t, conn, "signal", "Stop", "idle_done", 400)
+	insertEventPayload(t, conn, "signal", "SessionEnd", "ended", `{"reason":"other"}`, 300)
+	terminate(t, conn, "signal", 300)
+
+	insertSession(t, conn, "forced", "%2")
+	insertEvent(t, conn, "forced", "UserPromptSubmit", "working", 400)
+	insertEvent(t, conn, "forced", "ForcedEnd", "ended", 300) // no payload at all
+	terminate(t, conn, "forced", 300)
+
+	// A SessionEnd with no reason recorded stores an empty payload string, which
+	// json_extract rejects as malformed rather than reading as absent. It must
+	// not take the query down or drop the row.
+	insertSession(t, conn, "noreason", "%3")
+	insertEvent(t, conn, "noreason", "Stop", "idle_done", 400)
+	insertEventPayload(t, conn, "noreason", "SessionEnd", "ended", "", 300)
+	terminate(t, conn, "noreason", 300)
+
+	// The ends that should not.
+	insertSession(t, conn, "typedexit", "%4")
+	insertEvent(t, conn, "typedexit", "Stop", "idle_done", 400)
+	insertEventPayload(t, conn, "typedexit", "SessionEnd", "ended", `{"reason":"prompt_input_exit"}`, 300)
+	terminate(t, conn, "typedexit", 300)
+
+	// Still live: it belongs to the queue view, not here.
+	insertSession(t, conn, "live", "%5")
+	insertEvent(t, conn, "live", "Stop", "idle_done", 60)
+
+	got, err := ResumableCandidates(conn)
+	if err != nil {
+		t.Fatalf("ResumableCandidates: %v", err)
+	}
+	found := map[string]Row{}
+	for _, r := range got {
+		found[r.SessionID] = r
+	}
+	for _, want := range []string{"signal", "forced", "noreason"} {
+		if _, ok := found[want]; !ok {
+			t.Errorf("session %q missing from the candidates", want)
+		}
+	}
+	for _, unwanted := range []string{"typedexit", "live"} {
+		if _, ok := found[unwanted]; ok {
+			t.Errorf("session %q should not be a candidate", unwanted)
+		}
+	}
+	if len(got) != 3 {
+		t.Fatalf("len(candidates) = %d, want 3: %+v", len(got), got)
+	}
+
+	// Every candidate is labelled with the pseudo state the picker renders, and
+	// carries the state it was in before the end so the summary can name it.
+	if s := found["forced"]; s.EffectiveState != StateResumable || s.PriorState.String != "working" {
+		t.Errorf("forced = {%q, %q}, want {%q, working}", s.EffectiveState, s.PriorState.String, StateResumable)
+	}
+	if s := found["signal"]; s.PriorState.String != "idle_done" {
+		t.Errorf("signal prior state = %q, want idle_done", s.PriorState.String)
+	}
+}
+
+// Resumable rows sort behind every live row, then interrupted before finished,
+// then newest first -- so a host that came back up offers the work that was
+// actually in flight at the top.
+func TestResumableCandidates_Ordering(t *testing.T) {
+	conn, err := Open(filepath.Join(t.TempDir(), "o.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	type seed struct {
+		id    string
+		prior string
+		ago   int64
+	}
+	// Inserted in an order that matches neither the priority nor the recency
+	// the result must come back in.
+	for _, s := range []seed{
+		{"done-old", "idle_done", 500},
+		{"work-old", "working", 400},
+		{"appr-new", "awaiting_approval", 100},
+		{"done-new", "idle_done", 200},
+		{"work-new", "working", 150},
+	} {
+		insertSession(t, conn, s.id, "")
+		insertEvent(t, conn, s.id, "Stop", s.prior, s.ago+50)
+		insertEvent(t, conn, s.id, "ForcedEnd", "ended", s.ago)
+		terminate(t, conn, s.id, s.ago)
+	}
+
+	got, err := ResumableCandidates(conn)
+	if err != nil {
+		t.Fatalf("ResumableCandidates: %v", err)
+	}
+	var ids []string
+	for _, r := range got {
+		ids = append(ids, r.SessionID)
+		if r.Priority <= 5 {
+			t.Errorf("%s has priority %d, which would sort it among the live rows",
+				r.SessionID, r.Priority)
+		}
+	}
+	want := []string{"appr-new", "work-new", "work-old", "done-new", "done-old"}
+	if strings.Join(ids, ",") != strings.Join(want, ",") {
+		t.Errorf("order = %v, want %v", ids, want)
+	}
+}
+
+// A session whose only event is the end has no prior state to report, and must
+// still be offered rather than dropped by the join that looks for one.
+func TestResumableCandidates_NoPriorState(t *testing.T) {
+	conn, err := Open(filepath.Join(t.TempDir(), "p.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	insertSession(t, conn, "bare", "%1")
+	insertEvent(t, conn, "bare", "ForcedEnd", "ended", 100)
+	terminate(t, conn, "bare", 100)
+
+	got, err := ResumableCandidates(conn)
+	if err != nil {
+		t.Fatalf("ResumableCandidates: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].PriorState.Valid {
+		t.Errorf("PriorState = %q, want NULL", got[0].PriorState.String)
+	}
+	if got[0].Priority != priorityResumableIdle {
+		t.Errorf("Priority = %d, want %d", got[0].Priority, priorityResumableIdle)
+	}
+}
+
+// The prior state is what the session was last DOING, which takes two things
+// the naive "the event before the last one" does not give. A session that ended,
+// was resumed and ended again has to report the second run, not the first. And
+// end events do not count as a prior state: 'ended' says nothing about the work,
+// so a row carrying more than one of them in a row -- the shape a resurrected
+// session leaves behind -- must be looked past rather than reported as
+// "resumable (was ended)" and sorted as if it had finished cleanly.
+func TestResumableCandidates_PriorStateIsTheLastWorkingState(t *testing.T) {
+	conn, err := Open(filepath.Join(t.TempDir(), "q.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	insertSession(t, conn, "twice", "%1")
+	// First run, closed cleanly.
+	insertEvent(t, conn, "twice", "Stop", "idle_done", 900)
+	insertEventPayload(t, conn, "twice", "SessionEnd", "ended", `{"reason":"other"}`, 800)
+	// Resumed, then cut off mid-approval -- and closed twice over.
+	insertEvent(t, conn, "twice", "SessionStart", "working", 700)
+	insertEvent(t, conn, "twice", "PermissionRequest", "awaiting_approval", 600)
+	insertEventPayload(t, conn, "twice", "SessionEnd", "ended", `{"reason":"other"}`, 550)
+	insertEvent(t, conn, "twice", "ForcedEnd", "ended", 500)
+	terminate(t, conn, "twice", 500)
+
+	got, err := ResumableCandidates(conn)
+	if err != nil {
+		t.Fatalf("ResumableCandidates: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (only the last event decides)", len(got))
+	}
+	if got[0].PriorState.String != "awaiting_approval" {
+		t.Errorf("PriorState = %q, want awaiting_approval", got[0].PriorState.String)
+	}
+	if got[0].Priority != priorityResumable {
+		t.Errorf("Priority = %d, want %d (interrupted, so ahead of the finished ones)",
+			got[0].Priority, priorityResumable)
+	}
+}
+
+// The picker's filesystem filter reads cwd and transcript_path off the row, so
+// the candidate query has to carry them through.
+func TestResumableCandidates_CarriesResumeInputs(t *testing.T) {
+	conn, err := Open(filepath.Join(t.TempDir(), "c2.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Exec(`
+		INSERT INTO sessions(session_id, tmux_pane, cwd, transcript_path)
+		VALUES ('s', '%1', '/w/a', '/t/a.jsonl')
+	`); err != nil {
+		t.Fatalf("insert session: %v", err)
+	}
+	insertEvent(t, conn, "s", "ForcedEnd", "ended", 10)
+	terminate(t, conn, "s", 10)
+
+	got, err := ResumableCandidates(conn)
+	if err != nil {
+		t.Fatalf("ResumableCandidates: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].Cwd.String != "/w/a" || got[0].TranscriptPath.String != "/t/a.jsonl" {
+		t.Errorf("cwd/transcript = %q/%q, want /w/a and /t/a.jsonl",
+			got[0].Cwd.String, got[0].TranscriptPath.String)
+	}
+	if got[0].TmuxPane.String != "%1" {
+		t.Errorf("tmux_pane = %q, want %%1", got[0].TmuxPane.String)
 	}
 }
 

--- a/src/claude-queue/internal/db/queries.go
+++ b/src/claude-queue/internal/db/queries.go
@@ -17,7 +17,27 @@ type Row struct {
 	Payload        sql.NullString
 	CreatedAt      int64
 	Priority       int
+
+	// PriorState is the state the session was last in before it ended, and is
+	// set only for the resumable rows -- a live row's own RawState already says
+	// what it is doing. It is what separates "the host went down mid-task" from
+	// "the work was finished and the session closed", which decides both the
+	// resumable ordering and what the summary column says.
+	PriorState sql.NullString
 }
+
+// StateResumable is the pseudo effective_state of a terminated row that
+// `claude --resume` can reopen. It is not a state any hook writes: the ledger
+// only knows 'ended', and this names the subset of ended rows worth offering.
+const StateResumable = "resumable"
+
+// priorityResumable / priorityResumableIdle sort the resumable rows behind
+// every live one -- the queue view's own priorities top out at 5 -- and, among
+// themselves, put the sessions that were interrupted mid-task first.
+const (
+	priorityResumable     = 6
+	priorityResumableIdle = 7
+)
 
 // ListOpts filters the queue listing.
 type ListOpts struct {
@@ -62,7 +82,8 @@ func ListRows(conn *sql.DB, opts ListOpts) ([]Row, error) {
 	}
 	q := fmt.Sprintf(`
 		SELECT session_id, tmux_pane, cwd, transcript_path,
-		       event_type, raw_state, effective_state, payload, created_at, priority
+		       event_type, raw_state, effective_state, payload, created_at, priority,
+		       NULL AS prior_state
 		FROM queue
 		WHERE %s
 		ORDER BY priority ASC, created_at DESC
@@ -72,14 +93,69 @@ func ListRows(conn *sql.DB, opts ListOpts) ([]Row, error) {
 	if err != nil {
 		return nil, fmt.Errorf("list: %w", err)
 	}
-	defer rows.Close()
+	return scanRows(rows)
+}
 
+// ResumableCandidates returns the terminated rows whose conversation
+// `claude --resume` could reopen, ordered to follow the live rows: interrupted
+// sessions first, newest first within each group.
+//
+// This is only the half of the test that SQL can answer. A resume also needs
+// the transcript and the working directory to still be on disk, and the ledger
+// having recorded a path is no evidence of that -- short-lived sessions never
+// write a jsonl, and a reaped worktree takes the cwd with it. Callers must run
+// the surviving candidates past a filesystem check (picker.filterResumable)
+// before offering them, because `claude --resume` with an id it cannot find
+// starts an empty session under that id instead of failing.
+//
+// The reason filter is what keeps the list to sessions that were CUT OFF. A
+// SessionEnd carrying reason 'prompt_input_exit' is a human closing the REPL at
+// a stopping point, so it is excluded; every other end is either a signal
+// (SIGTERM, `claude stop`, the host going down) or a ForcedEnd synthesised by
+// reconcile after a session vanished without notice, and those are the ones
+// worth offering back. json_valid guards the extract because a SessionEnd with
+// no reason stores an empty payload string, which json_extract rejects as
+// malformed rather than reading as absent.
+func ResumableCandidates(conn *sql.DB) ([]Row, error) {
+	rows, err := conn.Query(`
+		SELECT s.session_id, s.tmux_pane, s.cwd, s.transcript_path,
+		       e.event_type, e.state AS raw_state, ? AS effective_state,
+		       e.payload, e.created_at,
+		       CASE WHEN p.state IN ('working', 'awaiting_approval') THEN ? ELSE ? END AS priority,
+		       p.state AS prior_state
+		FROM events e
+		JOIN (SELECT session_id, MAX(id) AS mid FROM events GROUP BY session_id) l
+		  ON e.id = l.mid
+		JOIN sessions s ON s.session_id = e.session_id
+		LEFT JOIN events p ON p.id = (
+		  SELECT MAX(id) FROM events
+		  WHERE session_id = e.session_id AND id < e.id AND state != 'ended'
+		)
+		WHERE s.terminated_at IS NOT NULL
+		  AND e.state = 'ended'
+		  AND COALESCE(
+		        CASE WHEN json_valid(e.payload) THEN json_extract(e.payload, '$.reason') END,
+		        ''
+		      ) != 'prompt_input_exit'
+		ORDER BY priority ASC, e.created_at DESC
+	`, StateResumable, priorityResumable, priorityResumableIdle)
+	if err != nil {
+		return nil, fmt.Errorf("list resumable: %w", err)
+	}
+	return scanRows(rows)
+}
+
+// scanRows drains a query shaped like the column list both listings select, and
+// closes it. Shared so the two cannot drift apart in column order.
+func scanRows(rows *sql.Rows) ([]Row, error) {
+	defer rows.Close()
 	var out []Row
 	for rows.Next() {
 		var r Row
 		if err := rows.Scan(
 			&r.SessionID, &r.TmuxPane, &r.Cwd, &r.TranscriptPath,
 			&r.EventType, &r.RawState, &r.EffectiveState, &r.Payload, &r.CreatedAt, &r.Priority,
+			&r.PriorState,
 		); err != nil {
 			return nil, err
 		}

--- a/src/claude-queue/internal/db/queries.go
+++ b/src/claude-queue/internal/db/queries.go
@@ -116,9 +116,21 @@ func ListRows(conn *sql.DB, opts ListOpts) ([]Row, error) {
 // worth offering back. json_valid guards the extract because a SessionEnd with
 // no reason stores an empty payload string, which json_extract rejects as
 // malformed rather than reading as absent.
+//
+// tmux_pane is dropped rather than selected. The ledger never clears it -- the
+// upsert COALESCEs it forward -- so on these rows it always names the pane of a
+// process that has ended, and pane ids are a per-server counter that a fresh
+// server restarts from %0, meaning the recorded id almost certainly resolves to
+// an unrelated live pane after a reboot. The picker's last-resort fallback
+// trusts a ledger pane when the roster cannot be read, on the grounds that an
+// unreadable roster is not evidence the session ended; for a row selected by
+// terminated_at that premise is simply false, and honouring it would switch to
+// a stranger's pane instead of resuming, silently. Where a pane is genuinely
+// reachable the roster names the process and the picker re-derives the pane
+// from its ancestry, so nothing is lost by withholding this column.
 func ResumableCandidates(conn *sql.DB) ([]Row, error) {
 	rows, err := conn.Query(`
-		SELECT s.session_id, s.tmux_pane, s.cwd, s.transcript_path,
+		SELECT s.session_id, NULL AS tmux_pane, s.cwd, s.transcript_path,
 		       e.event_type, e.state AS raw_state, ? AS effective_state,
 		       e.payload, e.created_at,
 		       CASE WHEN p.state IN ('working', 'awaiting_approval') THEN ? ELSE ? END AS priority,

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -22,6 +22,7 @@ var emoji = map[string]string{
 	"idle_done":         "✅",
 	"working":           "⚙️",
 	"stale":             "🧟",
+	db.StateResumable:   "💤",
 }
 
 var ascii = map[string]string{
@@ -29,6 +30,7 @@ var ascii = map[string]string{
 	"idle_done":         "[.]",
 	"working":           "[*]",
 	"stale":             "[X]",
+	db.StateResumable:   "[~]",
 }
 
 // FormatLine renders one queue row as a tab-delimited line for fzf.
@@ -56,6 +58,7 @@ func FormatLine(row db.Row, worktree string, nowSec int64, asciiMode bool) strin
 		EffectiveState: row.EffectiveState,
 		RawState:       row.RawState,
 		Payload:        row.Payload.String,
+		PriorState:     row.PriorState.String,
 	})
 
 	age := formatAge(nowSec - row.CreatedAt)
@@ -87,6 +90,44 @@ func rowTranscript(row db.Row) string {
 		return row.TranscriptPath.String
 	}
 	return ""
+}
+
+// filterResumable drops the candidates whose resume would fail, which is the
+// half of the test db.ResumableCandidates cannot make: both preconditions live
+// on disk rather than in the ledger.
+//
+// It is the same pair resumeBlocked checks when a row is picked, applied a step
+// earlier so a candidate that cannot be reopened is never listed at all -- and
+// so the count reported when the queue is empty is a count of rows that will
+// actually resume. fileExists and dirExists are parameters so the rule can be
+// exercised without laying out transcripts and worktrees on a real filesystem.
+func filterResumable(rows []db.Row, fileExists, dirExists func(string) bool) []db.Row {
+	var out []db.Row
+	for _, r := range rows {
+		transcript, cwd := rowTranscript(r), rowCwd(r)
+		if transcript == "" || cwd == "" {
+			continue
+		}
+		if !fileExists(transcript) || !dirExists(cwd) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// noRowsMessage explains an empty picker. The resumable count is the reason it
+// is not just a constant: a host that has just come back up has no live session
+// at all, and that is precisely when the flag that would show the recoverable
+// ones needs advertising -- there is no way to discover it from inside the
+// popup.
+func noRowsMessage(resumable int, shown bool) string {
+	if resumable == 0 || shown {
+		return "no active sessions"
+	}
+	return fmt.Sprintf(
+		"no active sessions, but %d can be resumed: reopen the picker with --show-resumable (prefix Q)",
+		resumable)
 }
 
 func formatAge(sec int64) string {
@@ -369,6 +410,7 @@ func Run(args []string) {
 	fs := flag.NewFlagSet("picker", flag.ExitOnError)
 	showWorking := fs.Bool("show-working", false, "include working sessions")
 	showStale := fs.Bool("show-stale", false, "include stale sessions")
+	showResumable := fs.Bool("show-resumable", false, "include ended sessions a resume could reopen")
 	_ = fs.Parse(args)
 
 	conn, err := db.Open(db.DefaultPath())
@@ -397,8 +439,25 @@ func Run(args []string) {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		return
 	}
+	// Read the resumable rows whether or not they will be listed: the count is
+	// what the empty-queue message needs in order to point at the flag.
+	// Best-effort for the same reason the sweep above is -- a failure here is no
+	// reason to withhold the live queue.
+	var resumable []db.Row
+	if cands, err := db.ResumableCandidates(conn); err != nil {
+		fmt.Fprintln(os.Stderr, "resumable lookup skipped:", err)
+	} else {
+		resumable = filterResumable(cands, isFile, isDir)
+	}
+	if *showResumable {
+		// Appended, not merged: ResumableCandidates hands back priorities above
+		// every one the queue view assigns, so concatenation is already the
+		// global order and fzf is run with --no-sort.
+		rows = append(rows, resumable...)
+	}
+
 	if len(rows) == 0 {
-		fmt.Fprintln(os.Stderr, "no active sessions")
+		fmt.Fprintln(os.Stderr, noRowsMessage(len(resumable), *showResumable))
 		return
 	}
 

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -97,10 +97,9 @@ func rowTranscript(row db.Row) string {
 // on disk rather than in the ledger.
 //
 // It is the same pair resumeBlocked checks when a row is picked, applied a step
-// earlier so a candidate that cannot be reopened is never listed at all -- and
-// so the count reported when the queue is empty is a count of rows that will
-// actually resume. fileExists and dirExists are parameters so the rule can be
-// exercised without laying out transcripts and worktrees on a real filesystem.
+// earlier so a candidate that cannot be reopened is never listed at all.
+// fileExists and dirExists are parameters so the rule can be exercised without
+// laying out transcripts and worktrees on a real filesystem.
 func filterResumable(rows []db.Row, fileExists, dirExists func(string) bool) []db.Row {
 	var out []db.Row
 	for _, r := range rows {
@@ -116,11 +115,10 @@ func filterResumable(rows []db.Row, fileExists, dirExists func(string) bool) []d
 	return out
 }
 
-// noRowsMessage explains an empty picker. The resumable count is the reason it
-// is not just a constant: a host that has just come back up has no live session
-// at all, and that is precisely when the flag that would show the recoverable
-// ones needs advertising -- there is no way to discover it from inside the
-// popup.
+// noRowsMessage explains an empty picker, naming the resumable count and the
+// flag that would list them: a host that has just come back up has no live
+// session at all, which is exactly when a default-off flag has to advertise
+// itself. The count is post-filter, so it never offers rows that cannot resume.
 func noRowsMessage(resumable int, shown bool) string {
 	if resumable == 0 || shown {
 		return "no active sessions"

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -253,6 +253,37 @@ func TestResumableRowRoutesToResume(t *testing.T) {
 	}
 }
 
+// The unreadable-roster case, which is where a resumable row carrying a pane
+// would do real damage. reachablePane's last-resort fallback trusts the ledger
+// pane when the roster cannot be read, because an unreadable roster is not
+// evidence a session ended -- true for a live row, false for one selected by
+// terminated_at. Pane ids are a per-server counter restarting at %0, so after a
+// reboot the recorded id resolves to an unrelated live pane and the pick would
+// switch to a stranger's session with no error. db.ResumableCandidates withholds
+// the column so the fallback has nothing to trust; this asserts the whole chain
+// from the rendered line, since it is FormatLine's hidden column that feeds it.
+func TestResumableRowCarriesNoPaneForTheRosterFallback(t *testing.T) {
+	row := db.Row{
+		SessionID:      testUUID,
+		TmuxPane:       sql.NullString{}, // what ResumableCandidates hands back
+		Cwd:            sql.NullString{String: "/w/a", Valid: true},
+		TranscriptPath: sql.NullString{String: "/t/a.jsonl", Valid: true},
+		EffectiveState: db.StateResumable,
+		RawState:       "ended",
+		CreatedAt:      nowMinus(60),
+	}
+	fields := strings.Split(FormatLine(row, "wt", nowUnix(), false), "\t")
+	if fields[5] != "" {
+		t.Fatalf("hidden tmux_pane = %q, want empty for a resumable row", fields[5])
+	}
+
+	// %0 and %1 exist on the rebooted server, belonging to unrelated sessions.
+	mux := &fakeMux{panes: map[string]bool{"%0": true, "%1": true}}
+	if got := reachablePane(mux, nil, fields[4], fields[5], false); got != "" {
+		t.Errorf("reachablePane with an unreadable roster = %q, want empty", got)
+	}
+}
+
 // A row that came back from the resumable query but whose session turns out to
 // be running after all -- reconcile closed it early, or it was restarted since
 // -- falls back to the existing routing instead of resuming onto a live

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -92,6 +92,184 @@ func TestFormatLine_DeepCwdShowsWorktree(t *testing.T) {
 	}
 }
 
+// A resumable row is rendered from the same eight columns as a live one, but
+// its state is not one any hook writes, so both icon maps and the summary have
+// to know it -- an unmapped state renders as an empty icon and a bare
+// "resumable", which is the failure this asserts against.
+func TestFormatLine_Resumable(t *testing.T) {
+	row := db.Row{
+		SessionID:      "s9",
+		TmuxPane:       sql.NullString{String: "%3", Valid: true},
+		Cwd:            sql.NullString{String: "/home/x/ghq/dotrc_wt", Valid: true},
+		TranscriptPath: sql.NullString{String: "/home/x/.claude/projects/enc/s9.jsonl", Valid: true},
+		EventType:      "ForcedEnd",
+		RawState:       "ended",
+		EffectiveState: db.StateResumable,
+		PriorState:     sql.NullString{String: "working", Valid: true},
+		CreatedAt:      nowMinus(7200),
+	}
+
+	fields := strings.Split(FormatLine(row, "dotrc_wt", nowUnix(), false), "\t")
+	if len(fields) != 8 {
+		t.Fatalf("want 8 fields, got %d", len(fields))
+	}
+	if fields[0] != emoji[db.StateResumable] || fields[0] == "" {
+		t.Errorf("emoji icon = %q, want %q", fields[0], emoji[db.StateResumable])
+	}
+	if !strings.Contains(fields[2], "resumable") {
+		t.Errorf("summary = %q, want it to say the row is resumable", fields[2])
+	}
+	// What the session was doing when it was cut off is the only thing telling
+	// these rows apart, so it has to survive into the summary.
+	if !strings.Contains(fields[2], "working") {
+		t.Errorf("summary = %q, want it to name the prior state", fields[2])
+	}
+	if fields[3] != "2h" {
+		t.Errorf("age = %q, want 2h", fields[3])
+	}
+	// The resume path needs both of these off the picked line.
+	if fields[6] != "/home/x/ghq/dotrc_wt" || fields[7] != "/home/x/.claude/projects/enc/s9.jsonl" {
+		t.Errorf("hidden cwd/transcript = %q/%q", fields[6], fields[7])
+	}
+
+	asciiIcon := strings.Split(FormatLine(row, "dotrc_wt", nowUnix(), true), "\t")[0]
+	if asciiIcon == "" {
+		t.Error("ascii icon is empty: CLAUDE_QUEUE_ASCII=1 would render the column blank")
+	}
+	if asciiIcon == fields[0] {
+		t.Errorf("ascii icon = %q, same as the emoji one", asciiIcon)
+	}
+}
+
+// The filesystem half of the resumable test. db.ResumableCandidates cannot make
+// it, and skipping it would list rows whose resume silently starts an empty
+// session under the same id.
+func TestFilterResumable(t *testing.T) {
+	row := func(id, cwd, transcript string) db.Row {
+		return db.Row{
+			SessionID:      id,
+			Cwd:            sql.NullString{String: cwd, Valid: cwd != ""},
+			TranscriptPath: sql.NullString{String: transcript, Valid: transcript != ""},
+			EffectiveState: db.StateResumable,
+		}
+	}
+	// Only these two paths exist.
+	files := func(p string) bool { return p == "/t/ok.jsonl" }
+	dirs := func(p string) bool { return p == "/w/ok" }
+
+	in := []db.Row{
+		row("keep", "/w/ok", "/t/ok.jsonl"),
+		row("no-transcript-recorded", "/w/ok", ""),
+		row("no-cwd-recorded", "", "/t/ok.jsonl"),
+		// A short-lived session records a transcript path but never writes the
+		// file, so the ledger having one is only half the check.
+		row("transcript-missing", "/w/ok", "/t/gone.jsonl"),
+		// A reaped worktree takes the directory the resume would run in.
+		row("cwd-reaped", "/w/reaped", "/t/ok.jsonl"),
+	}
+
+	got := filterResumable(in, files, dirs)
+	if len(got) != 1 || got[0].SessionID != "keep" {
+		var ids []string
+		for _, r := range got {
+			ids = append(ids, r.SessionID)
+		}
+		t.Fatalf("filterResumable kept %v, want [keep]", ids)
+	}
+
+	if got := filterResumable(nil, files, dirs); got != nil {
+		t.Errorf("filterResumable(nil) = %+v, want nil", got)
+	}
+}
+
+// The empty picker is the state a host reboot leaves behind, and the flag that
+// would show the recoverable sessions cannot be discovered from inside the
+// popup -- so the count has to be in the message.
+func TestNoRowsMessage(t *testing.T) {
+	const plain = "no active sessions"
+
+	if got := noRowsMessage(0, false); got != plain {
+		t.Errorf("nothing to resume = %q, want %q", got, plain)
+	}
+	// Already listing them: there is nothing left to point at.
+	if got := noRowsMessage(3, true); got != plain {
+		t.Errorf("with the flag already on = %q, want %q", got, plain)
+	}
+
+	got := noRowsMessage(3, false)
+	if !strings.Contains(got, "3") {
+		t.Errorf("message = %q, want the candidate count in it", got)
+	}
+	if !strings.Contains(got, "--show-resumable") {
+		t.Errorf("message = %q, want it to name the flag", got)
+	}
+}
+
+// Selecting a resumable row must reach the resume path PR #55 already built,
+// not a second one. This walks the whole chain the pick goes through -- render
+// the row, split the line, resolve the pane, route -- for a session the roster
+// no longer lists.
+func TestResumableRowRoutesToResume(t *testing.T) {
+	row := db.Row{
+		SessionID: testUUID,
+		// A pane id left over from a tmux server that has since been replaced.
+		// It exists on the current server (it is a per-server counter that
+		// restarts from %0), so trusting it would switch to an unrelated pane.
+		TmuxPane:       sql.NullString{String: "%1", Valid: true},
+		Cwd:            sql.NullString{String: "/w/a", Valid: true},
+		TranscriptPath: sql.NullString{String: "/t/a.jsonl", Valid: true},
+		EffectiveState: db.StateResumable,
+		RawState:       "ended",
+		PriorState:     sql.NullString{String: "working", Valid: true},
+		CreatedAt:      nowMinus(60),
+	}
+	fields := strings.Split(FormatLine(row, "wt", nowUnix(), false), "\t")
+	mux := &fakeMux{panes: map[string]bool{"%1": true}}
+
+	// The roster was read and does not list the session: the host it ran on went
+	// down, so there is no process to displace.
+	tgt := Target{
+		SessionID:        fields[4],
+		Pane:             reachablePane(mux, nil, fields[4], fields[5], true),
+		Cwd:              fields[6],
+		TranscriptPath:   fields[7],
+		RosterOK:         true,
+		TranscriptExists: true,
+		CwdExists:        true,
+	}
+
+	act := DecideAction(tgt)
+	if act.Kind != "resume" {
+		t.Fatalf("Kind = %q, want resume (%+v)", act.Kind, act)
+	}
+	if act.Resume != testUUID {
+		t.Errorf("Resume = %q, want the full uuid %q", act.Resume, testUUID)
+	}
+	if act.KillPID != 0 {
+		t.Errorf("KillPID = %d, want 0: nothing is running to kill", act.KillPID)
+	}
+	if act.Cwd != "/w/a" {
+		t.Errorf("Cwd = %q, want /w/a", act.Cwd)
+	}
+}
+
+// A row that came back from the resumable query but whose session turns out to
+// be running after all -- reconcile closed it early, or it was restarted since
+// -- falls back to the existing routing instead of resuming onto a live
+// process. Resumable rows add no branch of their own to DecideAction.
+func TestResumableRowInRosterFallsBackToExistingRouting(t *testing.T) {
+	agents := []roster.Agent{{SessionID: testUUID, PID: 100, Kind: "background"}}
+	mux := &fakeMux{}
+
+	tgt := resumable()
+	tgt.Pane = reachablePane(mux, agents, testUUID, "%1", true)
+	tgt.InRoster, tgt.Kind, tgt.PID = true, "background", 100
+
+	if act := DecideAction(tgt); act.Kind != "attach" || act.Short != "61c846eb" {
+		t.Errorf("DecideAction = %+v, want attach by short id", act)
+	}
+}
+
 func TestFormatAge(t *testing.T) {
 	cases := []struct {
 		sec  int64

--- a/src/claude-queue/internal/summary/summary.go
+++ b/src/claude-queue/internal/summary/summary.go
@@ -14,6 +14,7 @@ type Input struct {
 	EffectiveState string
 	RawState       string
 	Payload        string // raw JSON from events.payload
+	PriorState     string // resumable rows only: the state before the end
 }
 
 // Summarize returns the picker summary column for a queue row.
@@ -27,8 +28,22 @@ func Summarize(in Input) string {
 		return "working"
 	case "stale":
 		return "stale (was " + in.RawState + ")"
+	case "resumable":
+		return summarizeResumable(in.PriorState)
 	}
 	return in.EffectiveState
+}
+
+// summarizeResumable names what the session was doing when it was cut off,
+// which is the one thing that distinguishes these rows from each other: the
+// payload of an end event carries only its reason, and the raw state is 'ended'
+// for all of them. A session whose only recorded event is the end has no prior
+// state to report.
+func summarizeResumable(prior string) string {
+	if prior == "" {
+		return "resumable"
+	}
+	return "resumable (was " + prior + ")"
 }
 
 // TruncateWidth trims s to at most cols terminal columns (double-width chars count 2).

--- a/src/claude-queue/internal/summary/summary_test.go
+++ b/src/claude-queue/internal/summary/summary_test.go
@@ -61,6 +61,23 @@ func TestSummaryForStale(t *testing.T) {
 	}
 }
 
+// A resumable row's own state is 'ended' and its payload holds only the end
+// reason, so the prior state is the only thing that distinguishes one of these
+// rows from another.
+func TestSummaryForResumable(t *testing.T) {
+	got := Summarize(Input{EffectiveState: "resumable", RawState: "ended", PriorState: "working"})
+	if got != "resumable (was working)" {
+		t.Errorf("got %q, want %q", got, "resumable (was working)")
+	}
+}
+
+func TestSummaryForResumable_NoPriorState(t *testing.T) {
+	got := Summarize(Input{EffectiveState: "resumable", RawState: "ended"})
+	if got != "resumable" {
+		t.Errorf("got %q, want %q", got, "resumable")
+	}
+}
+
 func TestTruncateWidth_JapanesePreservesWidth(t *testing.T) {
 	got := TruncateWidth("あいうえおかきくけこ", 6)
 	if got != "あいう" {


### PR DESCRIPTION
## Summary

ホスト再起動などで閉じられた claude session を、再起動後も picker から選んで復元できるようにする。#54（pane 再解決 + `terminated_at` の resurrect）と #55（resume 経路）の続き。

- `db.ResumableCandidates` — terminated だが resume で拾い直せる row を引く。`terminated_at` がセット済みで最後の event が `ended`、かつ `SessionEnd` の payload の `reason` が `prompt_input_exit` **でない**もの。`ForcedEnd` は payload を持たないので対象に含まれる
- `picker.filterResumable` — `transcript_path` と `cwd` が実際にファイル／ディレクトリとして存在する候補だけを残す。述語を注入する形なので、実ファイルシステムに依存せずテストできる
- 並び順は live な row の全部より後ろ（priority 6/7）。resumable 同士では終了直前の state が `working` / `awaiting_approval` だったものを先に出し、その中では新しい順
- 表示は `💤` / `[~]`（emoji・ascii 両方）と `resumable (was working)` 形の summary
- `--show-resumable`（既定 off）を picker に追加し、`dot/tmux.conf` の `bind-key Q` 側だけに付ける。`bind-key q`（既定ビュー）は変えない
- **live な row が 0 件のときは、resumable の候補数と flag 名を stderr に出す**
- 選択時の分岐は足していない。#55 の resume 経路にそのまま乗る
- resumable な row は `tmux_pane` を運ばない（クエリ側で NULL）

## Why

**view の絞り込みは緩めない。** `queue` view は「今どこかで動いている session」の定義で、status-right のカウント・`reconcile`・L3 自己修復がその定義に乗っている。終了済みを混ぜると生きている session を数える手段が消えるので、終了済み側だけを別クエリで引いて擬似 state `resumable` を付け、live な row の後ろへ並べる。既定 off にしたのは、平常時の picker が auto-GC の保持期間（7 日）ぶんの終了済み row を抱えて使いにくくなるのを避けるため。

**実在確認は選択時ではなく列挙時に行う。** 存在しない uuid を `--resume` に渡してもエラーにならず、その id で空の新規 session が立つ。短命 session は jsonl を書かないので `transcript_path` があってもファイルが無いことがあり、reap 済み worktree の session は cwd 側が消えている。ledger にパスがあることは確認になっていないので、resume できない row はそもそも一覧に出さない。案内に出す候補数も同じ確認を通したあとの数にする — でなければ resume できない row を数えて勧めることになる。

**`prompt_input_exit` を除くのは、拾いたいのが「切られた」session だから。** この reason は人が REPL を区切りで閉じた end で、ホスト再起動では `other`（signal 経由）か `ForcedEnd` になる。実データでの分布は `prompt_input_exit` 19 / `other` 44 / `ForcedEnd` 18。

**resumable な row から `tmux_pane` を落としたのは、picker の fallback の前提がこの row では崩れるから。** ledger は `tmux_pane` を終了時にクリアせず `COALESCE` で持ち回るので、resumable な row の pane は必ず「終わったプロセスの pane」になる。pane id は tmux server 単位のカウンタで新しい server は `%0` から振り直すため、再起動後は無関係な live pane に高確率で衝突する。picker が ledger の pane を信用するのは roster を読めなかったときだけで、その根拠は「roster を読めないことは session の死の証拠にならない」だが、`terminated_at` で選んだ row には成り立たない — 死んでいる証拠を別に持っているため。信用すると会話の復元ではなく他人の pane への switch になり、しかもエラーが出ない。pane が本当に到達可能なケースでは roster がプロセスを名指しでき picker が祖先を辿って再解決するので、列を落としても失うものは無い。

**live 0 件のときに案内するのは、再起動直後がまさにその状態だから。** popup の中から flag の存在に気づく経路が無く、既定 off の機能は必要になる瞬間に自分から名乗らないと無いのと同じになる。

`json_extract` を `json_valid` で守っているのは、reason 無しの `SessionEnd` が payload に空文字列を格納するため（`internal/hook/dispatch.go` の `buildPayload` は空 map のとき `""` を返す）。SQLite はこれを「不在」ではなく malformed JSON として拒否するので、守らないとクエリ全体が落ちる。

## テスト

- SQL の候補抽出: reason による除外（`SessionEnd` + `prompt_input_exit` は除外、`SessionEnd` + `other` と `ForcedEnd` は包含、payload 空文字列も包含）、並び順、prior state の解決（resume を挟んだ 2 周目を報告し、`ended` は prior state として数えない）、resume 入力（cwd / transcript）の受け渡し
- Go 側の実在確認フィルタを、注入した述語に対してテスト
- `FormatLine` の icon（emoji・ascii 両方が埋まっていること）と summary
- 選択時に resume 経路へ乗ること（stale な pane 列を持つ row から、pane 解決 → `DecideAction` まで通して `kill` 無しの resume に落ちる）。roster に居た場合に既存ロジック（attach）へ落ちることも
- live 0 件のときの案内（候補数と flag 名が入ること、既に flag が立っているときは出ないこと）

追加したテストは、①reason フィルタ ②interrupted-first の並び順 ③prior state の `ended` スキップ ④icon map の 2 種（emoji / ascii）⑤`tmux_pane` の NULL 化 をそれぞれ壊すと落ちることを確認済み。

## 既知の制約

`display-popup -E` は command の exit で popup を閉じるため、live 0 件のときの案内は `C-q q` 経路では読めず、picker をシェルから直接起動した場合に限られる。既存の `no active sessions` も同じ構造だが、読ませる前提の操作案内をそこに置いたのはこの変更が最初。到達性の改善（stdout に出して fzf の 1 行として見せる / `-EE` + 非 0 exit 等）は HOW の変更になるので、この PR では検証項目と design doc に制約として明記するに留めた。

## 検証

`~/.claude/session-queue.db` の**コピー**に対して確認（実 DB は読み取りのみ、live session は触っていない）。

- 実データ 128 sessions / 75 terminated に対し候補 52 件、`prompt_input_exit` の end は 1 件も混ざらない。実在確認を通したのは 32 件
- 全 session を terminated にしたコピー（再起動直後相当）で `picker` を起動すると `no active sessions, but 32 can be resumed: reopen the picker with --show-resumable (prefix Q)` が出る
- `--show-resumable` 付きでは live な row が先、resumable がその後ろ。resumable 内では `was working` が `was idle_done` より先、各群で新しい順。`CLAUDE_QUEUE_ASCII=1` で `[~]` に切り替わる
- 既定ビューには resumable な row が 1 件も出ない

再起動を挟む本番相当の検証は委譲元が別途行う。

## Refs

- #54 / #55（pane 再解決・`terminated_at` の resurrect・resume 経路）
- `src/claude-queue/README.md`「終了済み session の掘り起こし（`--show-resumable`）」節
- `docs/design/claude-tmux-worktree.md`「終了済み row は view を広げず別クエリで拾う」節
