### PR TITLE
test(claude-queue): reconcile の誤 terminate が可逆であることを pin する

### DIFF
--- a/src/claude-queue/internal/hook/dispatch_test.go
+++ b/src/claude-queue/internal/hook/dispatch_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
+	"github.com/knagiri/dotrc/src/claude-queue/internal/state"
 )
 
 func openTestDB(t *testing.T) *Deps {
@@ -208,6 +209,126 @@ func TestDispatch_SessionEndStillTerminatesAfterResurrect(t *testing.T) {
 	}
 	if !terminated.Valid {
 		t.Error("terminated_at is NULL after the second SessionEnd, want it set")
+	}
+}
+
+// queueRows counts how many rows the picker's view surfaces for a session. The
+// view has two predicates -- terminated_at IS NULL and a latest event that is
+// not 'ended' -- so it is the only assertion that covers both halves of a
+// resurrection at once.
+func queueRows(t *testing.T, d *Deps, id string) int {
+	t.Helper()
+	var n int
+	if err := d.DB.QueryRow(
+		"SELECT COUNT(*) FROM queue WHERE session_id = ?", id,
+	).Scan(&n); err != nil {
+		t.Fatalf("count queue rows for %s: %v", id, err)
+	}
+	return n
+}
+
+func terminatedAt(t *testing.T, d *Deps, id string) sql.NullInt64 {
+	t.Helper()
+	var at sql.NullInt64
+	if err := d.DB.QueryRow(
+		"SELECT terminated_at FROM sessions WHERE session_id = ?", id,
+	).Scan(&at); err != nil {
+		t.Fatalf("query terminated_at for %s: %v", id, err)
+	}
+	return at
+}
+
+// reconcileTerminate replays what a `claude-queue reconcile` pass does to a row
+// it judges gone -- db.TerminateSession is literally the per-session call
+// reconcile.Sweep makes -- and asserts the row really did leave the view, so a
+// later "it came back" assertion cannot pass by never having left.
+func reconcileTerminate(t *testing.T, d *Deps, id string) {
+	t.Helper()
+	if err := db.TerminateSession(d.DB, id); err != nil {
+		t.Fatalf("TerminateSession(%s): %v", id, err)
+	}
+	if n := queueRows(t, d, id); n != 0 {
+		t.Fatalf("session %s still has %d queue row(s) right after reconcile closed it", id, n)
+	}
+}
+
+// reconcile closes every tracked row that `claude agents --json` does not list,
+// and a session that is alive but absent from that roster is a misjudgement
+// rather than an impossibility. This pins the misjudgement as RECOVERABLE: the
+// next hook event from the still-running session puts it back in the queue view.
+//
+// The table covers every event that says "alive", not just SessionStart,
+// because a session that reconcile wrongly closed is by definition already up
+// and will never fire SessionStart again -- recovery that needed one would be no
+// recovery at all for the case that motivates it.
+//
+// Both mechanisms are asserted separately, since either one regressing alone is
+// enough to make the terminate permanent:
+//   - upsertSession clears terminated_at (the view's terminated_at IS NULL)
+//   - the event Dispatch inserts carries a non-'ended' state (the view's
+//     e.state != 'ended'), superseding the synthetic ForcedEnd reconcile wrote
+func TestDispatch_AfterReconcileTerminate_LiveEventRestoresRow(t *testing.T) {
+	for _, ev := range []string{
+		"SessionStart", "UserPromptSubmit",
+		"PermissionRequest", "PermissionDenied",
+		"PostToolUse", "PostToolUseFailure",
+		"Stop", "StopFailure",
+	} {
+		t.Run(ev, func(t *testing.T) {
+			d := openTestDB(t)
+			seed := &Input{SessionID: "s", HookEventName: "SessionStart", Cwd: "/work"}
+			if err := Dispatch(d, "SessionStart", seed); err != nil {
+				t.Fatalf("seed SessionStart: %v", err)
+			}
+			reconcileTerminate(t, d, "s")
+
+			in := &Input{SessionID: "s", HookEventName: ev, ToolName: "Bash"}
+			if err := Dispatch(d, ev, in); err != nil {
+				t.Fatalf("%s after reconcile: %v", ev, err)
+			}
+
+			if at := terminatedAt(t, d, "s"); at.Valid {
+				t.Errorf("terminated_at = %d after %s, want NULL", at.Int64, ev)
+			}
+			if n := queueRows(t, d, "s"); n != 1 {
+				t.Errorf("queue rows after %s = %d, want 1", ev, n)
+			}
+			want, _ := state.ForEvent(ev)
+			var got string
+			if err := d.DB.QueryRow(
+				"SELECT raw_state FROM queue WHERE session_id = 's'",
+			).Scan(&got); err != nil {
+				t.Fatalf("query raw_state: %v", err)
+			}
+			if got != want {
+				t.Errorf("raw_state = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// The recovery above must not extend to SessionEnd. It is the one event that is
+// not evidence of life, so a session reconcile closed and that then genuinely
+// ends has to stay closed -- otherwise the upsert's terminated_at = NULL would
+// reopen rows on the way out.
+func TestDispatch_AfterReconcileTerminate_SessionEndStaysClosed(t *testing.T) {
+	d := openTestDB(t)
+	seed := &Input{SessionID: "s", HookEventName: "SessionStart", Cwd: "/work"}
+	if err := Dispatch(d, "SessionStart", seed); err != nil {
+		t.Fatalf("seed SessionStart: %v", err)
+	}
+	reconcileTerminate(t, d, "s")
+
+	end := &Input{SessionID: "s", HookEventName: "SessionEnd", Reason: "other"}
+	if err := Dispatch(d, "SessionEnd", end); err != nil {
+		t.Fatalf("SessionEnd after reconcile: %v", err)
+	}
+
+	if at := terminatedAt(t, d, "s"); !at.Valid {
+		t.Error("terminated_at is NULL after SessionEnd, want it set")
+	}
+	if n := queueRows(t, d, "s"); n != 0 {
+		t.Errorf("queue rows after SessionEnd = %d, want 0", n)
 	}
 }
 


### PR DESCRIPTION
## Summary

`claude-queue reconcile` の誤 terminate が不可逆かどうかを実装から判定し、その結論を回帰テストで pin した。

**判定は分岐 A — 不可逆性は既に解消済み。** しかも `SessionStart` 限定ではなく、**どの生存 hook event でも**巻き戻る。実装変更は無く、追加は `internal/hook/dispatch_test.go` の 121 行のみ。

### 根拠（読んだ箇所）

復帰には 2 つの述語を解く必要があり、`queue` view（`internal/db/schema.go`）は `s.terminated_at IS NULL` **と** `e.state != 'ended'` の両方を要求する。reconcile はその両方を閉じる: `db.TerminateSession`（`internal/db/queries.go`）が `terminated_at` を立て、かつ合成 `ForcedEnd`/`'ended'` を最新 event として書く。

1. `internal/hook/dispatch.go` の `upsertSession` が `ON CONFLICT DO UPDATE` で `terminated_at = NULL` を立てる（8936769 で入った）。event 種別で絞っていないので `Dispatch` が受ける全 event で効き、1 つ目の述語を解く。`SessionEnd` は同一 tx 内で upsert の**後**に `terminated_at` を再設定するため、正しく終了扱いのまま残る。
2. `internal/state/transitions.go` の table を見ると、`SessionEnd` / 合成 `ForcedEnd` 以外の全 event が非 `'ended'` 状態へ写る。したがって後続の生存 event が挿す行が `ForcedEnd` を最新から押しのけ、2 つ目の述語も解ける。

`SessionStart` に限られないことが結論を分岐 A に落とす鍵。reconcile が誤判定しうるのは「生きているが roster に載らない session」だけで、そのような session は既に起動済みなので二度と `SessionStart` を出さない。`SessionStart` 限定の復帰なら、その唯一のケースに対しては復帰していないことになる。

### テスト

- `TestDispatch_AfterReconcileTerminate_LiveEventRestoresRow` — reconcile の閉じ方そのもの（`db.TerminateSession`。`reconcile.Sweep` が session ごとに呼ぶ実物）で閉じたうえで、生存 event 8 種（`SessionStart` / `UserPromptSubmit` / `PermissionRequest` / `PermissionDenied` / `PostToolUse` / `PostToolUseFailure` / `Stop` / `StopFailure`）それぞれで `queue` view に復帰することを assert する。`terminated_at` と view 行数を別々に見るのは、上の 2 機構のどちらが単独で壊れても permanent terminate に戻るため。復帰後の `raw_state` も見て、行が「在る」だけでなく正しい状態で戻ることを押さえる。
- `TestDispatch_AfterReconcileTerminate_SessionEndStaysClosed` — 対の否定側。`SessionEnd` は生存を示さないので、reconcile が閉じた後に本当に終了した session は閉じたまま残る。
- ヘルパー `reconcileTerminate` は閉じた直後に view から消えたことも assert するので、「復帰した」の assert が「そもそも消えていなかった」で通り抜けることがない。

**判別力の確認**: `upsertSession` から `terminated_at = NULL` を外すと 8 subtest すべてが落ちる（既存の `TestDispatch_SessionStartAfterEnd_Resurrects` も落ちる）。復帰後に戻して全 green。

## Why

reconcile 導入時のレビューで severity high の指摘が出ていた — 生存中の session を一度 terminate すると以後の hook event でも `queue` view に復帰せず、`db.GC` の 7 日保持まで見えなくなる、というもの。当時は実 DB で照合した限り判定は正しく、トリガー（roster に載らない種別の session）も未観測だったため、証拠なく grace period を足すのは `evidence-over-guesswork` に反するとしてゲートされた。

その後 8936769 が `--resume` の別問題を直す過程でこの不可逆性も解消していた。ただし副作用として解消されただけで、reconcile 経路をガードするテストは無かった。そこで grace period のような挙動変更は入れず、既に成り立っている可逆性を pin するテストだけを足した。8936769 が将来意図せず戻されたときに落ちる。

`terminated_at = NULL` を全 event に効かせる設計は 8936769 のコメントが `--resume` を理由に説明しているが、reconcile の誤判定に対する可逆性という第 2 の理由は記録されていなかった。テストのコメントがそれを担う。

## Refs

- 8936769 `fix(claude-queue): SessionStart で terminated_at を戻して resume を picker に出す`（PR #55）