### PR TITLE
fix(gh-pr-checks): superseded な cancelled run を failure から外す

### DIFF
--- a/bin/gh-pr-checks
+++ b/bin/gh-pr-checks
@@ -41,16 +41,28 @@ set -euo pipefail
 # failures.
 #
 # So a cancelled run is dropped from the failure count only when a *newer
-# completed run of the same workflow name* exists. Deliberately not a blanket
-# dedup down to the highest run_number per name: a lone cancelled run (human
+# completed run of the same workflow* exists. Deliberately not a blanket
+# dedup down to the highest run_number per workflow: a lone cancelled run (human
 # stop, job timeout) has to keep counting, and a config where push and
 # pull_request both fire on one SHA legitimately has two same-named runs, one of
 # which a blanket dedup would silently discard. run_number is the ordering key,
 # and it is per-workflow -- in the measurement `Go Lint and Build` and `Go Test`
-# both carried 5119/5120 -- so the comparison must be grouped by name and is
-# never global. A run with no run_number can neither be superseded nor supersede
-# anything, and commit statuses (source == "status") have no run_number at all,
-# so they are outside this entirely.
+# both carried 5119/5120 -- so the comparison must be grouped and is never
+# global.
+#
+# The grouping key is workflow_id, not name. GitHub lets two distinct workflow
+# *files* share the same `name:`, and run_number is a per-file counter, not a
+# per-name one -- so a same-named pair of files would let one file's high
+# run_number exonerate the other file's real cancellation, which is the
+# dangerous direction (a real failure read as passed). workflow_id uniquely
+# identifies the file and is a required field on every actions/runs entry, so
+# grouping by it costs nothing. A run (or commit status) whose grouping key is
+# null can neither be superseded nor supersede anything: `jq` aborts with
+# "Cannot index object with null" if an object is indexed by a null key rather
+# than falling through `//`, so both `newest_completed` and `is_superseded`
+# must guard the key before using it, symmetrically. A run with no run_number
+# is excluded the same way, and commit statuses (source == "status") have
+# neither run_number nor workflow_id, so they are outside this entirely.
 #
 # The two payloads reach jq on stdin rather than through --argjson. Linux caps a
 # *single* argv element at MAX_ARG_STRLEN (128 KiB), independently of the much
@@ -97,10 +109,12 @@ fi
 # way `gh run list --limit N` can lose it. --jq drops every field the report
 # below never reads, while keeping the response shape ({workflow_runs: [...]},
 # {statuses: [...]}) that the program still indexes into. run_number is kept
-# because it is the ordering key the superseded-run rule above needs; without it
-# a projected run carries no way to tell which of two same-named runs is newer.
+# because it is the ordering key the superseded-run rule above needs, and
+# workflow_id because it is that rule's grouping key -- without both, a
+# projected run carries no way to tell which of two runs of the same workflow
+# is newer.
 runs=$(gh api "repos/$repo/actions/runs?head_sha=$sha&per_page=100" \
-  --jq '{workflow_runs: [(.workflow_runs // [])[] | {name, status, conclusion, run_number}]}')
+  --jq '{workflow_runs: [(.workflow_runs // [])[] | {name, status, conclusion, run_number, workflow_id}]}')
 # Commit statuses catch external CI that never creates an Actions run.
 statuses=$(gh api "repos/$repo/commits/$sha/status" \
   --jq '{statuses: [(.statuses // [])[] | {context, state}]}')
@@ -108,20 +122,25 @@ statuses=$(gh api "repos/$repo/commits/$sha/status" \
 # skipped / neutral are not failures: a skipped job is the normal outcome of a
 # paths-filter, so treating it as a failure would block merges on unrelated PRs.
 printf '%s\n%s\n' "$runs" "$statuses" | jq -n --argjson pr "$pr" --arg sha "$sha" '
-  # $newest maps a workflow name to the highest run_number it has among
-  # *completed* runs. A still-running replacement therefore does not yet
-  # exonerate the run it cancelled -- the gate stays shut until it finishes,
-  # which is the conservative direction.
+  # $newest maps a workflow_id (as a string -- jq object keys must be strings)
+  # to the highest run_number it has among *completed* runs. A still-running
+  # replacement therefore does not yet exonerate the run it cancelled -- the
+  # gate stays shut until it finishes, which is the conservative direction.
   def newest_completed:
     reduce (.[]
             | select(.source == "actions" and .status == "completed"
-                     and .name != null and .run_number != null))
-      as $r ({}; .[$r.name] = ([(.[$r.name] // -1), $r.run_number] | max));
-  # Strictly greater, so two same-named runs sharing a run_number supersede
-  # neither each other nor themselves.
+                     and .workflow_id != null and .run_number != null))
+      as $r ({}; .[($r.workflow_id|tostring)] =
+               ([(.[($r.workflow_id|tostring)] // -1), $r.run_number] | max));
+  # Strictly greater, so two runs of the same workflow sharing a run_number
+  # supersede neither each other nor themselves. The workflow_id != null guard
+  # mirrors the one in newest_completed: indexing $newest with a null key is a
+  # jq hard error ("Cannot index object with null"), raised before the `//`
+  # fallback ever runs, so the guard has to come first rather than relying on
+  # `//` alone.
   def is_superseded($newest):
-    .source == "actions" and .run_number != null
-    and (($newest[.name] // -1) > .run_number);
+    .source == "actions" and .workflow_id != null and .run_number != null
+    and (($newest[(.workflow_id|tostring)] // -1) > .run_number);
 
   def is_failure:
     if .source == "actions"
@@ -150,12 +169,12 @@ printf '%s\n%s\n' "$runs" "$statuses" | jq -n --argjson pr "$pr" --arg sha "$sha
   | (input) as $statuses
   | [ ($runs.workflow_runs // [])[]
     | {name: .name, source: "actions", status: .status, conclusion: .conclusion,
-       run_number: .run_number} ]
+       run_number: .run_number, workflow_id: .workflow_id} ]
   + [ ($statuses.statuses // [])[]
     | {name: .context, source: "status",
        status: (if .state == "pending" then "pending" else "completed" end),
        conclusion: (if .state == "pending" then null else .state end),
-       run_number: null} ]
+       run_number: null, workflow_id: null} ]
   | . as $raw
   | (($raw | newest_completed) as $newest
      | [ $raw[] | . + {superseded: is_superseded($newest)} ]) as $checks

--- a/bin/gh-pr-checks
+++ b/bin/gh-pr-checks
@@ -28,6 +28,30 @@ set -euo pipefail
 #   stance that pending checks are not waited on (auto-merge waits instead).
 # - At most 100 Actions runs for the head SHA are read (no pagination).
 #
+# A cancelled Actions run counts as a failure: a run stopped by a human, or by a
+# job-level timeout, must never read as "passed". That stays. But
+# `concurrency: cancel-in-progress: true` manufactures cancelled runs that mean
+# the opposite -- a later event killed an in-flight run and replaced it, and the
+# head_sha listing keeps *both* the killed run (cancelled) and its replacement
+# (success). The stale cancelled one then pinned has_failure to true forever, so
+# the merge gate never reopened even though every workflow had in fact passed.
+# Measured on a work repo: releasing a draft PR with `gh pr ready` fires
+# pull_request for both `opened` and `ready_for_review`, so all 22 workflows ran
+# twice (49 runs) and this wrapper reported "5 failure" against zero real
+# failures.
+#
+# So a cancelled run is dropped from the failure count only when a *newer
+# completed run of the same workflow name* exists. Deliberately not a blanket
+# dedup down to the highest run_number per name: a lone cancelled run (human
+# stop, job timeout) has to keep counting, and a config where push and
+# pull_request both fire on one SHA legitimately has two same-named runs, one of
+# which a blanket dedup would silently discard. run_number is the ordering key,
+# and it is per-workflow -- in the measurement `Go Lint and Build` and `Go Test`
+# both carried 5119/5120 -- so the comparison must be grouped by name and is
+# never global. A run with no run_number can neither be superseded nor supersede
+# anything, and commit statuses (source == "status") have no run_number at all,
+# so they are outside this entirely.
+#
 # The two payloads reach jq on stdin rather than through --argjson. Linux caps a
 # *single* argv element at MAX_ARG_STRLEN (128 KiB), independently of the much
 # larger ARG_MAX total (2 MiB here), so one oversized element is enough to make
@@ -72,9 +96,11 @@ fi
 # head_sha filters server-side, so nothing is lost to a client-side cutoff the
 # way `gh run list --limit N` can lose it. --jq drops every field the report
 # below never reads, while keeping the response shape ({workflow_runs: [...]},
-# {statuses: [...]}) that the program still indexes into.
+# {statuses: [...]}) that the program still indexes into. run_number is kept
+# because it is the ordering key the superseded-run rule above needs; without it
+# a projected run carries no way to tell which of two same-named runs is newer.
 runs=$(gh api "repos/$repo/actions/runs?head_sha=$sha&per_page=100" \
-  --jq '{workflow_runs: [(.workflow_runs // [])[] | {name, status, conclusion}]}')
+  --jq '{workflow_runs: [(.workflow_runs // [])[] | {name, status, conclusion, run_number}]}')
 # Commit statuses catch external CI that never creates an Actions run.
 statuses=$(gh api "repos/$repo/commits/$sha/status" \
   --jq '{statuses: [(.statuses // [])[] | {context, state}]}')
@@ -82,9 +108,29 @@ statuses=$(gh api "repos/$repo/commits/$sha/status" \
 # skipped / neutral are not failures: a skipped job is the normal outcome of a
 # paths-filter, so treating it as a failure would block merges on unrelated PRs.
 printf '%s\n%s\n' "$runs" "$statuses" | jq -n --argjson pr "$pr" --arg sha "$sha" '
+  # $newest maps a workflow name to the highest run_number it has among
+  # *completed* runs. A still-running replacement therefore does not yet
+  # exonerate the run it cancelled -- the gate stays shut until it finishes,
+  # which is the conservative direction.
+  def newest_completed:
+    reduce (.[]
+            | select(.source == "actions" and .status == "completed"
+                     and .name != null and .run_number != null))
+      as $r ({}; .[$r.name] = ([(.[$r.name] // -1), $r.run_number] | max));
+  # Strictly greater, so two same-named runs sharing a run_number supersede
+  # neither each other nor themselves.
+  def is_superseded($newest):
+    .source == "actions" and .run_number != null
+    and (($newest[.name] // -1) > .run_number);
+
   def is_failure:
     if .source == "actions"
-    then (.conclusion // "") | IN("failure", "timed_out", "cancelled", "startup_failure")
+    then if (.conclusion // "") == "cancelled"
+         # cancel-in-progress replacement, not a real failure -- see the
+         # superseded-run comment block at the top of this file.
+         then (.superseded | not)
+         else (.conclusion // "") | IN("failure", "timed_out", "startup_failure")
+         end
     else (.conclusion // "") | IN("failure", "error")
     end;
   def is_pending:
@@ -103,15 +149,23 @@ printf '%s\n%s\n' "$runs" "$statuses" | jq -n --argjson pr "$pr" --arg sha "$sha
   (input) as $runs
   | (input) as $statuses
   | [ ($runs.workflow_runs // [])[]
-    | {name: .name, source: "actions", status: .status, conclusion: .conclusion} ]
+    | {name: .name, source: "actions", status: .status, conclusion: .conclusion,
+       run_number: .run_number} ]
   + [ ($statuses.statuses // [])[]
     | {name: .context, source: "status",
        status: (if .state == "pending" then "pending" else "completed" end),
-       conclusion: (if .state == "pending" then null else .state end)} ]
-  | . as $checks
+       conclusion: (if .state == "pending" then null else .state end),
+       run_number: null} ]
+  | . as $raw
+  | (($raw | newest_completed) as $newest
+     | [ $raw[] | . + {superseded: is_superseded($newest)} ]) as $checks
   | ($checks | length) as $total
   | ($checks | map(select(is_failure)) | length) as $failure
   | ($checks | map(select(is_pending)) | length) as $pending
+  # The top-level shape is fixed -- pr-review-automerge reads has_failure,
+  # pending_count and summary -- so superseded runs are still listed and still
+  # counted in $total; the summary just buckets them with the successes, and the
+  # per-check `superseded` flag is what lets a reader reconcile the two.
   | {pr: $pr,
      sha: $sha,
      checks: $checks,

--- a/test/gh-wrappers.test.sh
+++ b/test/gh-wrappers.test.sh
@@ -191,15 +191,17 @@ else echo "FAIL: gh-pr-checks Case D rc=$rc out=${out:0:200}"; fail=1; fi
 # the stale cancelled one used to pin has_failure to true forever. Shaped after
 # the measurement that prompted the fix, including the `Go Lint and Build` /
 # `Go Test` pair sharing run_numbers 5119/5120: run_number is per-workflow, so a
-# global comparison would be meaningless and the grouping by name is load-bearing.
+# global comparison would be meaningless and the grouping by workflow_id is
+# load-bearing (each same-named pair below shares one workflow_id, standing in
+# for "same workflow file").
 fx="$checksstub/e"
 checksfx "$fx" \
-  '{"workflow_runs":[{"name":"Packages Tests","status":"completed","conclusion":"cancelled","run_number":9525},
-                     {"name":"Packages Tests","status":"completed","conclusion":"success","run_number":9526},
-                     {"name":"Go Lint and Build","status":"completed","conclusion":"cancelled","run_number":5119},
-                     {"name":"Go Lint and Build","status":"completed","conclusion":"success","run_number":5120},
-                     {"name":"Go Test","status":"completed","conclusion":"success","run_number":5119},
-                     {"name":"Go Test","status":"completed","conclusion":"success","run_number":5120}]}' \
+  '{"workflow_runs":[{"name":"Packages Tests","status":"completed","conclusion":"cancelled","run_number":9525,"workflow_id":701},
+                     {"name":"Packages Tests","status":"completed","conclusion":"success","run_number":9526,"workflow_id":701},
+                     {"name":"Go Lint and Build","status":"completed","conclusion":"cancelled","run_number":5119,"workflow_id":702},
+                     {"name":"Go Lint and Build","status":"completed","conclusion":"success","run_number":5120,"workflow_id":702},
+                     {"name":"Go Test","status":"completed","conclusion":"success","run_number":5119,"workflow_id":703},
+                     {"name":"Go Test","status":"completed","conclusion":"success","run_number":5120,"workflow_id":703}]}' \
   '{"statuses":[]}'
 out=$(checksenv "$fx" 537 2>/dev/null); rc=$?
 if [ "$rc" -eq 0 ] \
@@ -214,11 +216,11 @@ else echo "FAIL: gh-pr-checks superseded rc=$rc out=$out"; fail=1; fi
 # looks exactly like this, and reading it as "passed" is the dangerous direction,
 # so the exemption in case E must not generalise into an unconditional dedup.
 # `Lint` carries a much higher run_number than the cancelled `E2E`: comparing
-# run_numbers without grouping by name would wrongly exonerate E2E here.
+# run_numbers without grouping by workflow_id would wrongly exonerate E2E here.
 fx="$checksstub/f"
 checksfx "$fx" \
-  '{"workflow_runs":[{"name":"E2E","status":"completed","conclusion":"cancelled","run_number":11},
-                     {"name":"Lint","status":"completed","conclusion":"success","run_number":99}]}' \
+  '{"workflow_runs":[{"name":"E2E","status":"completed","conclusion":"cancelled","run_number":11,"workflow_id":810},
+                     {"name":"Lint","status":"completed","conclusion":"success","run_number":99,"workflow_id":820}]}' \
   '{"statuses":[]}'
 out=$(checksenv "$fx" 537 2>/dev/null); rc=$?
 if [ "$rc" -eq 0 ] \
@@ -228,20 +230,20 @@ if [ "$rc" -eq 0 ] \
   echo "ok: gh-pr-checks still counts a lone cancelled run as a failure (no unconditional dedup)"
 else echo "FAIL: gh-pr-checks lone cancelled rc=$rc out=$out"; fail=1; fi
 
-# Case G: the three ways "newer completed run of the same name" can fail to hold.
-# All must resolve conservatively, i.e. the cancelled run keeps counting:
-# - Twin: the same-named run shares the run_number, so neither is newer.
+# Case G: the three ways "newer completed run of the same workflow" can fail to
+# hold. All must resolve conservatively, i.e. the cancelled run keeps counting:
+# - Twin: the same-workflow run shares the run_number, so neither is newer.
 # - NoKey: the cancelled run has no ordering key, so nothing can be shown newer.
 # - Racing: the replacement exists but has not completed, so it cannot yet
 #   vouch for anything -- the gate stays shut until it does.
 fx="$checksstub/g"
 checksfx "$fx" \
-  '{"workflow_runs":[{"name":"Twin","status":"completed","conclusion":"cancelled","run_number":7},
-                     {"name":"Twin","status":"completed","conclusion":"success","run_number":7},
-                     {"name":"NoKey","status":"completed","conclusion":"cancelled","run_number":null},
-                     {"name":"NoKey","status":"completed","conclusion":"success","run_number":8},
-                     {"name":"Racing","status":"completed","conclusion":"cancelled","run_number":3},
-                     {"name":"Racing","status":"in_progress","conclusion":null,"run_number":4}]}' \
+  '{"workflow_runs":[{"name":"Twin","status":"completed","conclusion":"cancelled","run_number":7,"workflow_id":831},
+                     {"name":"Twin","status":"completed","conclusion":"success","run_number":7,"workflow_id":831},
+                     {"name":"NoKey","status":"completed","conclusion":"cancelled","run_number":null,"workflow_id":832},
+                     {"name":"NoKey","status":"completed","conclusion":"success","run_number":8,"workflow_id":832},
+                     {"name":"Racing","status":"completed","conclusion":"cancelled","run_number":3,"workflow_id":833},
+                     {"name":"Racing","status":"in_progress","conclusion":null,"run_number":4,"workflow_id":833}]}' \
   '{"statuses":[]}'
 out=$(checksenv "$fx" 537 2>/dev/null); rc=$?
 if [ "$rc" -eq 0 ] \
@@ -250,6 +252,43 @@ if [ "$rc" -eq 0 ] \
   && printf '%s' "$out" | jq -e '[.checks[] | select(.conclusion == "cancelled")] | length == 3 and all(.superseded | not)' >/dev/null; then
   echo "ok: gh-pr-checks treats an equal run_number, a missing run_number and an unfinished replacement as not superseding"
 else echo "FAIL: gh-pr-checks superseded boundaries rc=$rc out=$out"; fail=1; fi
+
+# Case H: a run with no workflow_id (the "name" field this dedup used to group
+# by is nullable in GitHub's schema, and `--jq` turns any missing/nullable field
+# into JSON null) must not abort the wrapper. jq's object-index operator raises
+# a hard error ("Cannot index object with null") on a null key *before* the `//`
+# fallback ever runs, so a naive `$newest[.workflow_id]` crashes jq with exit
+# code 5 instead of falling through to -1. Regression check for that; run
+# against the pre-fix jq program to confirm this actually fails there.
+fx="$checksstub/h"
+checksfx "$fx" \
+  '{"workflow_runs":[{"name":null,"status":"completed","conclusion":"success","run_number":12,"workflow_id":null}]}' \
+  '{"statuses":[]}'
+out=$(checksenv "$fx" 537 2>/dev/null); rc=$?
+if [ "$rc" -eq 0 ] \
+  && printf '%s' "$out" | jq -e '.has_failure == false and .pending_count == 0' >/dev/null \
+  && printf '%s' "$out" | jq -e '.summary == "1 checks: 1 success, 0 pending, 0 failure"' >/dev/null; then
+  echo "ok: gh-pr-checks does not abort on a run with a null grouping key"
+else echo "FAIL: gh-pr-checks null-key rc=$rc out=$out"; fail=1; fi
+
+# Case I: two distinct workflow *files* sharing the same name: run_number is
+# per-file, so file A's high run_number must not exonerate file B's cancelled
+# run just because jq grouped them by name. workflow_id (unique per file) is
+# the correct grouping key; name is not. This is the dangerous direction (a
+# real cancellation read as passed), unlike Case F's isolation by different
+# names -- here the names collide and only workflow_id keeps them apart.
+fx="$checksstub/i"
+checksfx "$fx" \
+  '{"workflow_runs":[{"name":"CI","status":"completed","conclusion":"cancelled","run_number":10,"workflow_id":901},
+                     {"name":"CI","status":"completed","conclusion":"success","run_number":900,"workflow_id":902}]}' \
+  '{"statuses":[]}'
+out=$(checksenv "$fx" 537 2>/dev/null); rc=$?
+if [ "$rc" -eq 0 ] \
+  && printf '%s' "$out" | jq -e '.has_failure == true' >/dev/null \
+  && printf '%s' "$out" | jq -e '.summary == "2 checks: 1 success, 0 pending, 1 failure"' >/dev/null \
+  && printf '%s' "$out" | jq -e '[.checks[] | select(.conclusion == "cancelled")] | length == 1 and all(.superseded | not)' >/dev/null; then
+  echo "ok: gh-pr-checks does not let a same-named different-workflow_id run supersede a real cancellation"
+else echo "FAIL: gh-pr-checks same-name distinct-workflow_id rc=$rc out=$out"; fail=1; fi
 
 # gh-pr-checks: missing / non-numeric / extra-flag arg fail (no flag passthrough).
 PATH="$checksstub:$PATH" "$bindir/gh-pr-checks" >/dev/null 2>&1; [ $? -ne 0 ] \

--- a/test/gh-wrappers.test.sh
+++ b/test/gh-wrappers.test.sh
@@ -186,6 +186,71 @@ if [ "$rc" -eq 0 ] \
   echo "ok: gh-pr-checks handles a runs payload past MAX_ARG_STRLEN (128 KiB argv element cap)"
 else echo "FAIL: gh-pr-checks Case D rc=$rc out=${out:0:200}"; fail=1; fi
 
+# Case E: superseded runs -- `concurrency: cancel-in-progress` leaves the killed
+# run (cancelled) next to its replacement (success) under the same head SHA, and
+# the stale cancelled one used to pin has_failure to true forever. Shaped after
+# the measurement that prompted the fix, including the `Go Lint and Build` /
+# `Go Test` pair sharing run_numbers 5119/5120: run_number is per-workflow, so a
+# global comparison would be meaningless and the grouping by name is load-bearing.
+fx="$checksstub/e"
+checksfx "$fx" \
+  '{"workflow_runs":[{"name":"Packages Tests","status":"completed","conclusion":"cancelled","run_number":9525},
+                     {"name":"Packages Tests","status":"completed","conclusion":"success","run_number":9526},
+                     {"name":"Go Lint and Build","status":"completed","conclusion":"cancelled","run_number":5119},
+                     {"name":"Go Lint and Build","status":"completed","conclusion":"success","run_number":5120},
+                     {"name":"Go Test","status":"completed","conclusion":"success","run_number":5119},
+                     {"name":"Go Test","status":"completed","conclusion":"success","run_number":5120}]}' \
+  '{"statuses":[]}'
+out=$(checksenv "$fx" 537 2>/dev/null); rc=$?
+if [ "$rc" -eq 0 ] \
+  && printf '%s' "$out" | jq -e '.has_failure == false and .pending_count == 0' >/dev/null \
+  && printf '%s' "$out" | jq -e '.summary == "6 checks: 6 success, 0 pending, 0 failure"' >/dev/null \
+  && printf '%s' "$out" | jq -e '[.checks[] | select(.conclusion == "cancelled")] | length == 2 and all(.superseded)' >/dev/null \
+  && printf '%s' "$out" | jq -e '[.checks[] | select(.run_number == 9526 or .run_number == 5120)] | all(.superseded | not)' >/dev/null; then
+  echo "ok: gh-pr-checks does not count a cancelled run superseded by a newer completed run of the same workflow"
+else echo "FAIL: gh-pr-checks superseded rc=$rc out=$out"; fail=1; fi
+
+# Case F: a lone cancelled run still fails. A human stop or a job-level timeout
+# looks exactly like this, and reading it as "passed" is the dangerous direction,
+# so the exemption in case E must not generalise into an unconditional dedup.
+# `Lint` carries a much higher run_number than the cancelled `E2E`: comparing
+# run_numbers without grouping by name would wrongly exonerate E2E here.
+fx="$checksstub/f"
+checksfx "$fx" \
+  '{"workflow_runs":[{"name":"E2E","status":"completed","conclusion":"cancelled","run_number":11},
+                     {"name":"Lint","status":"completed","conclusion":"success","run_number":99}]}' \
+  '{"statuses":[]}'
+out=$(checksenv "$fx" 537 2>/dev/null); rc=$?
+if [ "$rc" -eq 0 ] \
+  && printf '%s' "$out" | jq -e '.has_failure == true' >/dev/null \
+  && printf '%s' "$out" | jq -e '.summary == "2 checks: 1 success, 0 pending, 1 failure"' >/dev/null \
+  && printf '%s' "$out" | jq -e '.checks | all(.superseded | not)' >/dev/null; then
+  echo "ok: gh-pr-checks still counts a lone cancelled run as a failure (no unconditional dedup)"
+else echo "FAIL: gh-pr-checks lone cancelled rc=$rc out=$out"; fail=1; fi
+
+# Case G: the three ways "newer completed run of the same name" can fail to hold.
+# All must resolve conservatively, i.e. the cancelled run keeps counting:
+# - Twin: the same-named run shares the run_number, so neither is newer.
+# - NoKey: the cancelled run has no ordering key, so nothing can be shown newer.
+# - Racing: the replacement exists but has not completed, so it cannot yet
+#   vouch for anything -- the gate stays shut until it does.
+fx="$checksstub/g"
+checksfx "$fx" \
+  '{"workflow_runs":[{"name":"Twin","status":"completed","conclusion":"cancelled","run_number":7},
+                     {"name":"Twin","status":"completed","conclusion":"success","run_number":7},
+                     {"name":"NoKey","status":"completed","conclusion":"cancelled","run_number":null},
+                     {"name":"NoKey","status":"completed","conclusion":"success","run_number":8},
+                     {"name":"Racing","status":"completed","conclusion":"cancelled","run_number":3},
+                     {"name":"Racing","status":"in_progress","conclusion":null,"run_number":4}]}' \
+  '{"statuses":[]}'
+out=$(checksenv "$fx" 537 2>/dev/null); rc=$?
+if [ "$rc" -eq 0 ] \
+  && printf '%s' "$out" | jq -e '.has_failure == true and .pending_count == 1' >/dev/null \
+  && printf '%s' "$out" | jq -e '.summary == "6 checks: 2 success, 1 pending, 3 failure"' >/dev/null \
+  && printf '%s' "$out" | jq -e '[.checks[] | select(.conclusion == "cancelled")] | length == 3 and all(.superseded | not)' >/dev/null; then
+  echo "ok: gh-pr-checks treats an equal run_number, a missing run_number and an unfinished replacement as not superseding"
+else echo "FAIL: gh-pr-checks superseded boundaries rc=$rc out=$out"; fail=1; fi
+
 # gh-pr-checks: missing / non-numeric / extra-flag arg fail (no flag passthrough).
 PATH="$checksstub:$PATH" "$bindir/gh-pr-checks" >/dev/null 2>&1; [ $? -ne 0 ] \
   && echo "ok: gh-pr-checks missing arg fails" || { echo "FAIL: gh-pr-checks missing arg"; fail=1; }


### PR DESCRIPTION
## Summary

`bin/gh-pr-checks` が、置き換えられた（superseded な）workflow run を failure として数え続け、`has_failure` を恒久的に `true` にしていたのを直す。

- `--jq` 射影に `run_number`（順序キー）と `workflow_id`（グルーピングキー）を追加
- 集計前に **`workflow_id`** でグルーピングし、**同じ workflow のより新しい `completed` な run が存在する `cancelled` run だけ**を failure から外す（`newest_completed` / `is_superseded`）
- グルーピングキーが `name` ではなく `workflow_id` なのは、GitHub が同一の `name:` を持つ別 workflow *file* を許し、`run_number` が file ごとの連番であるため。同名 2 file があると片方の高い `run_number` がもう片方の実 cancellation を誤って exonerate する（＝実 failure を pass と読む危険側）
- `newest_completed` / `is_superseded` の両方で、グルーピングキーと `run_number` の null を対称的に guard する。jq はオブジェクトを null キーで index すると `//` のフォールバックに落ちる**前**に `Cannot index object with null` で abort するため
- `checks[]` の各要素に `run_number` / `workflow_id` / `superseded` を載せ、summary の内訳（superseded は success 側に計上される）を読み手が突き合わせられるようにした
- 出力の top-level shape（`{pr, sha, checks, has_failure, pending_count, summary}`）と、ペイロードを argv に載せず stdin へ流す設計（`MAX_ARG_STRLEN` 対策）は維持

`test/gh-wrappers.test.sh` に 5 ケース追加。

| Case | 入力 | 期待 |
|---|---|---|
| E | superseded な `cancelled` + より新しい同 workflow の `success`（実測データの形） | `has_failure: false` |
| F | 単独の `cancelled` ＋ 別 workflow でより大きい `run_number` の `success` | `has_failure: true`（グルーピング無しの比較なら誤って除外される形） |
| G | `run_number` 同値 / 順序キー欠落 / 未完了の置き換え run | いずれも supersede せず |
| H | `workflow_id` が null の run | wrapper が abort せず（naive な実装は jq が rc=5 で落ちる） |
| I | 同一 `name`・別 `workflow_id` の 2 file | 高い `run_number` が他 file の `cancelled` を supersede しない |

判別力は実測で確認済み: Case E は base（`18d1188`）の実装で FAIL、Case H は `5c73342` で rc=5、Case I は `5c73342` で `has_failure: false` になり FAIL する。F / G は「無条件 dedup へ一般化した誤修正」を捕まえるガード。

## Why

`concurrency: cancel-in-progress: true` を持つワークフローでは、後続イベントが実行中の run を潰し、**潰された古い run（`cancelled`）とそれを置き換えた新しい run（`success`）の両方**が head SHA の listing に残る。workflow でグルーピングせずに集計していたため、古いほうの `cancelled` が `has_failure` を永久に `true` にし、CI が実際には全部通っていても `pr-review-automerge` の merge gate が二度と開かなかった。

業務 repo での実測: draft PR を `gh pr ready` で解除する経路では `pull_request` の `types` に `opened` と `ready_for_review` の両方が含まれるため CI が 2 バッチ走り、1 バッチ目の実行中だったものが潰される。22 ワークフローがすべて 2 回走って 49 run になり、`gh-pr-checks` は `49 checks: 44 success, 0 pending, 5 failure / has_failure: true` を返した。実 failure はゼロ。

設計上の判断を 2 つ、意図的に狭く取っている。

- **`cancelled` を無条件に failure から外さない。** 人が止めた run やジョブ側の timeout で止まった run を「通った」と読むのは危険な方向なので、この保守的な既定は維持する。除外は「同じ workflow のより新しい completed な run が存在する」ときに限る。
- **無条件 dedup（最大 `run_number` だけ残す）にしない。** 単独で cancelled になった run が別の run に隠されうるし、`push` と `pull_request` が同一 SHA で両方発火する構成では同じ workflow の正当な run が 2 つ並ぶため、片方を黙って捨てることになる。

境界は保守的な方向へ倒している: 置き換え run がまだ `completed` でないときは exonerate せず（gate は完了まで閉じたまま）、`run_number` が同値または欠落している場合も supersede しない。`source == "status"` の commit status は `run_number` も `workflow_id` も持たないので、この判定の対象外（既存の分岐を維持）。
