### PR TITLE
docs: claude-reap-bg を worktree-scope と設計 doc に記載する

### DIFF
--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -13,6 +13,7 @@
 | Claude セッション可視化 | `src/claude-queue/`（→ `bin/claude-queue`）。詳細は同梱 README |
 | worktree 分岐起動 | `bin/claude-worktree` |
 | 委譲先の停止 | `bin/claude-stop-bg` |
+| 残存委譲先の掃除 | `bin/claude-reap-bg` |
 | エージェント運用ルール | `dot/claude/rules/worktree-scope.md` |
 
 ## レイヤ構成
@@ -114,7 +115,8 @@ claude-worktree [--tmux] <name> [-b <branch>] [-- <prompt...>]
 4. ユーザーは `claude attach <short-id>` で様子を見る。`C-q q`（③picker）からも同じ場所へ飛べる
    - 承認待ちで止まっていれば、attach した画面にその prompt がそのまま出る
 5. 委譲先は完遂しても session を終えず `idle` で待ち続ける。委譲元は完了報告を受けたら、
-   質問へ返信したかに関わらず `claude-stop-bg <short-id>` で閉じる（理由は後述）
+   質問へ返信したかに関わらず `claude-stop-bg <short-id>` で閉じる。閉じ手がいないまま残った
+   session は `claude-reap-bg` の sweep が後から拾う（理由はいずれも後述）
 
 ## 設計判断と根拠
 
@@ -155,6 +157,14 @@ prompt` とは別状態）で次の入力を待ち続ける。放置すると完
 幽霊行が残る。追跡がきれいに閉じるのは `claude stop`（= `claude-stop-bg`）で閉じた経路だけ。
 したがって委譲元は、完了報告を受けたら質問へ返信したかに関わらず `claude-stop-bg <short-id>` で
 閉じる（`delegate-to-worktree` 手順 6 / `worktree-scope.md` §6）。
+
+委譲元が閉じ損なう経路は残る。報告が届かない、委譲元の session が先に消える、人間が素の shell から
+`claude-worktree` を叩いて閉じ手が誰もいない — いずれでも `idle` の委譲先が居座る。そこを埋める
+二次経路が `claude-reap-bg`（`worktree-scope.md` §8）で、roster・claude-queue・transcript から
+「終わっていて、かつ返信を待っていない」と言える session だけを `claude-stop-bg` 経由で止める。
+外形からの判定は結局のところ推測なので、条件を欠くものは止めずに理由を report する側へ倒し、cron も
+置かず settings.json でも allow しない。引数無しで全 sweep できる道具を無人・無承認で走らせると、
+その推測が黙って生きた会話を消す形になる。
 
 worktree の滞留も同様に残る — ①はどちらの経路でも走り、誰も消さないので、後片付けは
 `worktree-scope.md` §7 の `git-reap-gone`（manual 運用）が担う。tmux session を作る経路は

--- a/dot/claude/rules/worktree-scope.md
+++ b/dot/claude/rules/worktree-scope.md
@@ -148,7 +148,7 @@ claude-worktree [--self] [--tmux] [--model <alias>] [--seed <path>]... <name> [-
 - `--` の後ろにプロンプトを渡すと、**既定では `claude --bg`（background agent, `acceptEdits`）が worktree dir で起動する**。tmux session も pane も作らない。委譲先はタスクを完遂しても session を終えず `idle` で残るので、委譲元が下記のとおり閉じる（**worktree も残る**ので、後片付けは §7 の `git-reap-gone`）。到達は `claude attach <short-id>`（`claude-worktree` が stdout に出す）か、claude-queue の picker（`C-q q`）から。承認待ちで止まった委譲先へ入る経路もこれ
 - `--tmux` を付けると従来どおり **detached tmux セッション（名前 = worktree basename）を作り、その pane で interactive claude を起動**する。人間が同席して協同する委譲（HOW をその場で詰める等）に使う。`gts <session>` でいつでも attach でき、REPL に留まる
 - `claude-worktree` が委譲元 session の name を解決し、プロンプト末尾へ `## 委譲元` 節（`報告先 name: <name>`）を自動付加する（`--tmux` 経路でも同じ。解決できないときは何も付かない）。委譲先はこれを受け取り、完了・不足・中断を SendMessage で委譲元へ報告する。**permission 承認だけはこの経路に乗らない**（tool call の途中で凍結するため委譲先自身が動けない）。承認は人間が attach して行う
-- 委譲元は委譲先から完了報告を受けたら、質問へ返信したかに関わらず `claude-stop-bg <short-id>` で閉じる（§7 の後片付けと同じく、保守的なラッパー経由で行う）。自然終了に任せない理由は 2 つ: 委譲先は完遂しても `idle`（承認待ちの `status: waiting` とは別状態）で次の入力を待ち続け、放置すると約 60 分居座る。しかもその自然消滅では `SessionEnd` が飛ばないため claude-queue の `terminated_at` が NULL のまま幽霊行が残る。追跡がきれいに閉じるのは `claude stop`（= `claude-stop-bg`）経路だけ
+- 委譲元は委譲先から完了報告を受けたら、質問へ返信したかに関わらず `claude-stop-bg <short-id>` で閉じる（§7 の後片付けと同じく、保守的なラッパー経由で行う）。自然終了に任せない理由は 2 つ: 委譲先は完遂しても `idle`（承認待ちの `status: waiting` とは別状態）で次の入力を待ち続け、放置すると約 60 分居座る。しかもその自然消滅では `SessionEnd` が飛ばないため claude-queue の `terminated_at` が NULL のまま幽霊行が残る。追跡がきれいに閉じるのは `claude stop`（= `claude-stop-bg`）経路だけ。この一次経路が取りこぼした session は §8 の `claude-reap-bg` が拾う
 - プロンプト無しなら worktree 追加のみ（stdout にパスのみ出力。`git wa` の置き換え）
 - `--self` は worktree の基準 repo を、cwd の repo ではなく **`claude-worktree` 自身が置かれている repo**（symlink 解決後。= dotrc）にする。無関係な project で作業中に dotrc のグローバル harness（rules / skills / bin）を切りたいときに使う。`--seed` のコピー元は `--self` の有無に関わらず cwd の checkout のまま
 - `--seed <path>`（繰り返し可）は、現 checkout の `<path>` を新 worktree の同じ相対位置へコピーする。存在しない／checkout 外の seed は worktree 作成前に fail する
@@ -201,3 +201,20 @@ git-reap-gone [--no-fetch] [<branch>...]
 - 引数でブランチ名を指定するとその対象だけを（同じゲートを通して）reap する。無指定なら全 `[gone]` を sweep。
 - **manual 運用**。cron/janitor の常駐は当面作らない。ただし全 `[gone]` を sweep できる形なので、将来そのまま cron/loop に挿せる。
 - settings.json で allow 済み（`git-reap-gone` / `git-reap-gone *`）なので承認なしで実行できる。
+
+### 8. 残存 background session の後片付け（`claude-reap-bg`）
+
+§7 がブランチと worktree を扱うのに対し、こちらは session を扱う。一次経路は §6 のとおり「委譲元が完了報告を受けて `claude-stop-bg <short-id>` で閉じる」で、`claude-reap-bg`（`bin/`）は**その取りこぼしを拾う二次経路**である。報告が届かない・委譲元の session が先に消える・人間が素の shell から `claude-worktree` を叩いて閉じ手が誰もいない、といった形で `idle` の委譲先が居座り、claude-queue に幽霊行が残る（理由は §6 の該当項）。閉じるべき主体が分かっているなら一次経路を使う。外から「終わっている」と判定するより、当事者が閉じるほうが確実。
+
+```
+claude-reap-bg [--dry-run] [--idle-minutes <n>] [<short-id>...]
+```
+
+- **`git-reap-gone`（§7）と同じ思想**。保守的な predicate を全通過したものだけ停止し、欠けるものは skip して blocking 理由を report する。skip があっても exit 0（manual な best-effort）。
+- **stop してよい条件（全通過のみ）**: ①roster（`claude agents --json`）が `kind == "background"` かつ `status == "idle"`、②claude-queue の最新 state が `idle_done`（`Stop` hook が書く）で、その event から `--idle-minutes`（既定 15）以上経っている、③transcript の最後の assistant ターンに `SendMessage` の tool_use が無い。③が bulk sweep を成立させている条件で、委譲元へ質問を送って返信を待つ委譲先も外からは `idle` に見えるため、これが無いと生きた作業を殺す。確認そのものができないもの（claude-queue に生きた row が無い・transcript が読めない／parse できない）も、止めずに skip する。
+- **停止は `claude-stop-bg` 経由**で、`claude stop` を直接は呼ばない。あちらの guard（background 以外を拒否、一意に解決しない id を拒否）が上の条件に重ねて効く。
+- 引数で short-id（8 桁）を指定するとその対象だけを（同じゲートを通して）stop する。無指定なら全 sweep。ゲートに掛からなかった id は skip として report されるので、名指ししたのに何も起きない理由が分かる。`--dry-run` は対象を report するだけで何も止めない。
+- **manual 運用**。cron/daemon の常駐は作らない。無人で走る session killer は、上の保守的な predicate がまさに避けようとしているものだから。
+- **settings.json では allow していない**（単一 id 指定に閉じた `claude-stop-bg` を allow しているのとは非対称）。引数無しで全 sweep できる形なので、allow すると agent へ session の一括 kill 権限を渡すことになり、grant の射程が読めない。実行ごとに承認プロンプトを踏むのは意図した摩擦で、まず `--dry-run` で対象を出してから承認を仰ぐ。
+
+設計上の位置づけ（一次経路と二次経路の天秤、cron を置かない理由）は `docs/design/claude-tmux-worktree.md` の「④の既定は `claude --bg`」節に一本化してある。


### PR DESCRIPTION
## Summary

`bin/claude-reap-bg` が repo に存在するのに、どの doc にも記載が無かった。人間も将来の agent も
その存在を知る経路が無く、残存 background session の後片付け手段として使われないまま埋もれる。
実装は変えず、記載だけを足す。

- `dot/claude/rules/worktree-scope.md`: §8「残存 background session の後片付け（`claude-reap-bg`）」を
  新設。§7（ブランチ／worktree の後片付け = `git-reap-gone`）の並びに置き、session を扱う面として
  分けた。usage、stop の全通過条件（roster が `kind == "background"` かつ `status == "idle"` /
  claude-queue の最新 state が `idle_done` で `--idle-minutes`（既定 15）以上経過 / transcript の
  最後の assistant ターンに `SendMessage` の tool_use が無い）、`claude-stop-bg` 経由で止めること、
  manual 運用、settings.json で allow していないことを記述。§6 の `claude-stop-bg` の項からも
  §8 へ辿れるようにした。
- `docs/design/claude-tmux-worktree.md`: 関連ファイルの表に `bin/claude-reap-bg` を追加。
  エンドツーエンドの流れ 5 と「④の既定は `claude --bg`」節に、閉じ手がいなかった場合の二次経路として
  追記した。

## Why

一次経路は「委譲元が完了報告を受けて `claude-stop-bg <short-id>` で閉じる」（`worktree-scope.md` §6）で、
`claude-reap-bg` はその取りこぼしを拾う二次経路である。この位置づけを両方の doc で明示した。閉じるべき
主体が分かっているなら、外形から「終わっている」と推測して掃くより当事者が閉じるほうが確実だから。

記述の分担は `doc-authoring.md` 観点 3（重複の一本化）に従って分けた。predicate や flag の列挙は
agent が読む rules 側に置き、design doc 側は「外形からの判定は推測なので保守側へ倒す」「だから cron を
置かず settings.json でも allow しない」という設計判断だけを述べ、詳細は rules を参照させる。

`settings.json` で allow しないのは意図した判断で、そのように書いた。引数無しで全 sweep できる形なので、
allow は agent へ session の一括 kill 権限を渡すことになる（単一 id 指定に閉じた `claude-stop-bg` を
allow しているのとは非対称）。実行ごとの承認プロンプトは意図した摩擦として残す。

記述は `bin/claude-reap-bg` / `bin/claude-stop-bg` の実装を読んで裏を取った。委譲時点の理解と実装が
食い違っていた 2 点は実装に合わせている: 経過時間の判定は claude-queue の最新 state が `idle_done`
であることを見る（`Stop` hook が書く state で、`Stop` という state 名ではない）、および positional 引数で
short-id を渡すと sweep 対象をその id に絞れる（同じゲートは通る）。

## Refs

- `bin/claude-reap-bg`, `bin/claude-stop-bg`, `bin/git-reap-gone`
- `dot/claude/rules/doc-authoring.md`, `dot/claude/rules/rule-authoring.md`
