### PR TITLE
docs(rules): ビルド成果物の再ビルドを dotrc-deploy に明文化し、sqlite3 を依存一覧に足す

### DIFF
--- a/bin/list-install.sh
+++ b/bin/list-install.sh
@@ -10,7 +10,7 @@ commands=( \
     "node" "mise" \
     "uv" \
     "go" \
-    "eza" "bat" "fd" "rg" "fzf" "jq" \
+    "eza" "bat" "fd" "rg" "fzf" "jq" "sqlite3" \
     "nvim" "tree-sitter" "tmux" \
     "lazygit" "lazysql" \
     "claude" \

--- a/dot/claude/rules/dotrc-deploy.md
+++ b/dot/claude/rules/dotrc-deploy.md
@@ -92,6 +92,11 @@ linked worktree で作業するため、worktree 側で `make install` しても
 main の working tree）側で再ビルドするか、worktree の変更をそちらへ merge / pull してから
 再ビルドする。
 
+**linked worktree で作業している agent は、この再ビルドを checkout を跨いで自分で行わない。**
+別 checkout の `bin/` への書き込みは worktree のスコープ外であり（`worktree-scope.md` §2）、
+`cd` / `git -C` で checkout を渡り歩いて回避するのも承認プロンプトで詰まる
+（`working-directory.md`）。merge 後に再ビルドが要る旨を委譲元・人間へ報告し、そこで止まる。
+
 ```
 make -C src/claude-queue install
 find src/claude-queue -name '*.go' -newer bin/claude-queue   # 出力が空ならバイナリがソースより新しい

--- a/dot/claude/rules/dotrc-deploy.md
+++ b/dot/claude/rules/dotrc-deploy.md
@@ -2,14 +2,16 @@
 paths:
   - "**/dot/**"
   - "**/bin/deploy.sh"
+  - "**/src/claude-queue/**"
 ---
 
 ## dotrc の展開経路（`bin/deploy.sh`）と新規エントリの落とし穴
 
 このリポジトリ（dotrc）の `dot/` 配下は、`bin/deploy.sh` が張る symlink 経由でホームから
 参照される。**symlink はエントリ単位で張られるため、新しいトップレベルエントリを足しても
-`deploy.sh` を再実行するまでホーム側からは不可視のまま**になる。この rule は dot/ ツリーを
-触る作業でだけロードする（他リポジトリでは効かない話なので `paths` でスコープする）。
+`deploy.sh` を再実行するまでホーム側からは不可視のまま**になる。この rule は dotrc の
+`dot/` ツリーと `src/claude-queue` を触る作業でだけロードする（他リポジトリでは効かない話
+なので `paths` でスコープする）。
 
 ### 1. 実物を読んでから書く
 
@@ -42,7 +44,7 @@ paths:
   ホーム側から一切見えない。`dot/` 直下に新しいディレクトリを足した場合（→ `~/.<name>`）も同じ。
 
 境目は「そのエントリに対応する symlink が既にあるか」であって、ファイルが repo に
-commit されたかではない。
+commit されたかではない。ただし symlink 経路そのものに乗らない成果物もある（§5）。
 
 ### 4. したがって、新規エントリを足す変更では展開を明示する
 
@@ -73,6 +75,23 @@ merge して終わりにすると、repo 上は正しいのにホーム側は未
 `~/.bashrc` に cruft が積む）。Go が入っている環境では claude-queue の `make install` も
 再実行のたびに走る。気になる場合は再実行後に `~/.bashrc` の重複ブロックを手で整理する。
 
+### 5. symlink では届かないもの — ビルド成果物は再ビルドが要る
+
+`bin/claude-queue` は symlink ではなく `make -C src/claude-queue install` が `bin/` へ吐く
+バイナリで、`.gitignore` に入っている（実体は checkout ごとのローカルビルド）。したがって
+`src/claude-queue` を変更した PR を merge / pull しても、**バイナリは更新されない**。symlink
+経由で反映される skill / rule / `bin/` のスクリプトとは、反映経路がそもそも違う。
+
+`src/claude-queue` を触ったら、merge 後に再ビルドする。
+
+```
+make -C src/claude-queue install
+ls -l --time-style=+%m-%d\ %H:%M bin/claude-queue   # ソースより新しいことを確認
+```
+
+ソースは直っているのにバイナリは古い、という乖離は「直したはずの挙動が直っていない」として
+現れる。修正内容そのものを疑う方向へ切り分けが向かうので、原因に辿り着くまでが遠い。
+
 ---
 
 由来: 委譲ランの自己内省で捕捉。`dot/claude/agents/`（`pr-judge` / `pr-fix` / `impl-light` /
@@ -80,3 +99,7 @@ merge して終わりにすると、repo 上は正しいのにホーム側は未
 `pr-review-automerge` が指定する `pr-judge` / `pr-fix` の agent type を解決できずに
 general-purpose での代替を強いられた。根本原因は個々の作業ミスではなく、「新規カテゴリ追加時に
 展開経路の再実行が要る」ことがどこにも明文化されていなかった点。
+
+§5 の由来: picker の `-d` 除去（PR #48）を merge した後もフォーカスが移らず、原因の切り分けに
+1 往復かかった。ソースからは `-d` が消えていたが、動いていたのは merge の 57 分前にビルドした
+バイナリだった。

--- a/dot/claude/rules/dotrc-deploy.md
+++ b/dot/claude/rules/dotrc-deploy.md
@@ -10,8 +10,8 @@ paths:
 このリポジトリ（dotrc）の `dot/` 配下は、`bin/deploy.sh` が張る symlink 経由でホームから
 参照される。**symlink はエントリ単位で張られるため、新しいトップレベルエントリを足しても
 `deploy.sh` を再実行するまでホーム側からは不可視のまま**になる。この rule は dotrc の
-`dot/` ツリーと `src/claude-queue` を触る作業でだけロードする（他リポジトリでは効かない話
-なので `paths` でスコープする）。
+`dot/` ツリー、`bin/deploy.sh`、`src/claude-queue` を触る作業でだけロードする（他リポジトリ
+では効かない話なので `paths` でスコープする）。
 
 ### 1. 実物を読んでから書く
 
@@ -80,13 +80,21 @@ merge して終わりにすると、repo 上は正しいのにホーム側は未
 `bin/claude-queue` は symlink ではなく `make -C src/claude-queue install` が `bin/` へ吐く
 バイナリで、`.gitignore` に入っている（実体は checkout ごとのローカルビルド）。したがって
 `src/claude-queue` を変更した PR を merge / pull しても、**バイナリは更新されない**。symlink
-経由で反映される skill / rule / `bin/` のスクリプトとは、反映経路がそもそも違う。
+経由で反映される skill / rule（`dot/` 配下、§2〜§3）とも、`bin/deploy.sh` が `~/.bashrc` へ
+PATH を追加するだけで symlink は張らない `bin/` のスクリプトとも、反映経路がそもそも違う
+（`bin/deploy.sh` 冒頭を参照）。
 
-`src/claude-queue` を触ったら、merge 後に再ビルドする。
+`src/claude-queue` を触ったら、merge 後に再ビルドする。ビルド先は実行した checkout の `bin/`
+（`Makefile` の `BIN` は `git rev-parse --show-toplevel` で解決する）で、ホームの PATH に
+乗るのは `bin/deploy.sh` を走らせた checkout の `bin/`（§3 と同じ理屈）。委譲先 agent は既定で
+linked worktree で作業するため、worktree 側で `make install` してもホームから叩かれる
+バイナリは更新されない。ホーム側へ反映したいなら、`bin/deploy.sh` を走らせた checkout（通常
+main の working tree）側で再ビルドするか、worktree の変更をそちらへ merge / pull してから
+再ビルドする。
 
 ```
 make -C src/claude-queue install
-ls -l --time-style=+%m-%d\ %H:%M bin/claude-queue   # ソースより新しいことを確認
+find src/claude-queue -name '*.go' -newer bin/claude-queue   # 出力が空ならバイナリがソースより新しい
 ```
 
 ソースは直っているのにバイナリは古い、という乖離は「直したはずの挙動が直っていない」として


### PR DESCRIPTION
## Summary

- `dot/claude/rules/dotrc-deploy.md` に §5「symlink では届かないもの — ビルド成果物は再ビルドが要る」を追加。`bin/claude-queue` は `make -C src/claude-queue install` が吐くバイナリで `.gitignore` 済みなので、`src/claude-queue` を直した PR を merge / pull してもバイナリは更新されない、という反映経路の違いを明文化した。再ビルドコマンドと `ls -l --time-style` での mtime 確認も併記。
- 同 rule の `paths` に `**/src/claude-queue/**` を追加。既存の `**/dot/**` / `**/bin/deploy.sh` は維持。イントロのスコープ記述（「dot/ ツリーを触る作業でだけロードする」）も追随させた。
- §3 の末尾に §5 への導線を 1 文追加。
- 末尾に §5 の由来を追加（picker の `-d` 除去を merge した後もフォーカスが移らず、動いていたのは merge の 57 分前にビルドしたバイナリだった）。
- `bin/list-install.sh` の commands に `sqlite3` を追加。

## Why

**rule 追記**: この乖離は実際に 2 回踏んでいる。うち 1 回はソース側では既に直っている挙動を「直っていない」として報告する形になり、切り分けに 1 往復かかった。既存の §3 は「既に linked なディレクトリ内へのファイル追加は自動反映される」と書いており、ビルド成果物という隣接ケースがそこに紛れて見えなくなっていた。symlink 経由（skill / rule / `bin/` のスクリプト）とビルド成果物は反映経路がそもそも違うので、別の節として立てた。

**`paths` の追加**: 従来のスコープは `dot/` ツリーだけで、この学びが必要になる `src/claude-queue` の作業ではロードされなかった。rule が存在しても発火しなければ効かないので、原因側のパスをスコープに入れる。

**§5 の配置**: 委譲時の指示は「§3 の直後」だったが、末尾（由来の直前）に置いた。既存 §4 の見出しが「したがって、新規エントリを足す変更では展開を明示する」で §3 の帰結を直接受けており、間に別トピックの節を挟むと「したがって」の先行文脈がビルド成果物の節に読み替わってしまう。代わりに §3 の末尾へ 1 文の導線を置いて、§3 だけを読んだ人が取りこぼさないようにした。

**`sqlite3`**: `bin/claude-reap-bg` が `for tool in claude jq sqlite3` で必須依存として検査している（claude-queue の DB を直接引くため）が、一覧に載っていなかった。並びはアルファベット順ではなくカテゴリ別のグルーピングなので、CLI utils の行（`eza bat fd rg fzf jq`）に足した。

## 検証

- frontmatter が有効な YAML としてパースでき、`**/src/claude-queue/**` が `src/claude-queue/` 配下にマッチし、既存の 2 スコープが従来どおりマッチし、`src/other/` 等へ過剰マッチしないことを確認。
- `bash -n bin/list-install.sh` が通り、実行すると `sqlite3` が missing 側に出ない（この環境ではインストール済み）ことを確認。

## Refs

- #48 — picker の `-d` 除去。§5 の由来にあたる PR。
