### PR TITLE
feat(claude-queue): picker の行に ai-title 列を足し、列順を並べ替える

### DIFF
--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -52,6 +52,32 @@ make install
 | `CLAUDE_QUEUE_ASCII=1` | アイコンを ASCII フォールバック `[!] [.] [*] [X] [~]` に切替 |
 | `CLAUDE_QUEUE_DEBUG=1` | エラーを `~/.claude/session-queue.log` に追記 |
 
+### picker の行
+
+行は tab 区切りで、fzf に見せるのは前半 5 列だけ（`--with-nth`）。
+
+| 列 | 中身 | 幅 |
+|---|---|---|
+| 1 | state アイコン | 可変（1〜2 桁） |
+| 2 | ai-title（transcript 由来） | 40 桁 padding + truncate |
+| 3 | worktree 名 | 56 桁 padding + truncate |
+| 4 | age | 可変（短い） |
+| 5 | summary（何で止まっているか） | padding なし。行末まで |
+| 6〜9 | session_id / tmux_pane / cwd / transcript_path | 非表示 |
+
+ai-title を worktree 名より前に置くのは、同じ repo に複数 session が並ぶと worktree 名は全部
+同じで summary も全部 `working` になり、「何の作業か」を言えるのが title だけになるため。
+padding と truncate は表示幅（全角 2 桁）で数える — 日本語タイトルが多数派なので、バイト数
+基準の `%-40s` では列が揃わない。popup は client 幅の 80%（実測 ~290 桁）あり、前半 3 列で
+100 桁弱しか使わないので、残りは summary が使う。
+
+ai-title は window 名と同じ transcript から取るが、**別関数**（`label.DisplayTitle`）で作る。
+window 名側の 16 桁切りと `-<id8>` 付与、`.` `:` `~` `#` の置換は tmux の `-t` target 構文と
+FORMATS 展開のための処理で、読むだけの行には要らない。ただし `\t` `\n` `\r` だけは title 側でも
+summary 側でも必ず潰す — 混ざると 6〜9 列目がずれ、picker が別 session の id / pane / cwd /
+transcript を掴む。tab を含む Bash コマンド（`awk -F'<tab>'`）は承認待ちで普通に出るので、
+これは机上の話ではない。
+
 ### picker の到達手段
 
 選択された session への到達手段を次の順で決める。
@@ -215,7 +241,9 @@ PR 作成時に description に貼って確認：
 - [ ] 拒否時は `PermissionDenied` で `⚙️1` に戻る
 - [ ] `C-q q` で popup、Enter で目的 pane にジャンプ、popup 自動閉
 - [ ] `claude --bg` で起動した background session（tmux_pane が NULL）を picker から選択、その worktree の tmux session に window が開いて `claude attach` される（popup を開いた session には増えない）
-- [ ] worktree のサブディレクトリで起動した session が、picker の 2 列目に worktree 名で並ぶ
+- [ ] worktree のサブディレクトリで起動した session が、picker の 3 列目に worktree 名で並ぶ
+- [ ] 同じ repo の複数 session が、picker の 2 列目の ai-title で見分けられる（title の無い row は空欄のまま 3 列目の開始位置が揃う）
+- [ ] tab を含む Bash コマンド（`awk -F'<tab>'`）の承認待ち row を picker から選ぶと、意図した session へ到達する（列がずれない）
 - [ ] `tmux_pane` が NULL の interactive session（他 pane の同 tmux server 上に存在するもの）を picker から選ぶと、`claude attach` ではなく再解決した pane へ直接 switch される
 - [ ] `tmux_pane` が「socket を別 server に明け渡した tmux server」の pane を指す interactive session を picker から選ぶと、SIGTERM 後に `claude --resume` で同じ session id のまま会話が復元される
 - [ ] 別 socket（`tmux -L other`）で稼働中の server 上の interactive session を picker から選ぶと、kill されず理由が出る

--- a/src/claude-queue/internal/label/label.go
+++ b/src/claude-queue/internal/label/label.go
@@ -65,6 +65,42 @@ func Resolve(transcriptPath, sessionID string) string {
 	return lbl
 }
 
+// DisplayTitle returns the conversation title for the picker's title column,
+// trimmed to cols terminal columns, or "" when the transcript offers none.
+//
+// Deliberately not Resolve: a window name has to survive tmux's -t target
+// syntax and its FORMATS expansion, which is why Resolve substitutes "." ":"
+// "~" "#" and spends its budget on a 16-column title plus a session id suffix.
+// An fzf row is read rather than handed to tmux, so none of that applies, and
+// all of it makes the title harder to read -- the suffix in particular repeats
+// a column the row already carries hidden.
+//
+// The one thing it must still strip is the column separators. The picker's
+// rows are tab-delimited and carry the session id, pane, cwd and transcript
+// path in hidden columns behind the visible ones, so a tab or a newline in a
+// title would shift those four and the pick would act on another session.
+func DisplayTitle(transcriptPath string, cols int) string {
+	return runewidth.Truncate(flatten(rawTitle(transcriptPath)), cols, "")
+}
+
+// flatten replaces the characters that would break a tab-delimited row with a
+// space, and drops the remaining control characters the way Sanitize does: a
+// control character is not a word boundary, so substituting one would invent a
+// space that was never in the title.
+func flatten(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r == '\t' || r == '\n' || r == '\r':
+			b.WriteByte(' ')
+		case unicode.IsControl(r):
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
 // shortID truncates a session id to the 8 chars every user-facing form of a
 // session id uses (it is also the only form `claude attach` takes).
 func shortID(sessionID string) string {

--- a/src/claude-queue/internal/label/label_test.go
+++ b/src/claude-queue/internal/label/label_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mattn/go-runewidth"
 )
 
 func TestSanitize(t *testing.T) {
@@ -302,4 +304,59 @@ func TestScanIgnoresAPartialFirstLine(t *testing.T) {
 	if prompt != "" {
 		t.Errorf("scan prompt = %q, want empty: a half line is not a prompt", prompt)
 	}
+}
+
+// DisplayTitle is the picker's title column, and the picker is the reason it
+// is not Resolve: the row is read rather than handed to tmux, so the target
+// syntax that Resolve exists to survive only gets in the way there.
+func TestDisplayTitle(t *testing.T) {
+	t.Run("keeps what a window name has to give up", func(t *testing.T) {
+		// A window name substitutes "." ":" "~" "#" and every space, and
+		// appends the session id; none of that helps someone reading a row.
+		path := writeTranscript(t, aiTitleLine("fix v1.2: picker ~ #cols"))
+		if got, want := DisplayTitle(path, 40), "fix v1.2: picker ~ #cols"; got != want {
+			t.Errorf("DisplayTitle = %q, want %q", got, want)
+		}
+		// The same title through Resolve, for contrast: this is what the
+		// column would have read if the window name had been reused.
+		if got := Resolve(path, sessionID); got == DisplayTitle(path, 40) {
+			t.Errorf("Resolve and DisplayTitle agree (%q): the window-name rules leaked into the row", got)
+		}
+	})
+
+	t.Run("cuts on terminal width, not runes", func(t *testing.T) {
+		// Japanese is the common case here and every rune of it is two
+		// columns, so a 20-character title is already a full 40-column cell.
+		path := writeTranscript(t, aiTitleLine(strings.Repeat("あ", 30)))
+		got := DisplayTitle(path, 40)
+		if w := runewidth.StringWidth(got); w != 40 {
+			t.Errorf("DisplayTitle is %d columns wide, want 40: %q", w, got)
+		}
+	})
+
+	t.Run("row separators cannot survive", func(t *testing.T) {
+		// The picker's hidden columns sit behind this one, so a tab or a
+		// newline in a title would shift the session id, pane, cwd and
+		// transcript path of that row and the pick would act on another
+		// session.
+		path := writeTranscript(t, aiTitleLine("col1\tcol2\rrest"))
+		got := DisplayTitle(path, 40)
+		if strings.ContainsAny(got, "\t\n\r") {
+			t.Errorf("DisplayTitle carries a row separator: %q", got)
+		}
+		if want := "col1 col2 rest"; got != want {
+			t.Errorf("DisplayTitle = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("nothing to title it with", func(t *testing.T) {
+		// "" is what leaves the column empty rather than padded with a name
+		// the transcript never offered.
+		if got := DisplayTitle(filepath.Join(t.TempDir(), "absent.jsonl"), 40); got != "" {
+			t.Errorf("DisplayTitle = %q, want empty", got)
+		}
+		if got := DisplayTitle("", 40); got != "" {
+			t.Errorf(`DisplayTitle("") = %q, want empty`, got)
+		}
+	})
 }

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -6,9 +6,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/mattn/go-runewidth"
 
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/label"
@@ -34,21 +37,64 @@ var ascii = map[string]string{
 	db.StateResumable:   "[~]",
 }
 
-// FormatLine renders one queue row as a tab-delimited line for fzf.
-// Visible columns (--with-nth=1,2,3,4): icon, worktree, summary, age.
-// The worktree name comes right after the icon so it starts at a fixed
-// position and stays scannable; the variable-width summary is demoted behind
-// it and left untruncated.
-// Hidden columns: session_id (5), tmux_pane (6), full cwd (7),
-// transcript_path (8). The full cwd is carried separately from the worktree
-// name because a background session is opened in a window that needs a real
-// working directory; the transcript path rides along because the resume path
-// must not run without confirming the conversation file is actually on disk.
+// Column positions in a rendered row, in the order FormatLine writes them.
+// The first five are shown (see fzfArgs); the last four ride along hidden
+// because the pick needs them and the eye does not.
 //
-// worktree is passed in rather than derived here: resolving it needs git (see
-// worktreeName), and keeping FormatLine pure is what lets the column contract
-// be asserted without a repository on disk.
-func FormatLine(row db.Row, worktree string, nowSec int64, asciiMode bool) string {
+// FormatLine writes these positions and parseSelection reads them back off the
+// line fzf returns, so the two have to agree: the hidden columns are addressed
+// by index, and an off-by-one there hands the pick another session's id, pane,
+// cwd or transcript path rather than failing.
+const (
+	colIcon = iota
+	colTitle
+	colWorktree
+	colAge
+	colSummary
+	colSessionID
+	colPane
+	colCwd
+	colTranscript
+	colCount
+)
+
+// The widths of the two padded columns, in terminal columns.
+//
+// The popup is 80% of the client width -- ~290 columns on the host these were
+// measured on -- and the old layout spent barely a third of that, so there is
+// room to make both scannable columns line up and still leave the summary the
+// rest of the row.
+//
+// 40 for the title because most titles here are Japanese, where 40 columns is
+// 20 characters: enough to recognise a conversation rather than merely tell two
+// apart. 56 for the worktree because the longest session name measured across
+// this host's live tmux sessions was 53, and a name that fits uncut is the
+// whole point of a fixed column.
+const (
+	titleWidth    = 40
+	worktreeWidth = 56
+)
+
+// FormatLine renders one queue row as a tab-delimited line for fzf.
+//
+// Visible columns: icon, ai-title, worktree, age, summary. The title and the
+// worktree are padded to fixed widths so both start at the same offset on
+// every row; the summary is last and unpadded so it can run to the end of the
+// row. Ordering them this way puts what a session is *about* (its title) ahead
+// of what it is *blocked on* (its summary), which is the distinction the old
+// layout lost: several sessions in one repo share a worktree name and all read
+// "working", and the title is the only column that tells them apart.
+//
+// Hidden columns: session_id, tmux_pane, full cwd, transcript_path. The full
+// cwd is carried separately from the worktree name because a background
+// session is opened in a window that needs a real working directory; the
+// transcript path rides along because the resume path must not run without
+// confirming the conversation file is actually on disk.
+//
+// title and worktree are passed in rather than derived here: one needs the
+// transcript off disk and the other needs git (see worktreeName), and keeping
+// FormatLine pure is what lets the column contract be asserted without either.
+func FormatLine(row db.Row, title, worktree string, nowSec int64, asciiMode bool) string {
 	icons := emoji
 	if asciiMode {
 		icons = ascii
@@ -69,10 +115,65 @@ func FormatLine(row db.Row, worktree string, nowSec int64, asciiMode bool) strin
 		pane = row.TmuxPane.String
 	}
 
-	return strings.Join([]string{
-		icon, worktree, sum, age,
-		row.SessionID, pane, rowCwd(row), rowTranscript(row),
-	}, "\t")
+	fields := make([]string, colCount)
+	fields[colIcon] = icon
+	// A row whose transcript could not be titled still pads its column, so the
+	// worktree beside it stays on the same offset as every other row.
+	fields[colTitle] = padWidth(title, titleWidth)
+	fields[colWorktree] = padWidth(worktree, worktreeWidth)
+	fields[colAge] = age
+	fields[colSummary] = sum
+	fields[colSessionID] = row.SessionID
+	fields[colPane] = pane
+	fields[colCwd] = rowCwd(row)
+	fields[colTranscript] = rowTranscript(row)
+	return strings.Join(fields, "\t")
+}
+
+// padWidth trims s to cols terminal columns and pads it back out to exactly
+// that many, so the column after it begins at the same offset on every row.
+//
+// Terminal width rather than bytes throughout: most titles here are Japanese,
+// where every rune is three bytes and two columns, so fmt's "%-40s" would
+// measure the wrong quantity twice over and leave the column ragged. The pad is
+// measured after the cut rather than computed from cols because Truncate stops
+// a column short rather than split a double-width rune in half.
+func padWidth(s string, cols int) string {
+	s = runewidth.Truncate(s, cols, "")
+	if pad := cols - runewidth.StringWidth(s); pad > 0 {
+		s += strings.Repeat(" ", pad)
+	}
+	return s
+}
+
+// selection is what a picked line is read for: the four hidden columns the
+// routing needs, with the padding the visible columns carry stripped off.
+type selection struct {
+	SessionID  string
+	Pane       string
+	Cwd        string
+	Transcript string
+}
+
+// parseSelection reads the hidden columns back off the line fzf printed, or
+// reports false when the line is not one FormatLine rendered.
+//
+// Split out of Run so the indices can be asserted against a line FormatLine
+// actually produced. They are positional and silent when wrong -- a shifted
+// index yields another row's session id and cwd, both of which look perfectly
+// valid to everything downstream -- so the round trip is the only thing that
+// can catch a column inserted ahead of them.
+func parseSelection(line string) (selection, bool) {
+	fields := strings.Split(line, "\t")
+	if len(fields) < colCount {
+		return selection{}, false
+	}
+	return selection{
+		SessionID:  strings.TrimSpace(fields[colSessionID]),
+		Pane:       strings.TrimSpace(fields[colPane]),
+		Cwd:        strings.TrimSpace(fields[colCwd]),
+		Transcript: strings.TrimSpace(fields[colTranscript]),
+	}, true
 }
 
 // rowCwd unwraps the nullable cwd column into the "" that the rest of the
@@ -480,7 +581,12 @@ func Run(args []string) {
 	asciiMode := os.Getenv("CLAUDE_QUEUE_ASCII") == "1"
 	names := worktreeCache{}
 	for _, r := range rows {
-		buf.WriteString(FormatLine(r, names.name(rowCwd(r)), now, asciiMode))
+		// The title is read here rather than inside FormatLine for the same
+		// reason the worktree name is -- it needs the filesystem. It costs one
+		// bounded tail read per row (see label's tailScanBytes), which the
+		// picker can afford: it is user-driven and lists a handful of rows.
+		title := label.DisplayTitle(rowTranscript(r), titleWidth)
+		buf.WriteString(FormatLine(r, title, names.name(rowCwd(r)), now, asciiMode))
 		buf.WriteByte('\n')
 	}
 
@@ -489,18 +595,15 @@ func Run(args []string) {
 		return
 	}
 
-	fields := strings.Split(selected, "\t")
-	if len(fields) < 8 {
+	sel, ok := parseSelection(selected)
+	if !ok {
 		return
 	}
-	sessionID := strings.TrimSpace(fields[4])
-	ledgerPane := strings.TrimSpace(fields[5])
-	cwd := strings.TrimSpace(fields[6])
-	transcript := strings.TrimSpace(fields[7])
+	sessionID, transcript := sel.SessionID, sel.Transcript
 
 	mux := multiplexer.Detect()
 
-	switch act := DecideAction(describeTarget(mux, sessionID, ledgerPane, cwd, transcript)); act.Kind {
+	switch act := DecideAction(describeTarget(mux, sessionID, sel.Pane, sel.Cwd, transcript)); act.Kind {
 	case "switch":
 		// A failed switch does not terminate the row. Every pane that reaches
 		// here was confirmed present in this server's pane table moments ago
@@ -603,14 +706,32 @@ func isDir(path string) bool {
 	return err == nil && fi.IsDir()
 }
 
-func runFzf(input string) (string, error) {
-	cmd := exec.Command("fzf",
+// fzfArgs is the fzf invocation, split out of runFzf so the visible-column
+// list can be asserted without running fzf.
+func fzfArgs() []string {
+	return []string{
 		"--delimiter=\t",
-		"--with-nth=1,2,3,4",
+		"--with-nth=" + visibleColumns(),
 		"--no-sort",
 		"--reverse",
 		"--height=100%",
-	)
+	}
+}
+
+// visibleColumns renders the 1-based positions --with-nth takes, derived from
+// the layout constants rather than written out. --with-nth addresses columns by
+// position, so a column inserted ahead of the hidden ones has to move it too;
+// deriving the list is what keeps that from being a separate thing to remember.
+func visibleColumns() string {
+	parts := make([]string, 0, colSummary+1)
+	for i := colIcon; i <= colSummary; i++ {
+		parts = append(parts, strconv.Itoa(i+1))
+	}
+	return strings.Join(parts, ",")
+}
+
+func runFzf(input string) (string, error) {
+	cmd := exec.Command("fzf", fzfArgs()...)
 	cmd.Stdin = strings.NewReader(input)
 	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -5,10 +5,14 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
+	"github.com/mattn/go-runewidth"
+
 	"github.com/knagiri/dotrc/src/claude-queue/internal/db"
+	"github.com/knagiri/dotrc/src/claude-queue/internal/label"
 	"github.com/knagiri/dotrc/src/claude-queue/internal/roster"
 )
 
@@ -25,36 +29,198 @@ func TestFormatLine_AwaitingApproval(t *testing.T) {
 		Payload:        sql.NullString{String: `{"tool_name":"Bash","tool_input":{"command":"pnpm prisma migrate"}}`, Valid: true},
 		CreatedAt:      nowMinus(120),
 	}
-	got := FormatLine(row, "everysteel-api", nowUnix(), false)
+	got := FormatLine(row, "prisma migration", "everysteel-api", nowUnix(), false)
 	fields := strings.Split(got, "\t")
-	if len(fields) != 8 {
-		t.Fatalf("want 8 tab-separated fields, got %d: %q", len(fields), got)
+	if len(fields) != colCount {
+		t.Fatalf("want %d tab-separated fields, got %d: %q", colCount, len(fields), got)
 	}
-	if fields[0] != "⏳" {
-		t.Errorf("icon = %q, want ⏳", fields[0])
+	if fields[colIcon] != "⏳" {
+		t.Errorf("icon = %q, want ⏳", fields[colIcon])
 	}
-	if fields[1] != "everysteel-api" {
-		t.Errorf("worktree = %q, want everysteel-api", fields[1])
+	// The title column is padded, so it is compared trimmed here; the padding
+	// itself is what TestFormatLine_ColumnWidths is about.
+	if got := strings.TrimSpace(fields[colTitle]); got != "prisma migration" {
+		t.Errorf("title = %q, want prisma migration", got)
 	}
-	if !strings.Contains(fields[2], "Bash: pnpm prisma migrate") {
-		t.Errorf("summary = %q", fields[2])
+	if got := strings.TrimSpace(fields[colWorktree]); got != "everysteel-api" {
+		t.Errorf("worktree = %q, want everysteel-api", got)
 	}
-	if fields[3] != "2m" {
-		t.Errorf("age = %q, want 2m", fields[3])
+	if fields[colAge] != "2m" {
+		t.Errorf("age = %q, want 2m", fields[colAge])
 	}
-	if fields[4] != "s1" {
-		t.Errorf("hidden session id = %q, want s1", fields[4])
+	if !strings.Contains(fields[colSummary], "Bash: pnpm prisma migrate") {
+		t.Errorf("summary = %q", fields[colSummary])
 	}
-	if fields[5] != "%1" {
-		t.Errorf("hidden tmux_pane = %q, want %%1", fields[5])
+	if fields[colSessionID] != "s1" {
+		t.Errorf("hidden session id = %q, want s1", fields[colSessionID])
 	}
-	if fields[6] != "/home/x/projects/everysteel-api" {
-		t.Errorf("hidden cwd = %q, want the full path", fields[6])
+	if fields[colPane] != "%1" {
+		t.Errorf("hidden tmux_pane = %q, want %%1", fields[colPane])
+	}
+	if fields[colCwd] != "/home/x/projects/everysteel-api" {
+		t.Errorf("hidden cwd = %q, want the full path", fields[colCwd])
 	}
 	// The resume path refuses to run without a transcript, so the path has to
 	// reach the pick through this hidden column.
-	if fields[7] != "/home/x/.claude/projects/enc/s1.jsonl" {
-		t.Errorf("hidden transcript_path = %q, want the full path", fields[7])
+	if fields[colTranscript] != "/home/x/.claude/projects/enc/s1.jsonl" {
+		t.Errorf("hidden transcript_path = %q, want the full path", fields[colTranscript])
+	}
+}
+
+// The column order itself, asserted once so a reshuffle has to come here
+// before it reaches the hidden columns: the summary moved behind the age and
+// the title was inserted in front of the worktree, which shifted every hidden
+// index by one.
+func TestFormatLine_ColumnOrder(t *testing.T) {
+	row := db.Row{
+		SessionID:      "sid",
+		TmuxPane:       sql.NullString{String: "%4", Valid: true},
+		Cwd:            sql.NullString{String: "/w/a", Valid: true},
+		TranscriptPath: sql.NullString{String: "/t/a.jsonl", Valid: true},
+		EffectiveState: "working",
+		CreatedAt:      nowMinus(60),
+	}
+	fields := strings.Split(FormatLine(row, "title", "wt", nowUnix(), true), "\t")
+	want := []string{"[*]", "title", "wt", "60s", "working", "sid", "%4", "/w/a", "/t/a.jsonl"}
+	if len(fields) != len(want) {
+		t.Fatalf("got %d columns, want %d", len(fields), len(want))
+	}
+	for i, w := range want {
+		if got := strings.TrimSpace(fields[i]); got != w {
+			t.Errorf("column %d = %q, want %q", i+1, got, w)
+		}
+	}
+}
+
+// The two padded columns exist so the eye can run down them, which only works
+// if every row spends the same number of terminal columns on each -- including
+// the rows that have nothing to put there.
+func TestFormatLine_ColumnWidths(t *testing.T) {
+	row := db.Row{SessionID: "s", EffectiveState: "working", CreatedAt: nowMinus(10)}
+
+	cases := []struct {
+		name            string
+		title, worktree string
+	}{{
+		name:  "ascii fits",
+		title: "picker title column", worktree: "dotrc_queue-picker-title-column",
+	}, {
+		// Japanese is the common case and every rune of it is two columns, so
+		// a byte-counting pad (fmt's "%-40s") would leave these rows short by
+		// roughly their own length again.
+		name:  "japanese counts double",
+		title: "picker の ai-title 列", worktree: "案件_日本語ワークツリー",
+	}, {
+		// Truncate stops a column short rather than split a double-width rune,
+		// so an over-long Japanese title needs the pad measured after the cut.
+		name:  "japanese overflows",
+		title: strings.Repeat("あ", 40), worktree: strings.Repeat("い", 40),
+	}, {
+		name:  "ascii overflows",
+		title: strings.Repeat("x", 80), worktree: strings.Repeat("y", 80),
+	}, {
+		// A transcript that could not be titled still holds the column open,
+		// or the worktree beside it would start in a different place.
+		name:  "empty title still holds its column",
+		title: "", worktree: "wt",
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fields := strings.Split(FormatLine(row, c.title, c.worktree, nowUnix(), true), "\t")
+			if w := runewidth.StringWidth(fields[colTitle]); w != titleWidth {
+				t.Errorf("title column is %d wide, want %d: %q", w, titleWidth, fields[colTitle])
+			}
+			if w := runewidth.StringWidth(fields[colWorktree]); w != worktreeWidth {
+				t.Errorf("worktree column is %d wide, want %d: %q", w, worktreeWidth, fields[colWorktree])
+			}
+		})
+	}
+}
+
+// A tab or a newline in a title would shift every hidden column of that row,
+// and the pick would then attach to another session or open a window in
+// another worktree's directory. label.DisplayTitle strips them at the source;
+// this is the picker's own end of that contract, since it is the one that
+// depends on it.
+func TestFormatLine_TitleCannotBreakTheRow(t *testing.T) {
+	row := db.Row{
+		SessionID:      "sid",
+		Cwd:            sql.NullString{String: "/w/a", Valid: true},
+		TranscriptPath: sql.NullString{String: "/t/a.jsonl", Valid: true},
+		EffectiveState: "working",
+		CreatedAt:      nowMinus(10),
+	}
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	line := `{"type":"ai-title","aiTitle":"col1\tcol2\rcol3"}` + "\n"
+	if err := os.WriteFile(path, []byte(line), 0600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	fields := strings.Split(FormatLine(row, label.DisplayTitle(path, titleWidth), "wt", nowUnix(), true), "\t")
+	if len(fields) != colCount {
+		t.Fatalf("a title with a tab in it produced %d columns, want %d", len(fields), colCount)
+	}
+	sel, ok := parseSelection(strings.Join(fields, "\t"))
+	if !ok || sel.SessionID != "sid" || sel.Cwd != "/w/a" {
+		t.Errorf("hidden columns shifted: %+v (ok=%v)", sel, ok)
+	}
+}
+
+// The hidden columns are addressed by index and every value in them looks
+// valid to the code downstream, so a shifted index does not fail -- it acts on
+// another session. The round trip through a line FormatLine actually rendered
+// is what catches that.
+func TestParseSelection(t *testing.T) {
+	row := db.Row{
+		SessionID:      testUUID,
+		TmuxPane:       sql.NullString{String: "%12", Valid: true},
+		Cwd:            sql.NullString{String: "/home/x/ghq/dotrc_wt", Valid: true},
+		TranscriptPath: sql.NullString{String: "/home/x/.claude/projects/enc/s.jsonl", Valid: true},
+		EffectiveState: "awaiting_approval",
+		Payload:        sql.NullString{String: `{"tool_name":"Bash","tool_input":{"command":"go test ./..."}}`, Valid: true},
+		CreatedAt:      nowMinus(30),
+	}
+	line := FormatLine(row, "ai タイトル", "dotrc_wt", nowUnix(), false)
+
+	sel, ok := parseSelection(line)
+	if !ok {
+		t.Fatalf("parseSelection rejected a line FormatLine rendered: %q", line)
+	}
+	want := selection{
+		SessionID:  testUUID,
+		Pane:       "%12",
+		Cwd:        "/home/x/ghq/dotrc_wt",
+		Transcript: "/home/x/.claude/projects/enc/s.jsonl",
+	}
+	if sel != want {
+		t.Errorf("parseSelection = %+v, want %+v", sel, want)
+	}
+
+	// fzf can return an empty selection, and a line from anywhere else is not
+	// one the hidden columns can be read off at all.
+	if _, ok := parseSelection(""); ok {
+		t.Error("parseSelection(\"\") reported success")
+	}
+	if _, ok := parseSelection("a\tb\tc"); ok {
+		t.Error("parseSelection accepted a short line")
+	}
+}
+
+// --with-nth addresses columns by 1-based position, so inserting a column
+// ahead of the hidden ones has to move it too. Getting this wrong does not
+// fail either -- it renders the session id and the full cwd as visible text.
+func TestFzfShowsExactlyTheVisibleColumns(t *testing.T) {
+	if got, want := visibleColumns(), "1,2,3,4,5"; got != want {
+		t.Errorf("visibleColumns = %q, want %q", got, want)
+	}
+	if !slices.Contains(fzfArgs(), "--with-nth=1,2,3,4,5") {
+		t.Errorf("fzfArgs = %v, want it to carry --with-nth=1,2,3,4,5", fzfArgs())
+	}
+	// The list has to stop before the first hidden column, whose contents are
+	// paths and ids no one wants in the popup.
+	if colSummary+1 != colSessionID {
+		t.Errorf("the visible run ends at column %d but the hidden ones start at %d", colSummary+1, colSessionID+1)
 	}
 }
 
@@ -62,12 +228,12 @@ func TestFormatLine_AwaitingApproval(t *testing.T) {
 // which is what resumeBlocked reads as "nothing to resume".
 func TestFormatLine_NoTranscript(t *testing.T) {
 	row := db.Row{SessionID: "s3", EffectiveState: "idle_done", CreatedAt: nowMinus(10)}
-	fields := strings.Split(FormatLine(row, "wt", nowUnix(), false), "\t")
-	if len(fields) != 8 {
-		t.Fatalf("want 8 fields, got %d", len(fields))
+	fields := strings.Split(FormatLine(row, "", "wt", nowUnix(), false), "\t")
+	if len(fields) != colCount {
+		t.Fatalf("want %d fields, got %d", colCount, len(fields))
 	}
-	if fields[7] != "" {
-		t.Errorf("hidden transcript_path = %q, want empty", fields[7])
+	if fields[colTranscript] != "" {
+		t.Errorf("hidden transcript_path = %q, want empty", fields[colTranscript])
 	}
 }
 
@@ -83,18 +249,18 @@ func TestFormatLine_DeepCwdShowsWorktree(t *testing.T) {
 		EffectiveState: "idle_done",
 		CreatedAt:      nowMinus(30),
 	}
-	fields := strings.Split(FormatLine(row, "dotrc_queue-picker", nowUnix(), false), "\t")
-	if fields[1] != "dotrc_queue-picker" {
-		t.Errorf("worktree = %q, want dotrc_queue-picker", fields[1])
+	fields := strings.Split(FormatLine(row, "", "dotrc_queue-picker", nowUnix(), false), "\t")
+	if got := strings.TrimSpace(fields[colWorktree]); got != "dotrc_queue-picker" {
+		t.Errorf("worktree = %q, want dotrc_queue-picker", got)
 	}
 	// The full cwd still rides along hidden: the attach path opens the window
 	// in the directory the session actually ran in.
-	if fields[6] != cwd {
-		t.Errorf("hidden cwd = %q, want %q", fields[6], cwd)
+	if fields[colCwd] != cwd {
+		t.Errorf("hidden cwd = %q, want %q", fields[colCwd], cwd)
 	}
 }
 
-// A resumable row is rendered from the same eight columns as a live one, but
+// A resumable row is rendered from the same nine columns as a live one, but
 // its state is not one any hook writes, so both icon maps and the summary have
 // to know it -- an unmapped state renders as an empty icon and a bare
 // "resumable", which is the failure this asserts against.
@@ -111,34 +277,34 @@ func TestFormatLine_Resumable(t *testing.T) {
 		CreatedAt:      nowMinus(7200),
 	}
 
-	fields := strings.Split(FormatLine(row, "dotrc_wt", nowUnix(), false), "\t")
-	if len(fields) != 8 {
-		t.Fatalf("want 8 fields, got %d", len(fields))
+	fields := strings.Split(FormatLine(row, "", "dotrc_wt", nowUnix(), false), "\t")
+	if len(fields) != colCount {
+		t.Fatalf("want %d fields, got %d", colCount, len(fields))
 	}
-	if fields[0] != emoji[db.StateResumable] || fields[0] == "" {
-		t.Errorf("emoji icon = %q, want %q", fields[0], emoji[db.StateResumable])
+	if fields[colIcon] != emoji[db.StateResumable] || fields[colIcon] == "" {
+		t.Errorf("emoji icon = %q, want %q", fields[colIcon], emoji[db.StateResumable])
 	}
-	if !strings.Contains(fields[2], "resumable") {
-		t.Errorf("summary = %q, want it to say the row is resumable", fields[2])
+	if !strings.Contains(fields[colSummary], "resumable") {
+		t.Errorf("summary = %q, want it to say the row is resumable", fields[colSummary])
 	}
 	// What the session was doing when it was cut off is the only thing telling
 	// these rows apart, so it has to survive into the summary.
-	if !strings.Contains(fields[2], "working") {
-		t.Errorf("summary = %q, want it to name the prior state", fields[2])
+	if !strings.Contains(fields[colSummary], "working") {
+		t.Errorf("summary = %q, want it to name the prior state", fields[colSummary])
 	}
-	if fields[3] != "2h" {
-		t.Errorf("age = %q, want 2h", fields[3])
+	if fields[colAge] != "2h" {
+		t.Errorf("age = %q, want 2h", fields[colAge])
 	}
 	// The resume path needs both of these off the picked line.
-	if fields[6] != "/home/x/ghq/dotrc_wt" || fields[7] != "/home/x/.claude/projects/enc/s9.jsonl" {
-		t.Errorf("hidden cwd/transcript = %q/%q", fields[6], fields[7])
+	if fields[colCwd] != "/home/x/ghq/dotrc_wt" || fields[colTranscript] != "/home/x/.claude/projects/enc/s9.jsonl" {
+		t.Errorf("hidden cwd/transcript = %q/%q", fields[colCwd], fields[colTranscript])
 	}
 
-	asciiIcon := strings.Split(FormatLine(row, "dotrc_wt", nowUnix(), true), "\t")[0]
+	asciiIcon := strings.Split(FormatLine(row, "", "dotrc_wt", nowUnix(), true), "\t")[colIcon]
 	if asciiIcon == "" {
 		t.Error("ascii icon is empty: CLAUDE_QUEUE_ASCII=1 would render the column blank")
 	}
-	if asciiIcon == fields[0] {
+	if asciiIcon == fields[colIcon] {
 		t.Errorf("ascii icon = %q, same as the emoji one", asciiIcon)
 	}
 }
@@ -225,16 +391,19 @@ func TestResumableRowRoutesToResume(t *testing.T) {
 		PriorState:     sql.NullString{String: "working", Valid: true},
 		CreatedAt:      nowMinus(60),
 	}
-	fields := strings.Split(FormatLine(row, "wt", nowUnix(), false), "\t")
+	sel, ok := parseSelection(FormatLine(row, "", "wt", nowUnix(), false))
+	if !ok {
+		t.Fatal("parseSelection rejected a line FormatLine rendered")
+	}
 	mux := &fakeMux{panes: map[string]bool{"%1": true}}
 
 	// The roster was read and does not list the session: the host it ran on went
 	// down, so there is no process to displace.
 	tgt := Target{
-		SessionID:        fields[4],
-		Pane:             reachablePane(mux, nil, fields[4], fields[5], true),
-		Cwd:              fields[6],
-		TranscriptPath:   fields[7],
+		SessionID:        sel.SessionID,
+		Pane:             reachablePane(mux, nil, sel.SessionID, sel.Pane, true),
+		Cwd:              sel.Cwd,
+		TranscriptPath:   sel.Transcript,
 		RosterOK:         true,
 		TranscriptExists: true,
 		CwdExists:        true,
@@ -274,14 +443,17 @@ func TestResumableRowCarriesNoPaneForTheRosterFallback(t *testing.T) {
 		RawState:       "ended",
 		CreatedAt:      nowMinus(60),
 	}
-	fields := strings.Split(FormatLine(row, "wt", nowUnix(), false), "\t")
-	if fields[5] != "" {
-		t.Fatalf("hidden tmux_pane = %q, want empty for a resumable row", fields[5])
+	sel, ok := parseSelection(FormatLine(row, "", "wt", nowUnix(), false))
+	if !ok {
+		t.Fatal("parseSelection rejected a line FormatLine rendered")
+	}
+	if sel.Pane != "" {
+		t.Fatalf("hidden tmux_pane = %q, want empty for a resumable row", sel.Pane)
 	}
 
 	// %0 and %1 exist on the rebooted server, belonging to unrelated sessions.
 	mux := &fakeMux{panes: map[string]bool{"%0": true, "%1": true}}
-	if got := reachablePane(mux, nil, fields[4], fields[5], false); got != "" {
+	if got := reachablePane(mux, nil, sel.SessionID, sel.Pane, false); got != "" {
 		t.Errorf("reachablePane with an unreadable roster = %q, want empty", got)
 	}
 }

--- a/src/claude-queue/internal/summary/summary.go
+++ b/src/claude-queue/internal/summary/summary.go
@@ -5,9 +5,20 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"unicode"
 
 	"github.com/mattn/go-runewidth"
 )
+
+// summaryWidth caps the two payload-derived summaries in terminal columns.
+//
+// The summary is rendered last and unpadded, so it has the rest of the popup
+// row to itself: the picker opens at 80% of the client width (~290 columns on
+// the host this was measured on) and the icon, title and worktree columns
+// ahead of it spend under 100 of those. The former 30 and 35 were sized for a
+// summary wedged between two variable-width columns, and kept the column from
+// using the room the new layout hands it.
+const summaryWidth = 150
 
 // Input is the minimal per-row data needed to render a summary.
 type Input struct {
@@ -18,7 +29,37 @@ type Input struct {
 }
 
 // Summarize returns the picker summary column for a queue row.
+//
+// The result never carries a tab, a newline or a carriage return. The picker's
+// rows are tab-delimited and hold the session id, pane, cwd and transcript
+// path in hidden columns behind the summary, so a separator smuggled in
+// through a payload shifts all four and the pick acts on another session's id
+// and working directory. Bash commands reach here verbatim and a literal tab
+// in one is ordinary (`awk -F'<tab>'`), so this is a live path rather than a
+// theoretical one. The guard sits on the way out so it covers every branch,
+// including the ones that pass a payload string through untouched.
 func Summarize(in Input) string {
+	return flatten(summarize(in))
+}
+
+// flatten replaces the row separators with a space and drops the remaining
+// control characters -- a control character is not a word boundary, so
+// substituting one would invent a space that was not in the payload.
+func flatten(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r == '\t' || r == '\n' || r == '\r':
+			b.WriteByte(' ')
+		case unicode.IsControl(r):
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func summarize(in Input) string {
 	switch in.EffectiveState {
 	case "awaiting_approval":
 		return summarizeApproval(in.Payload)
@@ -78,7 +119,11 @@ func toolInputSummary(tool string, raw json.RawMessage) string {
 	switch tool {
 	case "Bash":
 		if cmd, ok := obj["command"].(string); ok {
-			return TruncateWidth(strings.TrimSpace(cmd), 30)
+			// Flattened before the cut, not only by Summarize on the way out:
+			// runewidth gives a control character width 0, so a command full of
+			// tabs would spend none of the budget here and then widen past it
+			// once each tab became a space.
+			return TruncateWidth(flatten(cmd), summaryWidth)
 		}
 	case "Write", "Edit", "MultiEdit", "NotebookEdit":
 		if fp, ok := obj["file_path"].(string); ok {
@@ -106,7 +151,6 @@ func summarizeDone(payload string) string {
 	if err := json.Unmarshal([]byte(payload), &p); err != nil || p.Last == "" {
 		return "done"
 	}
-	flat := strings.ReplaceAll(p.Last, "\n", " ")
-	flat = strings.ReplaceAll(flat, "\r", " ")
-	return TruncateWidth(strings.TrimSpace(flat), 35)
+	// Flattened before the cut for the same reason as the Bash command above.
+	return TruncateWidth(flatten(p.Last), summaryWidth)
 }

--- a/src/claude-queue/internal/summary/summary_test.go
+++ b/src/claude-queue/internal/summary/summary_test.go
@@ -1,6 +1,11 @@
 package summary
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/mattn/go-runewidth"
+)
 
 func TestSummaryForAwaitingApproval_Bash(t *testing.T) {
 	got := Summarize(Input{
@@ -24,14 +29,19 @@ func TestSummaryForAwaitingApproval_Write(t *testing.T) {
 	}
 }
 
-func TestSummaryForIdleDone_TruncatesAt35(t *testing.T) {
-	long := "this is a very long assistant message that exceeds the limit by quite a bit really"
+func TestSummaryForIdleDone_TruncatesAtSummaryWidth(t *testing.T) {
+	long := strings.Repeat("assistant message that runs on and on ", 10)
 	got := Summarize(Input{
 		EffectiveState: "idle_done",
 		Payload:        `{"last_assistant_message":"` + long + `"}`,
 	})
-	if len(got) > 35 {
-		t.Errorf("summary longer than 35: %q (len=%d)", got, len(got))
+	if w := runewidth.StringWidth(got); w > summaryWidth {
+		t.Errorf("summary is %d columns wide, want at most %d: %q", w, summaryWidth, got)
+	}
+	// The point of raising the cap was that the column now has the rest of the
+	// row: a summary still cut at the old 35 would not be using it.
+	if w := runewidth.StringWidth(got); w < summaryWidth-2 {
+		t.Errorf("summary is only %d columns wide, want it to fill %d", w, summaryWidth)
 	}
 }
 
@@ -44,6 +54,41 @@ func TestSummaryForIdleDone_FlattensNewlines(t *testing.T) {
 		if r == '\n' {
 			t.Errorf("summary contains newline: %q", got)
 		}
+	}
+}
+
+// The picker's rows are tab-delimited and carry the session id, pane, cwd and
+// transcript path hidden behind the summary, so a tab reaching the column
+// shifts all four: the pick then attaches to another session, or opens a
+// window in another worktree's directory. A Bash command is the live path --
+// `awk -F'<tab>'` is ordinary in this repo -- and it reaches the summary
+// verbatim, which is why this asserts on a real awk invocation rather than on
+// a bare tab.
+func TestSummaryStripsTabs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Input
+	}{{
+		name: "bash command with a literal tab",
+		in: Input{
+			EffectiveState: "awaiting_approval",
+			Payload:        `{"tool_name":"Bash","tool_input":{"command":"awk -F'\t' '{print $2}' rows.tsv"}}`,
+		},
+	}, {
+		name: "assistant message with a literal tab",
+		in: Input{
+			EffectiveState: "idle_done",
+			Payload:        `{"last_assistant_message":"col1\tcol2"}`,
+		},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := Summarize(c.in)
+			if strings.ContainsAny(got, "\t\n\r") {
+				t.Errorf("summary carries a row separator: %q", got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

claude-queue の picker（`C-q q` の fzf 一覧）の可視列を
`icon / worktree / summary / age` から `icon / ai-title / worktree / age / summary` へ変える。
あわせて、列がずれる既存バグ（summary の tab 未除去）を塞ぐ。

**列レイアウト**

| 列 | 中身 | 幅 |
|---|---|---|
| 1 | state アイコン | 変更なし |
| 2 | ai-title（新規） | 40 桁 padding + truncate |
| 3 | worktree 名 | 56 桁 padding + truncate |
| 4 | age | 変更なし |
| 5 | summary | padding なし。行末まで |
| 6〜9 | session_id / tmux_pane / cwd / transcript_path（非表示） | 中身・順序そのまま。位置が 5〜8 から繰り下がり |

- padding / truncate は表示幅で計算する（日本語タイトルが多数派で全角は 2 桁。`fmt` の `%-40s` は
  バイト数基準なので崩れる）。ai-title が取れない行も padding だけ出して worktree 列の開始位置を保つ。
- 表示用タイトルは `label.DisplayTitle` として window 名用の `label.Resolve` とは別に用意した。
  16 桁切り・`-<id8>` 付与・`.` `:` `~` `#` の置換は tmux の `-t` target 構文と FORMATS 展開のための
  処理で、読むだけの行には不要。ただし `\t` `\n` `\r` は潰す。
- `--with-nth` は `colSummary` から導出する。位置指定なので列を前に挿すたびに動かす必要があり、
  忘れると session_id と cwd が popup に露出する。
- 隠し列の index 読み書きは `colIcon`..`colTranscript` の定数へ寄せ、`Run` の `strings.Split` は
  `parseSelection` として切り出した。ずれてもエラーにならず別 session の id / cwd を掴むだけなので、
  `FormatLine` が実際に描いた行との往復テストで固定している。

**あわせて直したバグ: summary の tab 未除去**

行は tab 区切りで summary の後ろに隠し列が続くのに、`internal/summary` は `\n` `\r` は潰していた
のに `\t` は素通ししていた。tab を含む Bash コマンド（この repo だと `awk -F'<tab>'` が普通に出る）が
承認待ちに入ると列がずれ、picker が別 session の id / pane / cwd / transcript を掴む。
除去は `Summarize` の出口に置いて全分岐を覆い、payload 由来の 2 経路では truncate の前にも潰す
（runewidth は制御文字を幅 0 と数えるので、tab だらけのコマンドは予算を使わないまま通過し、
空白へ変わった時点で予算を超えるため）。

summary の内部切り詰めは 30 / 35 桁から 150 桁へ引き上げた。列を行末へ移しても、この 2 つが
実際の上限として効いてしまうため。

## Why

直前の #67 で tmux window 名を transcript の ai-title 由来にしたが、picker の行は変えていなかった。
現状の 3 列目の summary は「いま何で止まっているか」であって「何の作業か」ではない。同じ repo に
複数 session が並ぶと worktree 名は全部同じ・summary は全部 `working` になり、行を見分けられなく
なる。それを言えるのは ai-title だけなので、列として足して worktree の前へ置いた。

幅の根拠は実測。popup は `dot/tmux.conf` の `display-popup -E -w 80%` で client 幅（実測 363 桁）の
80% ＝ 約 290 桁あるのに、旧レイアウトは tab stop 込みで 90〜110 桁しか使っていなかった。
worktree 名の実測最長は 53 桁（`tmux list-sessions` 全件）なので 56 桁に収まる。

## テスト

- 列契約: 列数・順序・各列の内容、および `--with-nth=1,2,3,4,5` が可視列と一致すること
- padding: 日本語（全角）・ascii・超過・空タイトルのそれぞれで表示幅が 40 / 56 になること
- `\t` `\n` `\r` の除去: `label.DisplayTitle` と `summary.Summarize` の両方
- 選択行の parse: `FormatLine` が描いた行から隠し列 4 つを往復で取り出せること
- tab 回帰テストは修正前の `internal/summary/summary.go`（`git show HEAD:...`）に掛けて 2 ケースとも
  落ちることを確認済み
- `make test` / `make vet` green

## 変更していないもの

- window 名の挙動（`label.Resolve` の 16 桁 + `-<id8>`、picker の `windowNameFor`、hook の rename 経路）
- DB スキーマ、隠し列の中身と順序、`dot/tmux.conf` の popup 幅（80%）

## Refs

- #67（`internal/label` を新設して window 名を ai-title 由来にした直前の PR）
- `src/claude-queue/README.md` に「picker の行」節を追加

## 注意

`bin/claude-queue` は symlink ではなくローカルビルドの成果物なので、merge / pull しただけでは
更新されない。`bin/deploy.sh` を走らせた checkout 側で `make -C src/claude-queue install` の
再実行が要る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
