### PR TITLE
feat(skills): 業務 repo の es-create-pr を上書きする個人 shim を追加

### DIFF
--- a/dot/claude/skills/es-create-pr/SKILL.md
+++ b/dot/claude/skills/es-create-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: es-create-pr
 description: コンテキストに基づいた説明付きで GitHub Pull Request を作成する
-allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git rev-parse *), Bash(git fetch origin *), Bash(git push *), Bash(git branch -m *), Bash(git ls-files *), Bash(gh repo view *), Bash(gh pr create *), Bash(gh pr edit *), Bash(gh pr list *), Bash(gh pr close *), Bash(gh run list *), Bash(./scripts/agent_pr/run.sh *), Bash(echo *), Read, Glob, Grep, AskUserQuestion
+allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git rev-parse *), Bash(git fetch origin *), Bash(git push *), Bash(git branch -m *), Bash(git branch --set-upstream-to=*), Bash(git ls-files *), Bash(gh repo view *), Bash(gh pr create *), Bash(gh pr edit *), Bash(gh pr list *), Bash(gh pr close *), Bash(gh run list *), Bash(./scripts/agent_pr/run.sh *), Bash(echo *), Read, Glob, Grep, AskUserQuestion
 ---
 
 # es-create-pr
@@ -33,8 +33,11 @@ personal が project を上書きするので、repo の CLAUDE.md が名指し�
    収集 → 未コミット変更の確認 → PR テンプレート → 本文ドラフト → self-check）。手順 6 の
    「Push → 作成」だけを以下で置き換える。
 
-2. **レーンの自己判定**: `./scripts/agent_pr/run.sh` が存在しなければ、この repo に agent
-   レーンは無い。`my-create-pr` の手順 6 をそのまま実行して終わる（`gh pr create`）。
+2. **レーンの自己判定**: `git ls-files ':(top)scripts/agent_pr/run.sh'` の出力が空なら、この
+   repo に agent レーンは無い。`my-create-pr` の手順 6 をそのまま実行して終わる（`gh pr
+   create`）。`:(top)` で repo root 基準の存在確認に固定する。手順 4 で叩く
+   `./scripts/agent_pr/run.sh` 自体も repo root からの相対パスなので、cwd は repo root に
+   保つこと。
 
 3. 存在する場合、現在のブランチ名と push 状況で分岐する。
 
@@ -53,26 +56,37 @@ personal が project を上書きするので、repo の CLAUDE.md が名指し�
 
    `<type>` は元のブランチ名の prefix をそのまま引き継ぐ（`fix/foo` → `agent/fix/foo`）。有効な
    prefix は `feature` / `fix` / `hotfix` / `refactor` / `test` / `ci` / `docs` / `dependencies`
-   で、`run.sh` が push 前にこの形式を検査する。prefix が無い・一覧に無い場合は適切なものを
+   で、`run.sh` が push 前にこの形式を検査する。`feat/` は一覧に無いが `feature` へ読み替える
+   （Conventional Commits の `feat` がこの repo での頻出 prefix なため）。prefix が無い・一覧に無い場合は適切なものを
    選んで付ける。**type を省くと Release Drafter の autolabeler にマッチせず、リリースノートで
    未分類になる。**
 
 4. **agent レーン**: push と PR 作成の待機を `run.sh` に任せ、返ってきた PR 番号へタイトルと
-   本文を入れる。
+   本文・base を入れる。
 
    ```
    ./scripts/agent_pr/run.sh agent/<type>/<topic>
    ```
 
-   PR 番号を標準出力に返す（実測で push から約 9 秒）。
+   PR 番号を標準出力に返す（実測で push から約 9 秒）。`run.sh` の push は
+   `HEAD:refs/heads/<branch>` で `-u` を伴わないため upstream が付かず、`git-reap-gone` が
+   拾う `[gone]` を検知できずに merge 後の後片付けが効かない。push 自体が
+   `origin/<branch>` の追跡 ref をローカルに作るので（fetch は不要）、この後で手当てする。
 
    ```
-   gh pr edit <番号> --title "<title>" --body-file - <<'PR_BODY_EOF'
+   git branch --set-upstream-to=origin/agent/<type>/<topic>
+   ```
+
+   ```
+   gh pr edit <番号> --title "<title>" --base <手順 1 で決めた base> --body-file - <<'PR_BODY_EOF'
    <body>
    PR_BODY_EOF
    ```
 
    - **`gh pr create` は実行しない。** PR の author を bot にするため、作成はワークフローに任せる。
+   - **`--base` は常に明示する。** `run.sh` は base を受け取らずワークフロー側の既定（通常は
+     デフォルトブランチ）で PR を作るため、手順 1 でユーザーが base を明示した場合や既定
+     ブランチが `main` 以外の場合に、手順 1 で集めた diff の基準と食い違いうる。
    - **`gh pr ready` は不要。** 以前は draft で PR を作っていたが、現在は最初から ready で作る
      （draft でも CI が回る repo なので、draft → ready にすると `opened` と `ready_for_review`
      で CI が二重に走る）。

--- a/dot/claude/skills/es-create-pr/SKILL.md
+++ b/dot/claude/skills/es-create-pr/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: es-create-pr
+description: コンテキストに基づいた説明付きで GitHub Pull Request を作成する
+allowed-tools: Bash(git status *), Bash(git diff *), Bash(git log *), Bash(git rev-parse *), Bash(git fetch origin *), Bash(git push *), Bash(git branch -m *), Bash(git ls-files *), Bash(gh repo view *), Bash(gh pr create *), Bash(gh pr edit *), Bash(gh pr list *), Bash(gh pr close *), Bash(gh run list *), Bash(./scripts/agent_pr/run.sh *), Bash(echo *), Read, Glob, Grep, AskUserQuestion
+---
+
+# es-create-pr
+
+業務 repo の共通 skill `es-create-pr` を、個人設定側で上書きするための shim。同名 skill は
+personal が project を上書きするので、repo の CLAUDE.md が名指しする `es-create-pr` という
+名前・起動条件はそのままに、中身だけがこれに差し替わる。
+
+<!--
+  存在理由: 業務 repo に agent レーン（`agent/**` への push を GitHub Actions が拾い、GitHub App
+  の installation token で PR を作る = PR の author が bot になるので push した本人が approve
+  できる）が入ったが、「既存の es-create-pr を前提にワークフローを組んでいる人がいる」という
+  要望により、repo 共通の es-create-pr には統合されなかった。既定の手順へ組み込むかは各自の
+  個人設定に委ねられている。
+
+  したがって repo 側が「共通 skill は agent レーンを扱わない」という方針をやめたら、この shim は
+  役目を終える。その時点で見直すこと。
+-->
+
+## この shim が持つもの
+
+タイトル・本文・コンテキスト収集は個人 skill **`my-create-pr` を正**とし、そちらに従う。
+ここが差し替えるのは **PR 作成の段だけ**。手順を写し取らないので、`my-create-pr` 側が
+変わっても drift しない。
+
+## 手順
+
+1. **`~/.claude/skills/my-create-pr/SKILL.md` を Read し、その手順 1〜5 に従う**（コンテキスト
+   収集 → 未コミット変更の確認 → PR テンプレート → 本文ドラフト → self-check）。手順 6 の
+   「Push → 作成」だけを以下で置き換える。
+
+2. **レーンの自己判定**: `./scripts/agent_pr/run.sh` が存在しなければ、この repo に agent
+   レーンは無い。`my-create-pr` の手順 6 をそのまま実行して終わる（`gh pr create`）。
+
+3. 存在する場合、現在のブランチ名と push 状況で分岐する。
+
+   | 現在のブランチ | 動作 |
+   |---|---|
+   | `agent/` で始まる | そのまま agent レーン（手順 4） |
+   | `agent/` 以外 **かつ未 push**（upstream 未設定） | `git branch -m agent/<type>/<topic>` でリネームしてから agent レーン |
+   | `agent/` 以外 **かつ push 済み** | 通常レーン（`my-create-pr` 手順 6） |
+
+   push 済みかは `git rev-parse --abbrev-ref --symbolic-full-name @{upstream}` が成功するかで見る。
+
+   リネームを未 push に限るのは、`run.sh` が `HEAD:refs/heads/<branch>` へ push するので
+   ローカルと別名のリモートブランチを作れてしまい、そうすると upstream の追跡と
+   `git-reap-gone` の後片付けが壊れるため。push 済みのブランチは既にレーンが決まっていると
+   みなし、混ぜない。
+
+   `<type>` は元のブランチ名の prefix をそのまま引き継ぐ（`fix/foo` → `agent/fix/foo`）。有効な
+   prefix は `feature` / `fix` / `hotfix` / `refactor` / `test` / `ci` / `docs` / `dependencies`
+   で、`run.sh` が push 前にこの形式を検査する。prefix が無い・一覧に無い場合は適切なものを
+   選んで付ける。**type を省くと Release Drafter の autolabeler にマッチせず、リリースノートで
+   未分類になる。**
+
+4. **agent レーン**: push と PR 作成の待機を `run.sh` に任せ、返ってきた PR 番号へタイトルと
+   本文を入れる。
+
+   ```
+   ./scripts/agent_pr/run.sh agent/<type>/<topic>
+   ```
+
+   PR 番号を標準出力に返す（実測で push から約 9 秒）。
+
+   ```
+   gh pr edit <番号> --title "<title>" --body-file - <<'PR_BODY_EOF'
+   <body>
+   PR_BODY_EOF
+   ```
+
+   - **`gh pr create` は実行しない。** PR の author を bot にするため、作成はワークフローに任せる。
+   - **`gh pr ready` は不要。** 以前は draft で PR を作っていたが、現在は最初から ready で作る
+     （draft でも CI が回る repo なので、draft → ready にすると `opened` と `ready_for_review`
+     で CI が二重に走る）。
+   - タイトルと本文がプレースホルダ（タイトル = ブランチ名、本文 = `requested by @<actor>`）で
+     見えるのは `gh pr edit` までの数秒。
+
+5. **`run.sh` が返らなかった場合**: 原因は `PR_BOT_ALLOWLIST`（repository variable）に未登録か、
+   runner の遅延。通常レーンへ切り替える前に、遅延した PR が無いか確認する。
+
+   ```
+   gh run list --workflow create-pr.yml
+   gh pr list --head <ブランチ>
+   ```
+
+   確認を挟むのは、`run.sh` のタイムアウトが push もワークフロー実行も取り消さないため、後から
+   PR が作られうるから。見つかればそれを使う（手順 4 の `gh pr edit` へ）。見つからず通常レーンへ
+   切り替えるなら、agent ブランチ側の PR があれば close し、ブランチを削除してから、`agent/`
+   以外の名前で push し直す。


### PR DESCRIPTION
## なぜ

業務 repo（eversteel/tetsunavi-monorepo）に **agent レーン**が入った。`agent/**` へ push すると GitHub Actions が GitHub App の installation token で PR を作るので、**PR の author が bot になり、push した本人が approve できる**。実装が Agent 主体になった結果「実装者 = Agent、レビュワー = その Agent と対話していたメンバー」という構図で片付く PR が増えたのに、GitHub 上の author が本人になるせいで self-approve できず、変更の大小を問わず必ずもう一人呼ばされていた。それを解消する仕組み。

ただし「既存の `es-create-pr` を前提にワークフローを組んでいる人がいるので変えないでほしい」という要望があり、**repo 共通の `es-create-pr` には統合されなかった**。既定の手順へ組み込むかは各自の個人設定に委ねられている。

そこで個人設定側で上書きする。

## やったこと

`dot/claude/skills/es-create-pr/SKILL.md` を 1 ファイル追加した。他は変更していない。

同名 skill は **personal が project を上書きする**（[公式ドキュメント](https://code.claude.com/docs/en/skills)）。この方式を選んだのは、業務 repo の CLAUDE.md が「PR 作成には `es-create-pr` を使い、条件を満たしたら自動起動する」と名指ししているため。同名で上書きすれば**その記述をそのまま活かしたまま中身だけ差し替わり**、指示の優先順位の解釈が一切入らない。

中身は薄い shim にした。タイトル・本文・コンテキスト収集は `my-create-pr` を正とし、この shim が持つのは **PR 作成の段だけ**。手順を写し取らないので `my-create-pr` 側が変わっても drift しない。

レーンは自己判定する。`scripts/agent_pr/run.sh` が無ければ agent レーンを持たない repo なので、`my-create-pr` の通常手順（`gh pr create`）へそのまま落ちる。あるときはブランチ名と push 状況で 3 分岐する。

| 現在のブランチ | 動作 |
|---|---|
| `agent/` で始まる | そのまま agent レーン |
| `agent/` 以外 かつ未 push | `git branch -m agent/<type>/<topic>` でリネームしてから agent レーン |
| `agent/` 以外 かつ push 済み | 通常レーン |

リネームを未 push に限るのは、`run.sh` が `HEAD:refs/heads/<branch>` へ push するのでローカルと別名のリモートブランチを作れてしまい、upstream の追跡と `git-reap-gone` の後片付けが壊れるため。push 済みのブランチは既にレーンが決まっているとみなし、混ぜない。

## 確認したこと

skill にはテストが書けないため、次で確認した。

* frontmatter の YAML が壊れていないこと
* `~/.claude/skills` は既存のディレクトリ symlink なので、skill の追加に deploy の再実行は不要
* `disable-model-invocation` は付けていない（付けると自動起動しなくなり、毎回手で `/es-create-pr` と打つことになる）

実際の動作確認は、次にこのフローで PR を出したときになる。

## 注意

**`~/.claude/skills` の symlink 先は main checkout なので、この PR が merge されるまでホーム側にこの skill は現れない。**

## 積み残し

* **`my-create-pr` と description が完全に同一になる。** repo の CLAUDE.md が `es-create-pr` を名指ししているので誤爆リスクは低いが、`my-create-pr` が選ばれると通常レーンで PR が作られ、この shim の意味が消える。`es-create-pr` 側の description に起動条件（`scripts/agent_pr/run.sh` を持つ repo での PR 作成）を足して区別するのが良さそう。別途対応する
* （スコープ外・未対応）`bin/deploy.sh` の 1 行目が `#/usr/bin/env sh` で `!` が欠けており shebang として機能していない。中身は `declare -A` / `function` と bash 依存なので、`sh bin/deploy.sh` で起動すると dash 系では落ちる
