### PR TITLE
feat(claude-queue): tmux window 名を transcript の ai-title 由来にする

### DIFF
--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -129,6 +129,26 @@ worktree dir の basename はそのまま tmux session 名になる。tmux の�
 `_` は tmux ターゲット・session 名どちらでも安全。`git wa` と `claude-worktree` の双方を
 `_` に統一した。
 
+### window 名は transcript の ai-title 由来（session 名は据え置き）
+
+session 名は上のとおり worktree dir basename のままだが、**window 名は中身で決める**。
+Claude Code は transcript jsonl に LLM 生成のタイトル（`{"type":"ai-title",...}`）を書いており、
+これが「その session が何をしているか」を知る唯一の安価な情報源になる。`claude agents --json` の
+roster 名は使わない — interactive では cwd basename + 2 桁 hex にしかならず session id 以上の
+情報が無いうえ、実測 0.54s で hook から毎回叩けない。
+
+最終形は `<ai-title を 16 桁に切ったもの>-<session id 8 桁>`。id 接尾辞を残すのは、同じ話題の
+window が複数ありうる一方で `new-window -S` の重複畳み込みは session 単位で効いてほしいため。
+採用するのは**最後の** ai-title で、話題が変わって付け直されると `-S` が旧名と一致せず window が
+1 枚増えるが、その window のコマンドが終われば `~exited` へ改名されて自然に解消するので許容する。
+
+名前を張るのは (a) picker の attach / resume 経路（ai-title が取れなければ `attach-<id8>` /
+`resume-<id8>` へフォールバック）と、(b) hook の `UserPromptSubmit` / `Stop`。`Stop` も張るのは
+初回応答直後に ai-title が付くためで、これが無いと 2 度目の prompt まで既定名のまま残る。
+hook 側は **pane が window 唯一の pane のときだけ**改名する（split して 2 session が並ぶと
+名前を奪い合うため）。`rename-window` は tmux の automatic-rename を恒久 off にするので、
+`SessionEnd` では自分が付けた名前と一致するときに限り automatic-rename を戻す。
+
 ### ④の既定は `claude --bg`（tmux session を作らない）
 
 素朴に `claude -p` をバックグラウンド（`setsid`）で起動すると、環境変数を継承するため

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -92,6 +92,13 @@ make install
 session 名 = worktree ディレクトリ名（`gts` / `claude-worktree` と同じ慣習）。popup を開いた
 時点の current session には作らない。
 
+window 名は session の transcript にある ai-title から `<タイトル 16 桁>-<session id 8 桁>` を
+組む（取れなければ `attach-<id8>` / `resume-<id8>`）。picker 経由で開く window だけでなく、
+pane を持つ追跡中の session の window も hook（`UserPromptSubmit` / `Stop`）が同じ名前へ
+改名する。ただし改名するのは pane が window 唯一の pane のときだけで、`SessionEnd` では
+自分が付けた名前のときに限り tmux の automatic-rename を戻す。設計上の理由は
+[docs/design/claude-tmux-worktree.md](../../docs/design/claude-tmux-worktree.md) を参照。
+
 window を開く attach / resume の経路では、`claude` をそのまま pane のプロセスにせず shell 経由で
 走らせ、終了後は shell へ置き換える。`claude attach` は `C-z` で「shell へ戻る」と言うが、戻る先の
 shell が無ければ pane ごと閉じ、その window しか持たない session は道連れに消える。shell を挟めば

--- a/src/claude-queue/internal/hook/run.go
+++ b/src/claude-queue/internal/hook/run.go
@@ -37,7 +37,11 @@ func Run(event string) {
 	d := &Deps{DB: conn, Pane: pane}
 	if err := Dispatch(d, event, in); err != nil {
 		logDebug("dispatch %s: %v", event, err)
-		return
+		// Falls through rather than returning: applyWindowName touches only
+		// the terminal, never d.DB, so a Dispatch failure (SQLITE_BUSY is a
+		// real one) has nothing to do with whether the window can still be
+		// renamed. Returning here would make the two failures wrongly
+		// entangled in this one direction, contradicting the comment below.
 	}
 	// Deliberately outside Dispatch: the ledger transition is this hook's job,
 	// the window name is a side effect on the terminal, and a failure of one

--- a/src/claude-queue/internal/hook/run.go
+++ b/src/claude-queue/internal/hook/run.go
@@ -33,11 +33,17 @@ func Run(event string) {
 	defer conn.Close()
 
 	mux := multiplexer.Detect()
-	d := &Deps{DB: conn, Pane: mux.PaneID()}
+	pane := mux.PaneID()
+	d := &Deps{DB: conn, Pane: pane}
 	if err := Dispatch(d, event, in); err != nil {
 		logDebug("dispatch %s: %v", event, err)
 		return
 	}
+	// Deliberately outside Dispatch: the ledger transition is this hook's job,
+	// the window name is a side effect on the terminal, and a failure of one
+	// must not cost the other. It also runs after the commit so a slow tmux
+	// never holds the write transaction open.
+	applyWindowName(mux, event, pane, in.TranscriptPath, in.SessionID)
 	mux.RefreshStatus()
 }
 

--- a/src/claude-queue/internal/hook/window.go
+++ b/src/claude-queue/internal/hook/window.go
@@ -15,14 +15,15 @@ type windowMux interface {
 }
 
 // applyWindowName keeps the tmux window a session runs in named after what the
-// session is about.
+// session is about, and hands the name back once the session ends.
 //
-// It is wired to UserPromptSubmit and Stop, and nothing else. UserPromptSubmit
-// is the moment the topic can change; Stop is the moment right after the first
+// Renaming is wired to UserPromptSubmit and Stop only. UserPromptSubmit is the
+// moment the topic can change; Stop is the moment right after the first
 // answer, which is when Claude Code first writes an ai-title -- without it a
 // session would carry its fallback name until the user typed a second prompt.
-// The other events add nothing: they fire many times per turn and would only
-// re-derive the same name.
+// Every other event that could reach here would only re-derive the same name,
+// except SessionEnd below, which does not rename at all: it releases the name
+// this session installed so automatic-rename can take the window back.
 //
 // Everything here is best-effort and silent. Run swallows hook errors on
 // purpose (a hook must never be why a session misbehaves), and a window name is

--- a/src/claude-queue/internal/hook/window.go
+++ b/src/claude-queue/internal/hook/window.go
@@ -1,0 +1,87 @@
+package hook
+
+import (
+	"github.com/knagiri/dotrc/src/claude-queue/internal/label"
+)
+
+// windowMux is the slice of multiplexer.Multiplexer the window naming needs.
+// Narrowing it here is what lets the guard below be tested with a recorder
+// instead of a tmux server.
+type windowMux interface {
+	RenameWindow(pane, name string) error
+	SetAutomaticRename(pane string, on bool) error
+	WindowName(pane string) (string, bool)
+	WindowPaneCount(pane string) (int, bool)
+}
+
+// applyWindowName keeps the tmux window a session runs in named after what the
+// session is about.
+//
+// It is wired to UserPromptSubmit and Stop, and nothing else. UserPromptSubmit
+// is the moment the topic can change; Stop is the moment right after the first
+// answer, which is when Claude Code first writes an ai-title -- without it a
+// session would carry its fallback name until the user typed a second prompt.
+// The other events add nothing: they fire many times per turn and would only
+// re-derive the same name.
+//
+// Everything here is best-effort and silent. Run swallows hook errors on
+// purpose (a hook must never be why a session misbehaves), and a window name is
+// the least important thing in this program.
+func applyWindowName(mux windowMux, event, pane, transcriptPath, sessionID string) {
+	if pane == "" {
+		return // a background session has no pane, and nothing to rename
+	}
+	switch event {
+	case "UserPromptSubmit", "Stop":
+		if !ownsWindow(mux, pane) {
+			return
+		}
+		name := label.Resolve(transcriptPath, sessionID)
+		if name == "" {
+			return // nothing better than whatever the window is called now
+		}
+		_ = mux.RenameWindow(pane, name)
+	case "SessionEnd":
+		releaseWindowName(mux, pane, transcriptPath, sessionID)
+	}
+}
+
+// ownsWindow reports whether pane is the only pane in its window, which is the
+// condition for this session to speak for the window's name.
+//
+// Two claude sessions split side by side would otherwise rename the shared
+// window on every prompt each, and the name would flip between two topics with
+// no relation to which pane the user is looking at. Keeping the multiplexer's
+// own name in that case is the honest answer.
+//
+// A count that could not be read is treated as "not ours": the guard exists to
+// avoid taking a name that is not this session's to take, so the unknown case
+// has to fall on the side of not renaming.
+func ownsWindow(mux windowMux, pane string) bool {
+	n, ok := mux.WindowPaneCount(pane)
+	return ok && n == 1
+}
+
+// releaseWindowName hands the window name back to tmux when the session that
+// took it ends.
+//
+// tmux turns automatic-rename off for a window the moment anything renames it
+// ("This flag is automatically disabled for an individual window when a name is
+// specified at creation with new-window or new-session, or later with
+// rename-window" -- man tmux), and never turns it back on. Without this the
+// title of a finished conversation would sit on top of the shell the user goes
+// back to working in, for as long as that window lives.
+//
+// The name is compared first so only a name this session installed is given
+// back: a window the user renamed by hand, or one the picker's exit rename has
+// already moved to "<name>~exited", must keep the name it has.
+func releaseWindowName(mux windowMux, pane, transcriptPath, sessionID string) {
+	current, ok := mux.WindowName(pane)
+	if !ok || current == "" {
+		return
+	}
+	if current != label.Resolve(transcriptPath, sessionID) {
+		return
+	}
+	_ = mux.SetAutomaticRename(pane, true)
+}

--- a/src/claude-queue/internal/hook/window_test.go
+++ b/src/claude-queue/internal/hook/window_test.go
@@ -1,0 +1,170 @@
+package hook
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// recordingMux is a windowMux that answers from fixed values and records what
+// was asked of it, so the guard can be exercised without a tmux server.
+type recordingMux struct {
+	paneCount   int
+	paneCountOK bool
+	windowName  string
+	windowOK    bool
+
+	renamed   []string // names passed to RenameWindow
+	automatic []bool   // values passed to SetAutomaticRename
+}
+
+func (m *recordingMux) RenameWindow(pane, name string) error {
+	m.renamed = append(m.renamed, name)
+	return nil
+}
+
+func (m *recordingMux) SetAutomaticRename(pane string, on bool) error {
+	m.automatic = append(m.automatic, on)
+	return nil
+}
+
+func (m *recordingMux) WindowName(pane string) (string, bool) {
+	return m.windowName, m.windowOK
+}
+
+func (m *recordingMux) WindowPaneCount(pane string) (int, bool) {
+	return m.paneCount, m.paneCountOK
+}
+
+// solePane is the ordinary case: one claude session, one pane, one window.
+func solePane() *recordingMux {
+	return &recordingMux{paneCount: 1, paneCountOK: true}
+}
+
+const (
+	testSessionID  = "6773febd-ce31-4e22-8354-5bc0d72c18a1"
+	testWindowName = "Docs-Lint-判断-6773febd"
+)
+
+func titledTranscript(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	line := `{"type":"ai-title","aiTitle":"Docs Lint 判断","sessionId":"` + testSessionID + `"}` + "\n"
+	if err := os.WriteFile(path, []byte(line), 0600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+func TestApplyWindowName_RenamesOnPromptAndStop(t *testing.T) {
+	// Stop matters as much as UserPromptSubmit: the ai-title is written right
+	// after the first answer, so without Stop a session would keep its
+	// fallback name until the user typed a second prompt.
+	for _, event := range []string{"UserPromptSubmit", "Stop"} {
+		t.Run(event, func(t *testing.T) {
+			mux := solePane()
+			applyWindowName(mux, event, "%1", titledTranscript(t), testSessionID)
+			if len(mux.renamed) != 1 || mux.renamed[0] != testWindowName {
+				t.Errorf("renamed = %v, want [%q]", mux.renamed, testWindowName)
+			}
+		})
+	}
+}
+
+func TestApplyWindowName_LeavesOtherEventsAlone(t *testing.T) {
+	// PostToolUse and friends fire many times a turn and would only re-derive
+	// the same name, at the cost of a tmux call each.
+	for _, event := range []string{"SessionStart", "PostToolUse", "PermissionRequest"} {
+		t.Run(event, func(t *testing.T) {
+			mux := solePane()
+			applyWindowName(mux, event, "%1", titledTranscript(t), testSessionID)
+			if len(mux.renamed) != 0 || len(mux.automatic) != 0 {
+				t.Errorf("%s touched the window: renamed=%v automatic=%v", event, mux.renamed, mux.automatic)
+			}
+		})
+	}
+}
+
+func TestApplyWindowName_Guards(t *testing.T) {
+	tests := []struct {
+		name string
+		mux  *recordingMux
+		pane string
+	}{
+		{
+			// A background session has no pane of its own, so there is no
+			// window it can claim.
+			name: "no pane",
+			mux:  solePane(),
+			pane: "",
+		},
+		{
+			// Two sessions split side by side would flip the shared window's
+			// name between two topics on every prompt.
+			name: "the window holds another pane",
+			mux:  &recordingMux{paneCount: 2, paneCountOK: true},
+			pane: "%1",
+		},
+		{
+			// An unanswerable count is not evidence the pane is alone, and
+			// the guard exists precisely to avoid taking a name that is not
+			// this session's to take.
+			name: "the pane count could not be read",
+			mux:  &recordingMux{paneCount: 1, paneCountOK: false},
+			pane: "%1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyWindowName(tt.mux, "UserPromptSubmit", tt.pane, titledTranscript(t), testSessionID)
+			if len(tt.mux.renamed) != 0 {
+				t.Errorf("renamed = %v, want no rename", tt.mux.renamed)
+			}
+		})
+	}
+}
+
+func TestApplyWindowName_UntitledTranscriptKeepsTheCurrentName(t *testing.T) {
+	// Before the first prompt is written there is nothing to name the window
+	// after, and an empty rename would be worse than the name it has.
+	mux := solePane()
+	applyWindowName(mux, "UserPromptSubmit", "%1", filepath.Join(t.TempDir(), "absent.jsonl"), testSessionID)
+	if len(mux.renamed) != 0 {
+		t.Errorf("renamed = %v, want no rename", mux.renamed)
+	}
+}
+
+func TestApplyWindowName_SessionEnd(t *testing.T) {
+	transcript := titledTranscript(t)
+
+	t.Run("hands the name back when it is ours", func(t *testing.T) {
+		// rename-window disables tmux's automatic-rename permanently, so a
+		// session that named its window has to give it back or the title of a
+		// finished conversation sits on top of the user's shell forever.
+		mux := &recordingMux{windowName: testWindowName, windowOK: true}
+		applyWindowName(mux, "SessionEnd", "%1", transcript, testSessionID)
+		if len(mux.automatic) != 1 || !mux.automatic[0] {
+			t.Errorf("automatic = %v, want [true]", mux.automatic)
+		}
+	})
+
+	t.Run("leaves a name we did not set", func(t *testing.T) {
+		// A window the user renamed by hand, or one the picker's exit rename
+		// has already moved aside, keeps the name it has.
+		for _, current := range []string{"my-own-name", testWindowName + "~exited", ""} {
+			mux := &recordingMux{windowName: current, windowOK: true}
+			applyWindowName(mux, "SessionEnd", "%1", transcript, testSessionID)
+			if len(mux.automatic) != 0 {
+				t.Errorf("window named %q: automatic = %v, want untouched", current, mux.automatic)
+			}
+		}
+	})
+
+	t.Run("an unreadable window name changes nothing", func(t *testing.T) {
+		mux := &recordingMux{windowName: testWindowName, windowOK: false}
+		applyWindowName(mux, "SessionEnd", "%1", transcript, testSessionID)
+		if len(mux.automatic) != 0 {
+			t.Errorf("automatic = %v, want untouched", mux.automatic)
+		}
+	})
+}

--- a/src/claude-queue/internal/label/label.go
+++ b/src/claude-queue/internal/label/label.go
@@ -1,0 +1,272 @@
+// Package label derives a human-readable name for the tmux window a Claude
+// Code session runs in, from the session's own transcript.
+//
+// The transcript is the only source that knows what a session is about. The
+// live agent roster (`claude agents --json`) does not: for interactive
+// sessions it names an agent after its cwd basename plus two hex digits, which
+// carries no more information than the session id already does, and reading it
+// costs half a second of subprocess -- far too much for a hook that fires on
+// every prompt and every stop.
+package label
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"unicode"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// maxLabelWidth caps the title part of a window name in terminal columns
+// (a double-width rune counts 2, which is why this is width and not runes --
+// most titles here are Japanese). The 8-char session id and its separator are
+// added on top, so a full name stays around 25 columns: long enough to read,
+// short enough that a handful of them still fit one tmux status line.
+const maxLabelWidth = 16
+
+// tailScanBytes is how much of the end of a transcript is read before falling
+// back to a full scan. The ai-title line is rewritten on nearly every turn
+// (observed up to 106 times in one session), so the last one is almost always
+// within the final few KiB; transcripts themselves reach megabytes, which is
+// what makes reading all of it on every hook event the wrong default.
+const tailScanBytes = 256 << 10
+
+// maxLineBytes drops transcript lines longer than this instead of buffering
+// them. A single tool_result line runs to megabytes, and neither line kind
+// read here -- an ai-title record or a user prompt -- is ever near this big.
+const maxLineBytes = 1 << 20
+
+// readBufBytes is the reader window eachLine assembles lines in. It only
+// bounds how many ReadSlice calls a long line costs, not what can be read.
+const readBufBytes = 64 << 10
+
+// Resolve returns the tmux window name for the session whose transcript is at
+// transcriptPath, or "" when the transcript offers nothing to name it with.
+//
+// "" is deliberately not a name of its own: what a caller should fall back to
+// depends on the caller (the picker still knows whether it is attaching or
+// resuming, a hook has no name to install at all), so the choice is left there.
+//
+// The session id is kept as a suffix even when a title was found. Two windows
+// can legitimately carry the same title -- the same worktree picked twice, a
+// resumed conversation next to its original -- and the suffix is what keeps
+// tmux's `new-window -S` dedupe keyed on the session rather than on the topic.
+func Resolve(transcriptPath, sessionID string) string {
+	lbl := Sanitize(rawTitle(transcriptPath))
+	if lbl == "" {
+		return ""
+	}
+	if s := shortID(sessionID); s != "" {
+		return lbl + "-" + s
+	}
+	return lbl
+}
+
+// shortID truncates a session id to the 8 chars every user-facing form of a
+// session id uses (it is also the only form `claude attach` takes).
+func shortID(sessionID string) string {
+	if len(sessionID) > 8 {
+		return sessionID[:8]
+	}
+	return sessionID
+}
+
+// Sanitize turns raw title text into something tmux can carry as a window
+// name, and a human can read at a glance.
+//
+// "." and ":" cannot survive: tmux reads them as the window.pane and
+// session:window separators in -t targets. "~" cannot survive either, because
+// the picker renames a window to "<name>~exited" once its command finishes and
+// relies on no live window ever ending in that suffix (see multiplexer's
+// windowCommand). Whitespace becomes "-" so the name stays one shell word.
+// Everything else -- Japanese in particular, which most titles here are --
+// is kept as is.
+func Sanitize(s string) string {
+	// One line only: a title is a phrase, but a user prompt (the fallback
+	// source) is often a whole paragraph.
+	if i := strings.IndexAny(s, "\r\n"); i >= 0 {
+		s = s[:i]
+	}
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r == '.' || r == ':' || r == '~' || unicode.IsSpace(r):
+			b.WriteByte('-')
+		case unicode.IsControl(r):
+			// Dropped rather than substituted: a control character is not a
+			// word boundary, so turning it into "-" would invent one.
+		default:
+			b.WriteRune(r)
+		}
+	}
+	// Truncate after collapsing, so the width budget is spent on characters
+	// rather than on runs of separators; trim again afterwards because the cut
+	// can land right after a "-".
+	return trimDashes(runewidth.Truncate(collapseDashes(b.String()), maxLabelWidth, ""))
+}
+
+// collapseDashes folds runs of "-" into one and drops the leading and trailing
+// ones. Beyond looks: a leading "-" would make the name an option as far as
+// tmux's argument parser is concerned, and a trailing one would show up as a
+// dangling separator before the session id suffix.
+func collapseDashes(s string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range s {
+		if r == '-' {
+			prevDash = true
+			continue
+		}
+		if prevDash && b.Len() > 0 {
+			b.WriteByte('-')
+		}
+		prevDash = false
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func trimDashes(s string) string {
+	return strings.Trim(s, "-")
+}
+
+// rawTitle reads transcriptPath and returns the best label text in it, or ""
+// when it has none (which includes every failure to read it: a hook must never
+// be the reason a session misbehaves, so an unreadable transcript degrades to
+// "no name" rather than to an error).
+func rawTitle(path string) string {
+	if path == "" {
+		return ""
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return ""
+	}
+	if fi.Size() > tailScanBytes {
+		// The tail alone answers nearly every call. Its first line is almost
+		// certainly cut in half, which needs no handling: half a line is not
+		// valid JSON, so it is skipped like any other unparseable line.
+		if title, _ := scan(io.NewSectionReader(f, fi.Size()-tailScanBytes, tailScanBytes)); title != "" {
+			return title
+		}
+		// A session that has not been titled yet (or was titled only very
+		// early, before a long run of tool output) still deserves a name, so
+		// pay for the full read rather than give up.
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return ""
+		}
+	}
+	title, prompt := scan(f)
+	if title != "" {
+		return title
+	}
+	return prompt
+}
+
+// scan reads jsonl records and returns the last ai-title and the first user
+// prompt it saw.
+//
+// Last ai-title, not first: Claude Code re-titles a session when the topic
+// moves on (4 of 39 sampled sessions did), and following the current topic is
+// the point of naming the window at all. The cost is that a re-title makes the
+// picker's `new-window -S` miss the window it opened under the old name and
+// add a second one -- rare enough to accept, and self-correcting once the
+// stale window's command exits.
+func scan(r io.Reader) (title, prompt string) {
+	eachLine(r, func(line []byte) bool {
+		var rec record
+		if err := json.Unmarshal(line, &rec); err != nil {
+			return true
+		}
+		switch rec.Type {
+		case "ai-title":
+			if rec.AITitle != "" {
+				title = rec.AITitle
+			}
+		case "user":
+			if prompt == "" {
+				prompt = userPrompt(rec)
+			}
+		}
+		return true
+	})
+	return title, prompt
+}
+
+// record is the union of the two transcript line shapes this package reads.
+// Every other field of a transcript line is ignored, so one decode per line
+// covers both without a second pass.
+type record struct {
+	Type    string `json:"type"`
+	AITitle string `json:"aiTitle"`
+	Message struct {
+		// Raw because "user" covers two different things: a typed prompt has
+		// a string content, while a tool_result carries an array. Decoding
+		// into a string is itself the test that tells them apart.
+		Content json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+// userPrompt returns the prompt text of a user record, or "" when the record
+// is not a prompt a human typed.
+//
+// Lines opening with "<" are dropped: Claude Code wraps injected context in
+// pseudo-tags (<local-command-caveat>, <command-name>, <system-reminder>),
+// which are user records by type but say nothing about the conversation.
+func userPrompt(rec record) string {
+	var content string
+	if err := json.Unmarshal(rec.Message.Content, &content); err != nil {
+		return "" // an array: tool_result, not a typed prompt
+	}
+	content = strings.TrimSpace(content)
+	if strings.HasPrefix(content, "<") {
+		return ""
+	}
+	return content
+}
+
+// eachLine feeds r's newline-separated lines to fn, stopping early when fn
+// returns false.
+//
+// bufio.Scanner is not used because it fails the entire scan on the first line
+// over its buffer, and a transcript reliably contains such lines. Here an
+// oversized line is dropped and the scan continues -- the ai-title line that
+// matters is very likely to come after it.
+func eachLine(r io.Reader, fn func([]byte) bool) {
+	br := bufio.NewReaderSize(r, readBufBytes)
+	var acc []byte
+	dropped := false
+	for {
+		chunk, err := br.ReadSlice('\n')
+		if err == bufio.ErrBufferFull {
+			if dropped || len(acc)+len(chunk) > maxLineBytes {
+				acc, dropped = nil, true
+				continue
+			}
+			acc = append(acc, chunk...)
+			continue
+		}
+		line := chunk
+		if dropped {
+			line = nil
+		} else if len(acc) > 0 {
+			line = append(acc, chunk...)
+		}
+		acc, dropped = nil, false
+		if len(line) > 0 && !fn(line) {
+			return
+		}
+		if err != nil {
+			return // io.EOF, or a read error we have nothing better to do about
+		}
+	}
+}

--- a/src/claude-queue/internal/label/label.go
+++ b/src/claude-queue/internal/label/label.go
@@ -81,9 +81,13 @@ func shortID(sessionID string) string {
 // session:window separators in -t targets. "~" cannot survive either, because
 // the picker renames a window to "<name>~exited" once its command finishes and
 // relies on no live window ever ending in that suffix (see multiplexer's
-// windowCommand). Whitespace becomes "-" so the name stays one shell word.
-// Everything else -- Japanese in particular, which most titles here are --
-// is kept as is.
+// windowCommand). "#" cannot survive either: tmux format-expands window names
+// passed to `rename-window` and `new-window -n` (confirmed against tmux 3.6b),
+// so "#S"/"#T"/"#D"/"#W" substitute the session/pane/window, and an
+// unterminated "#{" swallows the rest of the name -- silently producing a
+// window that no longer matches what Resolve computed. Whitespace becomes "-"
+// so the name stays one shell word. Everything else -- Japanese in
+// particular, which most titles here are -- is kept as is.
 func Sanitize(s string) string {
 	// One line only: a title is a phrase, but a user prompt (the fallback
 	// source) is often a whole paragraph.
@@ -93,7 +97,7 @@ func Sanitize(s string) string {
 	var b strings.Builder
 	for _, r := range s {
 		switch {
-		case r == '.' || r == ':' || r == '~' || unicode.IsSpace(r):
+		case r == '.' || r == ':' || r == '~' || r == '#' || unicode.IsSpace(r):
 			b.WriteByte('-')
 		case unicode.IsControl(r):
 			// Dropped rather than substituted: a control character is not a

--- a/src/claude-queue/internal/label/label_test.go
+++ b/src/claude-queue/internal/label/label_test.go
@@ -34,6 +34,14 @@ func TestSanitize(t *testing.T) {
 			want: "a-b-c-d",
 		},
 		{
+			// "#" triggers tmux's format expansion in a window name (e.g.
+			// "#S" substitutes the session name), which would make the name
+			// tmux actually stores diverge from what Resolve computed.
+			name: "hash is replaced",
+			in:   "fix-#67",
+			want: "fix-67",
+		},
+		{
 			name: "runs of separators collapse and edges are trimmed",
 			in:   "  a   ..b  ",
 			want: "a-b",
@@ -200,6 +208,74 @@ func TestResolveFallsBackToAFullScan(t *testing.T) {
 	}
 	if got, want := Resolve(path, sessionID), "early-topic-6773febd"; got != want {
 		t.Errorf("Resolve = %q, want %q", got, want)
+	}
+}
+
+// TestResolveTailAloneAnswers covers the tail read's ordinary job: the sole
+// ai-title sits within the last tailScanBytes of the transcript, with nothing
+// answering before it. Unlike every other Resolve test above (which puts its
+// title within the first tailScanBytes and so never actually exercises the
+// tail window), this one only comes out right if the tail window is read from
+// somewhere past the head.
+func TestResolveTailAloneAnswers(t *testing.T) {
+	// Padding that parses cleanly but names nothing, so a wrong answer here
+	// can only come from the scan, never from the filler.
+	filler := `{"type":"assistant","message":{"role":"assistant","content":"` + strings.Repeat("x", 900) + `"}}`
+	var lines []string
+	for total := 0; total < 2*tailScanBytes; total += len(filler) + 1 {
+		lines = append(lines, filler)
+	}
+	lines = append(lines, aiTitleLine("tail only"))
+	path := writeTranscript(t, lines...)
+
+	if fi, err := os.Stat(path); err != nil || fi.Size() <= tailScanBytes {
+		t.Fatalf("fixture must exceed the tail window: size err=%v", err)
+	}
+	if got, want := Resolve(path, sessionID), "tail-only-6773febd"; got != want {
+		t.Errorf("Resolve = %q, want %q", got, want)
+	}
+}
+
+// TestResolveTailTitleBeatsHeadTitle pins the tail window's offset arithmetic
+// (fi.Size()-tailScanBytes in rawTitle), not just that a title is eventually
+// found. The head and the tail each carry a different ai-title; a correctly
+// placed tail window sees only the tail one and returns it directly. A wrong
+// offset (0, say -- reading the head instead of the tail) would see the
+// head's title instead, return it immediately as a non-empty match, and never
+// reach the fallback full scan that would otherwise have caught the mistake.
+// TestResolveFallsBackToAFullScan cannot tell these two code paths apart
+// because it only ever has one title in the whole transcript.
+func TestResolveTailTitleBeatsHeadTitle(t *testing.T) {
+	lines := []string{aiTitleLine("head topic")}
+	filler := `{"type":"assistant","message":{"role":"assistant","content":"` + strings.Repeat("x", 900) + `"}}`
+	for total := 0; total < 2*tailScanBytes; total += len(filler) + 1 {
+		lines = append(lines, filler)
+	}
+	lines = append(lines, aiTitleLine("tail topic"))
+	path := writeTranscript(t, lines...)
+
+	if fi, err := os.Stat(path); err != nil || fi.Size() <= tailScanBytes {
+		t.Fatalf("fixture must exceed the tail window: size err=%v", err)
+	}
+	if got, want := Resolve(path, sessionID), "tail-topic-6773febd"; got != want {
+		t.Errorf("Resolve = %q, want %q", got, want)
+	}
+}
+
+// TestScanReassemblesAMultiChunkLine covers eachLine's acc reassembly path: a
+// line longer than readBufBytes (64 KiB) but well under maxLineBytes (1 MiB),
+// which forces multiple ReadSlice passes to be stitched back into one line
+// before it can be unmarshalled. None of the other fixtures in this file
+// exercise it -- they are all short, or (TestScanSkipsOversizedLines) long
+// enough to take the drop path instead. A pasted user prompt or a long
+// ai-title both land in exactly this band, so the path is real, not
+// hypothetical.
+func TestScanReassemblesAMultiChunkLine(t *testing.T) {
+	const size = 200 << 10 // between readBufBytes and maxLineBytes
+	long := strings.Repeat("z", size)
+	title, _ := scan(strings.NewReader(aiTitleLine(long) + "\n"))
+	if len(title) != size || title != long {
+		t.Errorf("scan lost or corrupted a %d-byte line spanning multiple read buffers (got len=%d)", size, len(title))
 	}
 }
 

--- a/src/claude-queue/internal/label/label_test.go
+++ b/src/claude-queue/internal/label/label_test.go
@@ -1,0 +1,229 @@
+package label
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSanitize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			// Most titles this reads are Japanese, so multi-byte text has to
+			// survive intact rather than be transliterated or dropped.
+			name: "japanese is kept",
+			in:   "ロググループ管理",
+			want: "ロググループ管理",
+		},
+		{
+			name: "spaces become hyphens",
+			in:   "Vercel log drain",
+			want: "Vercel-log-drain",
+		},
+		{
+			// "." and ":" are tmux's window.pane and session:window
+			// separators; "~" is reserved for the picker's "~exited" suffix.
+			name: "tmux separators are replaced",
+			in:   "a.b:c~d",
+			want: "a-b-c-d",
+		},
+		{
+			name: "runs of separators collapse and edges are trimmed",
+			in:   "  a   ..b  ",
+			want: "a-b",
+		},
+		{
+			// A control character is not a word boundary, so it leaves no
+			// hyphen behind.
+			name: "control characters are dropped, not substituted",
+			in:   "a\x00\x07b",
+			want: "ab",
+		},
+		{
+			// A user prompt (the fallback source) is often a paragraph; only
+			// its opening line can be a window name.
+			name: "only the first line is used",
+			in:   "first line\nsecond line",
+			want: "first-line",
+		},
+		{
+			// 20 columns of half-width text cut to the 16 the budget allows.
+			name: "half-width text is cut at 16 columns",
+			in:   "abcdefghijklmnopqrst",
+			want: "abcdefghijklmnop",
+		},
+		{
+			// 9 double-width runes are 18 columns, so 8 of them fit.
+			name: "double-width runes count two columns each",
+			in:   "ロググループの管理",
+			want: "ロググループの管",
+		},
+		{
+			// The cut can land right after a separator, which would leave the
+			// name ending in a dangling hyphen before the id suffix.
+			name: "a trailing hyphen left by the cut is trimmed",
+			in:   "abcdefghijklmno pqr",
+			want: "abcdefghijklmno",
+		},
+		{
+			name: "empty stays empty",
+			in:   "",
+			want: "",
+		},
+		{
+			// Nothing but separators is no name at all, and must not become a
+			// window called "-".
+			name: "separators only yield nothing",
+			in:   " .:~ ",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Sanitize(tt.in); got != tt.want {
+				t.Errorf("Sanitize(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// writeTranscript lays out a jsonl file for one test and returns its path.
+// Fixtures are generated rather than committed: the big one below is a third of
+// a megabyte, and none of this is data worth carrying in the repository.
+func writeTranscript(t *testing.T, lines ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+func aiTitleLine(title string) string {
+	return fmt.Sprintf(`{"type":"ai-title","aiTitle":%q,"sessionId":"6773febd-ce31-4e22-8354-5bc0d72c18a1"}`, title)
+}
+
+func userLine(content string) string {
+	return fmt.Sprintf(`{"type":"user","message":{"role":"user","content":%q},"uuid":"x"}`, content)
+}
+
+const sessionID = "6773febd-ce31-4e22-8354-5bc0d72c18a1"
+
+func TestResolve(t *testing.T) {
+	t.Run("the last ai-title wins", func(t *testing.T) {
+		// Claude Code re-titles a session when the topic moves on, and the
+		// window should follow the conversation rather than its opening.
+		path := writeTranscript(t,
+			userLine("ci docs-lint の timeout を調べて"),
+			aiTitleLine("ci docs-lint timeout"),
+			aiTitleLine("Docs Lint 判断"),
+		)
+		if got, want := Resolve(path, sessionID), "Docs-Lint-判断-6773febd"; got != want {
+			t.Errorf("Resolve = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("falls back to the first user prompt", func(t *testing.T) {
+		// A session titled only after its first answer still has to be
+		// nameable from the moment the user hits enter.
+		path := writeTranscript(t,
+			userLine("GitHub App の PR 作成"),
+			userLine("次の質問"),
+		)
+		if got, want := Resolve(path, sessionID), "GitHub-App-の-PR-6773febd"; got != want {
+			t.Errorf("Resolve = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("tool results and injected context are not prompts", func(t *testing.T) {
+		// A tool_result is a "user" record with an array content, and Claude
+		// Code injects its own context as pseudo-tagged user text; neither
+		// says anything about what the session is about.
+		path := writeTranscript(t,
+			`{"type":"user","message":{"role":"user","content":[{"tool_use_id":"t1","type":"tool_result","content":"iac/cdk.json"}]}}`,
+			userLine("<local-command-caveat>Caveat: ...</local-command-caveat>"),
+			userLine("本当の質問"),
+		)
+		if got, want := Resolve(path, sessionID), "本当の質問-6773febd"; got != want {
+			t.Errorf("Resolve = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("nothing to name it with", func(t *testing.T) {
+		// "" is the contract that hands the choice back to the caller: the
+		// picker still knows it is attaching, a hook has nothing to install.
+		path := writeTranscript(t, `{"type":"assistant","message":{"role":"assistant"}}`)
+		if got := Resolve(path, sessionID); got != "" {
+			t.Errorf("Resolve = %q, want empty", got)
+		}
+	})
+
+	t.Run("an unreadable transcript is not an error", func(t *testing.T) {
+		if got := Resolve(filepath.Join(t.TempDir(), "absent.jsonl"), sessionID); got != "" {
+			t.Errorf("Resolve = %q, want empty", got)
+		}
+		if got := Resolve("", sessionID); got != "" {
+			t.Errorf(`Resolve("") = %q, want empty`, got)
+		}
+	})
+
+	t.Run("a session id shorter than 8 chars is used as is", func(t *testing.T) {
+		path := writeTranscript(t, aiTitleLine("topic"))
+		if got, want := Resolve(path, "abc"), "topic-abc"; got != want {
+			t.Errorf("Resolve = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestResolveFallsBackToAFullScan covers the case the tail read exists to
+// avoid paying for, and must not silently lose: a session titled early and then
+// buried under more than tailScanBytes of tool output. The tail alone sees no
+// ai-title there, so the read has to start over from the beginning.
+func TestResolveFallsBackToAFullScan(t *testing.T) {
+	lines := []string{aiTitleLine("early topic")}
+	// Padding that parses cleanly but names nothing, so a wrong answer here
+	// can only come from the scan, never from the filler.
+	filler := `{"type":"assistant","message":{"role":"assistant","content":"` + strings.Repeat("x", 900) + `"}}`
+	for total := 0; total < 2*tailScanBytes; total += len(filler) + 1 {
+		lines = append(lines, filler)
+	}
+	path := writeTranscript(t, lines...)
+
+	if fi, err := os.Stat(path); err != nil || fi.Size() <= tailScanBytes {
+		t.Fatalf("fixture must exceed the tail window: size err=%v", err)
+	}
+	if got, want := Resolve(path, sessionID), "early-topic-6773febd"; got != want {
+		t.Errorf("Resolve = %q, want %q", got, want)
+	}
+}
+
+// TestScanSkipsOversizedLines pins why bufio.Scanner is not used here: a
+// transcript reliably contains tool_result lines of several megabytes, and a
+// reader that gives up on the first one would never reach the title that
+// follows it.
+func TestScanSkipsOversizedLines(t *testing.T) {
+	huge := `{"type":"assistant","message":{"role":"assistant","content":"` + strings.Repeat("x", 2*maxLineBytes) + `"}}`
+	title, _ := scan(strings.NewReader(huge + "\n" + aiTitleLine("after the giant") + "\n"))
+	if want := "after the giant"; title != want {
+		t.Errorf("scan title = %q, want %q", title, want)
+	}
+}
+
+// TestScanIgnoresAPartialFirstLine is the tail read's one structural hazard:
+// the window starts mid-line. Half a JSON object is simply unparseable, which
+// is the same path every other malformed line takes.
+func TestScanIgnoresAPartialFirstLine(t *testing.T) {
+	title, prompt := scan(strings.NewReader(`ssage":{"role":"user","content":"cut in half"}}` + "\n" + aiTitleLine("whole") + "\n"))
+	if title != "whole" {
+		t.Errorf("scan title = %q, want %q", title, "whole")
+	}
+	if prompt != "" {
+		t.Errorf("scan prompt = %q, want empty: a half line is not a prompt", prompt)
+	}
+}

--- a/src/claude-queue/internal/multiplexer/multiplexer.go
+++ b/src/claude-queue/internal/multiplexer/multiplexer.go
@@ -18,9 +18,29 @@ type Multiplexer interface {
 	Switch(target string) error
 	// OpenSession opens argv in a window of the multiplexer session named
 	// name, creating that session if it does not exist, and moves the client
-	// there. cwd is the window's working directory. Returns an error when
-	// there is no multiplexer to open a session in.
-	OpenSession(name, cwd string, argv []string) error
+	// there. cwd is the window's working directory. window is the name to
+	// give that window, which callers derive from the session's content (see
+	// internal/label) -- the implementation only sanitizes it, it never
+	// invents one. Returns an error when there is no multiplexer to open a
+	// session in.
+	OpenSession(name, cwd, window string, argv []string) error
+	// RenameWindow renames the window holding pane. Used to keep a window's
+	// name following the conversation running in it, so it is best-effort:
+	// callers ignore the error rather than fail the operation they were in.
+	RenameWindow(pane, name string) error
+	// SetAutomaticRename re-enables (or disables) the multiplexer's own
+	// window naming for the window holding pane. Renaming a window turns
+	// tmux's automatic-rename off permanently, so a session that named its
+	// window has to hand the name back when it ends.
+	SetAutomaticRename(pane string, on bool) error
+	// WindowName returns the current name of the window holding pane.
+	// Reports false when it cannot be asked, which callers must not read as
+	// "the name is empty".
+	WindowName(pane string) (string, bool)
+	// WindowPaneCount returns how many panes share pane's window, so a caller
+	// can tell whether renaming that window speaks for pane alone. Reports
+	// false when it cannot be asked.
+	WindowPaneCount(pane string) (int, bool)
 	// FindPane returns the pane pid is running in, walking up the process
 	// tree until a pane matches, so a process started deeper than the pane's
 	// own shell is still located. Reports false when there is no such pane --
@@ -58,9 +78,20 @@ func (noopImpl) Switch(target string) error { return nil }
 // OpenSession cannot succeed without a multiplexer, and callers need to know:
 // unlike Switch, there is no silent degradation that still gets the user to
 // their session. The error is what makes the caller print a manual fallback.
-func (noopImpl) OpenSession(name, cwd string, argv []string) error {
+func (noopImpl) OpenSession(name, cwd, window string, argv []string) error {
 	return errors.New("no multiplexer detected")
 }
+
+// RenameWindow and SetAutomaticRename succeed silently for the same reason
+// Switch does: window naming is cosmetic, and a hook running outside tmux must
+// not report a failure over it.
+func (noopImpl) RenameWindow(pane, name string) error          { return nil }
+func (noopImpl) SetAutomaticRename(pane string, on bool) error { return nil }
+
+// WindowName and WindowPaneCount have no window to describe. The false is what
+// keeps a caller from acting on the zero values as if they were answers.
+func (noopImpl) WindowName(pane string) (string, bool)   { return "", false }
+func (noopImpl) WindowPaneCount(pane string) (int, bool) { return 0, false }
 
 // FindPane has no panes to search without a multiplexer. Unlike OpenSession this
 // needs no error: "not found" is already the answer the caller acts on.

--- a/src/claude-queue/internal/multiplexer/multiplexer_test.go
+++ b/src/claude-queue/internal/multiplexer/multiplexer_test.go
@@ -30,7 +30,7 @@ func TestDetect_NoMultiplexer(t *testing.T) {
 	}
 	// Unlike Switch, OpenSession must return an error: the picker's attach path
 	// relies on this to decide whether to print a manual-fallback hint.
-	if err := m.OpenSession("dotrc_wt", "/w/a", []string{"claude", "attach", "abc"}); err == nil {
+	if err := m.OpenSession("dotrc_wt", "/w/a", "some-window", []string{"claude", "attach", "abc"}); err == nil {
 		t.Errorf("noop OpenSession err = nil, want non-nil")
 	}
 	// With no server there is no pane to confirm and no server pid to compare
@@ -44,6 +44,21 @@ func TestDetect_NoMultiplexer(t *testing.T) {
 	}
 	if _, ok := m.ServerPID(); ok {
 		t.Error("noop ServerPID reported a server, want none")
+	}
+	// Window naming is cosmetic, so its writes stay silent like Switch; its
+	// two reads report false, which is what keeps the hook's rename guard
+	// from acting on a zero value it never actually measured.
+	if err := m.RenameWindow("%1", "x"); err != nil {
+		t.Errorf("noop RenameWindow err = %v, want nil", err)
+	}
+	if err := m.SetAutomaticRename("%1", true); err != nil {
+		t.Errorf("noop SetAutomaticRename err = %v, want nil", err)
+	}
+	if _, ok := m.WindowName("%1"); ok {
+		t.Error("noop WindowName reported a name, want none")
+	}
+	if _, ok := m.WindowPaneCount("%1"); ok {
+		t.Error("noop WindowPaneCount reported a count, want none")
 	}
 }
 

--- a/src/claude-queue/internal/multiplexer/tmux.go
+++ b/src/claude-queue/internal/multiplexer/tmux.go
@@ -27,7 +27,7 @@ func (tmuxImpl) Switch(target string) error {
 // needs the session, not just the window: a background session belongs to a
 // worktree, and opening its window wherever the popup happened to be invoked
 // from would scatter unrelated worktrees across one session.
-func (tmuxImpl) OpenSession(name, cwd string, argv []string) error {
+func (tmuxImpl) OpenSession(name, cwd, window string, argv []string) error {
 	if name == "" {
 		return errors.New("no session name")
 	}
@@ -37,7 +37,10 @@ func (tmuxImpl) OpenSession(name, cwd string, argv []string) error {
 	// tmux invocation below must see the same sanitized name has-session
 	// checks, so this has to run before any of them.
 	name = sanitizeSessionName(name)
-	window := windowName(argv)
+	// Same reasoning for the window name, and the same "before every use"
+	// requirement: -n, -S and the rename inside windowCommand all have to
+	// agree on one spelling or the dedupe stops matching.
+	window = sanitizeWindowName(window)
 	if err := exec.Command("tmux", "has-session", "-t="+name).Run(); err != nil {
 		// A new session must be created detached. The picker runs inside
 		// `display-popup -E`, and an attaching new-session would try to take
@@ -56,8 +59,8 @@ func (tmuxImpl) OpenSession(name, cwd string, argv []string) error {
 // newSessionArgs builds the tmux argv for creating the session. Split out from
 // OpenSession so the contract can be asserted without starting a tmux server.
 //
-// -n names the initial window explicitly with the same windowName(argv) used
-// by newWindowArgs below. Without it tmux auto-names the window from the
+// -n names the initial window explicitly with the same window name passed to
+// newWindowArgs below. Without it tmux auto-names the window from the
 // shell command, which does not match the name newWindowArgs' -S looks for,
 // so a session created via this path would never dedupe on a second pick of
 // the same target (a second window would stack instead of -S selecting the
@@ -88,9 +91,9 @@ func newWindowArgs(name, window, cwd string, argv []string) []string {
 }
 
 // exitedSuffix marks a window whose command has finished and which now holds
-// nothing but the fallback shell. windowName never emits "~" (it keeps only
-// [A-Za-z0-9_-]), so a renamed window can never collide with the name a later
-// pick asks -S for -- which is the whole point of the rename, see windowCommand.
+// nothing but the fallback shell. sanitizeWindowName never emits "~", so a
+// renamed window can never collide with the name a later pick asks -S for --
+// which is the whole point of the rename, see windowCommand.
 const exitedSuffix = "~exited"
 
 // windowCommand renders argv as the one trailing argument tmux runs in the new
@@ -157,30 +160,92 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
-// windowName derives a window name from the command being run, so repeated
-// picks of the same target collapse onto one window (see -S above) while two
-// different sessions opened in the same tmux session stay apart. Anything
-// outside [A-Za-z0-9_-] becomes "_": tmux reads "." and ":" as the
-// window.pane and session:window separators in -t targets.
-func windowName(argv []string) string {
-	if len(argv) == 0 {
+// sanitizeWindowName is the last gate before a caller-supplied name reaches
+// tmux. internal/label already produces names in this shape, so this is a
+// backstop rather than the formatting step -- which is why it substitutes and
+// trims but deliberately does not truncate: shortening a name twice, under two
+// different width rules, would make the -n / -S / rename spellings disagree.
+//
+// "." and ":" are the window.pane and session:window separators in -t targets.
+// "~" is reserved for exitedSuffix. A leading "-" would be read as an option by
+// tmux's argument parser, and a trailing one is just a dangling separator.
+// Empty falls back to "cmd", so tmux is never handed an unnamed window.
+func sanitizeWindowName(name string) string {
+	name = strings.Trim(strings.NewReplacer(".", "-", ":", "-", "~", "-").Replace(name), "-")
+	if name == "" {
 		return "cmd"
 	}
-	var b strings.Builder
-	for i, a := range argv {
-		if i > 0 {
-			b.WriteByte('-')
-		}
-		for _, r := range a {
-			switch {
-			case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
-				b.WriteRune(r)
-			default:
-				b.WriteByte('_')
-			}
+	return name
+}
+
+// RenameWindow renames the window pane belongs to. Passing a pane id where
+// tmux expects a target-window is deliberate and supported: tmux resolves it
+// to the window that contains the pane, which is what lets a hook rename "its"
+// window while knowing only $TMUX_PANE.
+func (tmuxImpl) RenameWindow(pane, name string) error {
+	return exec.Command("tmux", renameWindowArgs(pane, sanitizeWindowName(name))...).Run()
+}
+
+func renameWindowArgs(pane, name string) []string {
+	return []string{"rename-window", "-t", pane, name}
+}
+
+// SetAutomaticRename hands the window's name back to tmux (or takes it away).
+// tmux disables automatic-rename for a window as soon as anything names it
+// explicitly -- `new-window -n`, `rename-window` -- and never re-enables it on
+// its own, so without this the last name a session set would outlive it and
+// sit on top of the shell that takes the pane over.
+func (tmuxImpl) SetAutomaticRename(pane string, on bool) error {
+	return exec.Command("tmux", automaticRenameArgs(pane, on)...).Run()
+}
+
+func automaticRenameArgs(pane string, on bool) []string {
+	value := "off"
+	if on {
+		value = "on"
+	}
+	return []string{"setw", "-t", pane, "automatic-rename", value}
+}
+
+// WindowName returns the name of the window pane belongs to.
+func (tmuxImpl) WindowName(pane string) (string, bool) {
+	out, err := exec.Command("tmux", windowNameArgs(pane)...).Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimRight(string(out), "\n"), true
+}
+
+func windowNameArgs(pane string) []string {
+	return []string{"display", "-p", "-t", pane, "#{window_name}"}
+}
+
+// WindowPaneCount counts the panes sharing pane's window.
+func (tmuxImpl) WindowPaneCount(pane string) (int, bool) {
+	out, err := exec.Command("tmux", windowPanesArgs(pane)...).Output()
+	if err != nil {
+		return 0, false
+	}
+	return countLines(string(out)), true
+}
+
+func windowPanesArgs(pane string) []string {
+	return []string{"list-panes", "-t", pane, "-F", "#{pane_id}"}
+}
+
+// countLines counts the non-empty lines of a tmux -F listing. Blank lines are
+// skipped rather than counted, so the trailing newline does not inflate the
+// count into a second pane that is not there -- which for the rename guard
+// would be the expensive direction to be wrong in (it would silently stop
+// renaming every window).
+func countLines(out string) int {
+	n := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
 		}
 	}
-	return b.String()
+	return n
 }
 
 // sanitizeSessionName makes a worktree directory name usable as a tmux target.

--- a/src/claude-queue/internal/multiplexer/tmux.go
+++ b/src/claude-queue/internal/multiplexer/tmux.go
@@ -167,11 +167,16 @@ func shellQuote(s string) string {
 // different width rules, would make the -n / -S / rename spellings disagree.
 //
 // "." and ":" are the window.pane and session:window separators in -t targets.
-// "~" is reserved for exitedSuffix. A leading "-" would be read as an option by
-// tmux's argument parser, and a trailing one is just a dangling separator.
-// Empty falls back to "cmd", so tmux is never handed an unnamed window.
+// "~" is reserved for exitedSuffix. "#" is tmux's format-expansion marker for
+// the very argument this feeds -- rename-window and new-window -n both expand
+// "#S"/"#T"/"#D"/"#W"/"#{...}" in the name they are given (confirmed against
+// tmux 3.6b), so a "#" left in would make the name tmux stores diverge from
+// the one -S/-n/rename-window agreed on. A leading "-" would be read as an
+// option by tmux's argument parser, and a trailing one is just a dangling
+// separator. Empty falls back to "cmd", so tmux is never handed an unnamed
+// window.
 func sanitizeWindowName(name string) string {
-	name = strings.Trim(strings.NewReplacer(".", "-", ":", "-", "~", "-").Replace(name), "-")
+	name = strings.Trim(strings.NewReplacer(".", "-", ":", "-", "~", "-", "#", "-").Replace(name), "-")
 	if name == "" {
 		return "cmd"
 	}

--- a/src/claude-queue/internal/multiplexer/tmux_test.go
+++ b/src/claude-queue/internal/multiplexer/tmux_test.go
@@ -73,7 +73,7 @@ func TestNewSessionArgs(t *testing.T) {
 // would only hold when the session already existed, never on first creation.
 func TestNewSessionArgsWindowNameMatchesNewWindow(t *testing.T) {
 	argv := []string{"claude", "attach", "abc"}
-	window := windowName(argv)
+	window := "claude-attach-abc"
 
 	sessionArgs := newSessionArgs("dotrc_wt", window, "/w/a", argv)
 	windowArgs := newWindowArgs("dotrc_wt", window, "/w/a", argv)
@@ -246,7 +246,7 @@ func TestWindowCommand(t *testing.T) {
 // must be exactly the one -S looks for.
 func TestWindowCommandReleasesTheDedupeName(t *testing.T) {
 	argv := []string{"claude", "attach", "abc"}
-	window := windowName(argv)
+	window := "claude-attach-abc"
 
 	for _, tt := range []struct {
 		name string
@@ -271,29 +271,34 @@ func TestWindowCommandReleasesTheDedupeName(t *testing.T) {
 		})
 	}
 
-	// A released name must not be picked up by a later -S. windowName keeps
-	// only [A-Za-z0-9_-], so no argv -- not even one containing "~" itself --
-	// can produce a name that ends in the suffix.
-	for _, probe := range [][]string{argv, {"claude", "--resume", "u~exited"}, {"a.b", "c:d"}} {
-		if strings.HasSuffix(windowName(probe), exitedSuffix) {
-			t.Errorf("windowName(%v) = %q ends with %q; a live window could collide with a released one", probe, windowName(probe), exitedSuffix)
+	// A released name must not be picked up by a later -S. sanitizeWindowName
+	// strips "~", so no caller-supplied name -- not even one that already ends
+	// in the suffix -- can reach tmux still carrying it.
+	for _, probe := range []string{"claude-attach-abc", "u~exited", "a.b:c", "~exited"} {
+		if strings.HasSuffix(sanitizeWindowName(probe), exitedSuffix) {
+			t.Errorf("sanitizeWindowName(%q) = %q ends with %q; a live window could collide with a released one", probe, sanitizeWindowName(probe), exitedSuffix)
 		}
 	}
 }
 
-// TestWindowNameIgnoresShellWrap pins that the dedupe key stays derived from
-// the raw argv. Computing it from the wrapped command instead would fold the
-// "; exec ..." tail into every window name, changing what newWindowArgs' -S
-// matches on -- and the names of the two paths would drift apart the moment
-// only one of them wrapped.
-func TestWindowNameIgnoresShellWrap(t *testing.T) {
-	argv := []string{"claude", "attach", "abc"}
+// TestWindowCommandUsesTheGivenName pins that the name the window is created
+// under and the name its exit rename releases are the same string the caller
+// handed in. The wrap around the command must not leak into either: if the
+// two ever diverge, -S stops matching and repeat picks stack windows.
+func TestWindowCommandUsesTheGivenName(t *testing.T) {
+	const window = "AWS-ログ調査-6773febd"
 
-	if got, want := windowName(argv), "claude-attach-abc"; got != want {
-		t.Errorf("windowName(%v) = %q, want %q", argv, got, want)
+	got := windowCommand(window, []string{"claude", "attach", "abc"})
+	if len(got) != 1 {
+		t.Fatalf("windowCommand(...) = %v, want exactly one argument", got)
 	}
-	if wrapped := windowName(windowCommand(windowName(argv), argv)); wrapped == windowName(argv) {
-		t.Errorf("windowName of the wrapped command = %q, expected it to differ from the raw-argv name; the wrap must not feed windowName", wrapped)
+	if !strings.Contains(got[0], shellQuote(window+exitedSuffix)) {
+		t.Errorf("windowCommand(...) = %q, must release exactly %q", got[0], window+exitedSuffix)
+	}
+	// The caller's name is what -n installs, unchanged.
+	args := newWindowArgs("dotrc_wt", window, "/w/a", []string{"claude", "attach", "abc"})
+	if named := args[slices.Index(args, "-n")+1]; named != window {
+		t.Errorf("newWindowArgs named the window %q, want the caller's %q", named, window)
 	}
 }
 
@@ -336,36 +341,67 @@ func TestSanitizeSessionName(t *testing.T) {
 	}
 }
 
-func TestWindowName(t *testing.T) {
+func TestSanitizeWindowName(t *testing.T) {
 	tests := []struct {
 		name string
-		argv []string
+		in   string
 		want string
 	}{
 		{
-			name: "claude attach",
-			argv: []string{"claude", "attach", "61c846eb"},
-			want: "claude-attach-61c846eb",
+			// The common case: internal/label already produced a tmux-safe
+			// name, so this must be a pass-through -- including the Japanese
+			// most titles are written in.
+			name: "an already-safe label is untouched",
+			in:   "ロググループの管理-0837e774",
+			want: "ロググループの管理-0837e774",
 		},
 		{
 			// "." and ":" are the window.pane and session:window separators
 			// in tmux -t targets, so they cannot survive in a window name.
 			name: "separators are replaced",
-			argv: []string{"a.b", "c:d"},
-			want: "a_b-c_d",
+			in:   "a.b:c",
+			want: "a-b-c",
 		},
 		{
-			name: "empty argv",
-			argv: nil,
+			// "~" belongs to exitedSuffix; a name carrying it could collide
+			// with a released one and swallow the next pick.
+			name: "tilde is replaced",
+			in:   "u~exited",
+			want: "u-exited",
+		},
+		{
+			// tmux would read a leading "-" as an option to rename-window.
+			name: "edge dashes are trimmed",
+			in:   "-mid-dle-",
+			want: "mid-dle",
+		},
+		{
+			name: "empty falls back",
+			in:   "",
+			want: "cmd",
+		},
+		{
+			name: "all-separator input falls back",
+			in:   "...",
 			want: "cmd",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := windowName(tt.argv); got != tt.want {
-				t.Errorf("windowName(%v) = %q, want %q", tt.argv, got, tt.want)
+			if got := sanitizeWindowName(tt.in); got != tt.want {
+				t.Errorf("sanitizeWindowName(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+// sanitizeWindowName is a backstop, not the formatter: internal/label owns the
+// width budget, and a second truncation here under a different rule would make
+// -n, -S and the exit rename disagree about the same window.
+func TestSanitizeWindowNameDoesNotTruncate(t *testing.T) {
+	long := strings.Repeat("a", 200)
+	if got := sanitizeWindowName(long); got != long {
+		t.Errorf("sanitizeWindowName truncated a %d-char name to %d chars", len(long), len(got))
 	}
 }
 
@@ -451,5 +487,70 @@ func TestParsePanes(t *testing.T) {
 	// the walk could then match against.
 	if got := parsePanes("junk\n\nnotapid %1\n42 %2\n"); len(got) != 1 || got[42] != "%2" {
 		t.Errorf("parsePanes with junk lines = %v, want only 42:%%2", got)
+	}
+}
+
+// The window-naming commands are asserted as argv, for the same reason the
+// session builders are: the contract is the argument list, and checking it
+// needs no tmux server.
+func TestWindowNamingArgs(t *testing.T) {
+	// A pane id where tmux documents a target-window is deliberate: tmux
+	// resolves it to the window holding the pane, which is the only handle a
+	// hook has ($TMUX_PANE).
+	if got, want := renameWindowArgs("%5", "topic-6773febd"),
+		[]string{"rename-window", "-t", "%5", "topic-6773febd"}; !slices.Equal(got, want) {
+		t.Errorf("renameWindowArgs = %v, want %v", got, want)
+	}
+	if got, want := automaticRenameArgs("%5", true),
+		[]string{"setw", "-t", "%5", "automatic-rename", "on"}; !slices.Equal(got, want) {
+		t.Errorf("automaticRenameArgs(on) = %v, want %v", got, want)
+	}
+	if got, want := automaticRenameArgs("%5", false),
+		[]string{"setw", "-t", "%5", "automatic-rename", "off"}; !slices.Equal(got, want) {
+		t.Errorf("automaticRenameArgs(off) = %v, want %v", got, want)
+	}
+	if got, want := windowNameArgs("%5"),
+		[]string{"display", "-p", "-t", "%5", "#{window_name}"}; !slices.Equal(got, want) {
+		t.Errorf("windowNameArgs = %v, want %v", got, want)
+	}
+	// -F over the window's panes: the count is the number of lines, so the
+	// format has to be one field per pane and nothing else.
+	if got, want := windowPanesArgs("%5"),
+		[]string{"list-panes", "-t", "%5", "-F", "#{pane_id}"}; !slices.Equal(got, want) {
+		t.Errorf("windowPanesArgs = %v, want %v", got, want)
+	}
+}
+
+func TestCountLines(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want int
+	}{
+		{
+			// The single-pane answer is what the hook's rename guard turns on,
+			// and tmux always ends its listing with a newline: counting that
+			// as a second pane would stop every rename.
+			name: "one pane with a trailing newline",
+			out:  "%5\n",
+			want: 1,
+		},
+		{
+			name: "a split window",
+			out:  "%5\n%6\n",
+			want: 2,
+		},
+		{
+			name: "no output at all",
+			out:  "",
+			want: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := countLines(tt.out); got != tt.want {
+				t.Errorf("countLines(%q) = %d, want %d", tt.out, got, tt.want)
+			}
+		})
 	}
 }

--- a/src/claude-queue/internal/multiplexer/tmux_test.go
+++ b/src/claude-queue/internal/multiplexer/tmux_test.go
@@ -4,6 +4,8 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/knagiri/dotrc/src/claude-queue/internal/label"
 )
 
 // wantCommand is what `claude attach abc` must reach tmux as: one shell
@@ -370,6 +372,18 @@ func TestSanitizeWindowName(t *testing.T) {
 			want: "u-exited",
 		},
 		{
+			// "#" is tmux's format-expansion marker (rename-window and
+			// new-window -n both expand it), so a name carrying it would be
+			// stored under a different string than the one -S looks for.
+			// See sanitizeWindowName's doc comment for the observed
+			// substitutions (e.g. "#S" -> the session name). Unlike
+			// label.Sanitize, this backstop does not collapse runs of "-",
+			// so the input here is chosen free of adjacent separators.
+			name: "hash is replaced",
+			in:   "issue#123",
+			want: "issue-123",
+		},
+		{
 			// tmux would read a leading "-" as an option to rename-window.
 			name: "edge dashes are trimmed",
 			in:   "-mid-dle-",
@@ -402,6 +416,30 @@ func TestSanitizeWindowNameDoesNotTruncate(t *testing.T) {
 	long := strings.Repeat("a", 200)
 	if got := sanitizeWindowName(long); got != long {
 		t.Errorf("sanitizeWindowName truncated a %d-char name to %d chars", len(long), len(got))
+	}
+}
+
+// TestSanitizeWindowNameIsAFixedPointOfLabelSanitize pins the invariant the
+// package design depends on but never asserted directly: sanitizeWindowName
+// must be a no-op on whatever label.Sanitize already produced. If the two
+// characters lists ever drift apart -- e.g. a future separator gets added to
+// one but not the other -- the name -n/-S installed and the one this backstop
+// would produce for the *same* input diverge, and the -S dedupe in OpenSession
+// silently stops matching. "#" is exactly this failure mode's history: it was
+// missing from both.
+func TestSanitizeWindowNameIsAFixedPointOfLabelSanitize(t *testing.T) {
+	for _, in := range []string{
+		"a.b:c~d",
+		"fix-#67",
+		"x##y",
+		"fix-#{session_na",
+		"ロググループ管理",
+		"Vercel log drain",
+	} {
+		sanitized := label.Sanitize(in)
+		if got := sanitizeWindowName(sanitized); got != sanitized {
+			t.Errorf("sanitizeWindowName(label.Sanitize(%q)) = %q, want the fixed point %q", in, got, sanitized)
+		}
 	}
 }
 

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
+	"github.com/knagiri/dotrc/src/claude-queue/internal/label"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/multiplexer"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/reconcile"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/roster"
@@ -277,6 +278,21 @@ func resumeBlocked(t Target) string {
 	return ""
 }
 
+// windowNameFor names the window a pick opens after what the session is
+// actually about, falling back to "<kind>-<short id>" when its transcript
+// cannot say (a session that ended before being titled, a transcript that has
+// since been removed).
+//
+// The fallback keeps the old machine name's one virtue -- it is unique per
+// session, so `new-window -S` still collapses repeat picks of the same row --
+// while dropping the argv noise that made every window read the same.
+func windowNameFor(transcript, sessionID, kind string) string {
+	if name := label.Resolve(transcript, sessionID); name != "" {
+		return name
+	}
+	return kind + "-" + shortID(sessionID)
+}
+
 // shortID truncates a session id to the 8 chars `claude attach` takes, and the
 // form every message about a session uses.
 func shortID(sessionID string) string {
@@ -505,7 +521,7 @@ func Run(args []string) {
 		// Do NOT terminate the session on failure the way the pane path does:
 		// a failed window open says nothing about whether the session is alive,
 		// and the manual command still works.
-		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, []string{"claude", "attach", act.Short}); err != nil {
+		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, windowNameFor(transcript, sessionID, "attach"), []string{"claude", "attach", act.Short}); err != nil {
 			fmt.Fprintf(os.Stderr, "open session failed: %v\nrun: claude attach %s\n", err, act.Short)
 		}
 	case "resume":
@@ -519,7 +535,7 @@ func Run(args []string) {
 				return
 			}
 		}
-		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, []string{"claude", "--resume", act.Resume}); err != nil {
+		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, windowNameFor(transcript, sessionID, "resume"), []string{"claude", "--resume", act.Resume}); err != nil {
 			fmt.Fprintf(os.Stderr, "open session failed: %v\nrun: cd %s && claude --resume %s\n", err, act.Cwd, act.Resume)
 		}
 	default:

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -3,6 +3,8 @@ package picker
 import (
 	"database/sql"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -562,10 +564,17 @@ type fakeMux struct {
 	serverPID int             // ServerPID; 0 means "no server"
 }
 
-func (f *fakeMux) PaneID() string                                 { return "" }
-func (f *fakeMux) RefreshStatus()                                 {}
-func (f *fakeMux) Switch(target string) error                     { return nil }
-func (f *fakeMux) OpenSession(name, cwd string, a []string) error { return nil }
+func (f *fakeMux) PaneID() string                                         { return "" }
+func (f *fakeMux) RefreshStatus()                                         {}
+func (f *fakeMux) Switch(target string) error                             { return nil }
+func (f *fakeMux) OpenSession(name, cwd, window string, a []string) error { return nil }
+
+// The window-naming methods are equally unused here: picker.Run drives them,
+// and Run is the exec boundary these tests stay on the near side of.
+func (f *fakeMux) RenameWindow(pane, name string) error          { return nil }
+func (f *fakeMux) SetAutomaticRename(pane string, on bool) error { return nil }
+func (f *fakeMux) WindowName(pane string) (string, bool)         { return "", false }
+func (f *fakeMux) WindowPaneCount(pane string) (int, bool)       { return 0, false }
 func (f *fakeMux) FindPane(pid int) (string, bool) {
 	pane, ok := f.find[pid]
 	return pane, ok
@@ -763,6 +772,34 @@ func TestWaitGone(t *testing.T) {
 		other := []roster.Agent{{SessionID: "t", PID: 2}}
 		if !waitGone("s", func() ([]roster.Agent, error) { return other, nil }, func() {}, 2) {
 			t.Error("waitGone = false when only another session is listed, want true")
+		}
+	})
+}
+
+func TestWindowNameFor(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	line := `{"type":"ai-title","aiTitle":"GitHub App PR 作成","sessionId":"6773febd"}` + "\n"
+	if err := os.WriteFile(path, []byte(line), 0600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	const sessionID = "6773febd-ce31-4e22-8354-5bc0d72c18a1"
+
+	t.Run("named after the conversation", func(t *testing.T) {
+		if got, want := windowNameFor(path, sessionID, "attach"), "GitHub-App-PR-作-6773febd"; got != want {
+			t.Errorf("windowNameFor = %q, want %q", got, want)
+		}
+	})
+
+	// The fallback keeps the one virtue the old argv-derived name had: it is
+	// unique per session, so new-window -S still collapses repeat picks of the
+	// same row onto one window.
+	t.Run("falls back per action kind", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "absent.jsonl")
+		if got, want := windowNameFor(missing, sessionID, "attach"), "attach-6773febd"; got != want {
+			t.Errorf("windowNameFor = %q, want %q", got, want)
+		}
+		if got, want := windowNameFor(missing, sessionID, "resume"), "resume-6773febd"; got != want {
+			t.Errorf("windowNameFor = %q, want %q", got, want)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

claude-queue が関与する tmux window の名前を、中身が分かる名前にする。

これまでの window 名は picker が渡す argv をそのまま連結した機械名で、内容の手掛かりが
無かった（実測: `claude---resume-6773febd-ce31-4e22-8354-5bc0d72c18a1` /
`claude-attach-84802ca8` / 手動起動の `claude`）。これを
`Docs-Lint-判断-6773febd` のような内容由来の名前にする。

- **`internal/label`（新規）**: transcript jsonl の**最後の** `{"type":"ai-title",...}` から
  `<タイトル 16 桁>-<session id 8 桁>` を組む。ai-title が無ければ最初の user prompt、
  それも無ければ空文字を返して呼び出し側のフォールバックに委ねる。整形は空白・`.`・`:`・`~` を
  `-` に置換し、連続を畳んで端を落とし、`runewidth.Truncate` で 16 桁に切る（日本語タイトルが
  多いので全角は 2 桁計算、UTF-8 はそのまま残す）。
- **`internal/multiplexer`**: `OpenSession` が argv から window 名を組むのをやめ、引数で受け取る。
  hook 用に `RenameWindow` / `SetAutomaticRename` / `WindowName` / `WindowPaneCount` を追加。
- **`internal/hook`**: `UserPromptSubmit` と `Stop` で、pane がある追跡中 session の window を
  改名する（手動起動の window も対象）。`SessionEnd` で automatic-rename を戻す。
- **`internal/picker`**: attach / resume の両経路で行の `transcript_path` から名前を解決し、
  取れなければ `attach-<id8>` / `resume-<id8>` に落ちる。

DB スキーマは変更していない。既存の resumable 行にも遡って効く。`~exited` の仕組みと
`new-window -S` による重複畳み込み、worktree 由来の tmux **session** 名の規約はそのまま。

## Why

- **ラベル源に ai-title を選んだ理由**: `claude agents --json` の roster 名は interactive では
  cwd basename + 2 桁 hex にしかならず session id 以上の情報が無く、実測 0.54s かかるため
  hook から毎イベント叩けない。ai-title は background session にも付く。roster は
  `internal/roster` の `List()` が reconcile の生存判定に使う権威なので触っていない。
- **最後の ai-title を採る**: 話題が変わると付け直されるため、現在の話題に追随させる。
  付け直しを跨ぐと `new-window -S` が旧名と一致せず window が 1 枚増えるが、その window の
  コマンドが終われば `~exited` へ改名されて解消するので許容する。
- **`Stop` にも張る**: 初回応答直後に ai-title が付くので、これが無いと 2 度目の prompt まで
  既定名のまま残る。
- **pane 単独ガード**: split して 2 session が並ぶと window 名を奪い合うため、pane が window
  唯一の pane のときだけ改名する。pane 数が読めなかった場合も改名しない。
- **`SessionEnd` で automatic-rename を戻す**: `rename-window` は tmux の自動リネームを恒久
  off にする（man tmux: "This flag is automatically disabled for an individual window when a
  name is specified at creation with new-window or new-session, or later with rename-window"）
  ため、戻さないと claude 終了後もシェル作業中ずっと古い名前が残る。自分が付けた名前と
  一致するときに限る。
- **末尾 256 KiB 優先の読み出し**: ai-title は毎ターン書き直される（実測で 1 session 内 1〜106 回）
  ので通常は末尾で当たる。transcript は MB 級になるため全読みは既定にしない。当たらなければ
  先頭から読み直す。
- **`bufio.Scanner` を使わない**: transcript には数 MB の tool_result 行が確実に含まれ、Scanner は
  最初の巨大行で scan 全体を止めてしまい、その後にある ai-title へ到達できない。

## Test

`make test` / `make vet`（`src/claude-queue`）。

- 整形は純関数の table test（日本語 / 空白 / `.` `:` `~` の置換 / 制御文字の除去 / 16 桁 /
  全角 2 桁 / 連続ハイフンの畳み込みと端の除去 / 1 行目のみ / 空入力）
- ai-title 抽出は生成した fixture jsonl で: 複数あれば最後が採られる / 無ければ user prompt /
  tool_result 配列と `<local-command-caveat>` はスキップ / どちらも無ければ空 /
  末尾 256 KiB より前にしか ai-title が無い場合も全読みで拾える / 1 MiB 超の行を跨いでも拾える /
  tail 読みで生じる先頭の欠けた行を無視する
- tmux は既存 `tmux_test.go` の流儀どおり引数列を assert（`rename-window` / `setw` /
  `display -p` / `list-panes`）。`sanitizeWindowName` が切り詰めないことも固定
- hook の改名ガードは pane 数・window 名を注入した recorder で単体化

`tmux display -p -t <pane-id> "#{window_name}"` と `tmux list-panes -t <pane-id>` が pane id を
その window に解決することは、稼働中の tmux server 上で実測して確認した。

## Refs

- 設計の節: `docs/design/claude-tmux-worktree.md`「window 名は transcript の ai-title 由来」
- merge 後、`bin/claude-queue` の再ビルドが必要（`bin/deploy.sh` を走らせた checkout 側で
  `make -C src/claude-queue install`）
