### PR TITLE
fix(claude-queue): picker が開いた window を正常終了時に閉じて起動元 pane へ戻す

### DIFF
--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -212,22 +212,22 @@ resume が pane への switch と決定的に違うのは、**元プロセスを
 uuid を `--resume` に渡してもエラーにはならず、その id で空の新規 session が立ってしまうため、
 確認を欠いた resume は「成功したように見えて会話を失う」。
 
-picker が開いた window の終わり方は、コマンドの exit status で分ける。`claude attach` を意図して
-抜ける手段はどれも exit 0 で終わり（外からの `claude stop`、UI で `/exit` してから agent view を
-`Esc` で抜ける、`C-z`）、失敗系だけが非 0 になるので、exit status がこの 2 つを分ける唯一の
-信号になる。正常終了なら起動元 pane へ `switch-client` して window を閉じる — 残った window は
-ユーザーが手で閉じることになり、戻りたい先は元々作業していた pane だから。失敗したときだけ
-shell を残してエラーを読ませ、`-S` の照合名を握り続けないよう window を改名する。`bin/claude-worktree`
-の `--tmux` 経路も同じ「終わったら起動元 pane へ戻す」形で、picker はそれに揃えている。
+picker が開いた window の終わり方は、**コマンドの exit status で分ける**。`claude attach` を意図して
+抜ける手段はどれも exit 0 で終わり、失敗系だけが非 0 になるので、exit status がこの 2 つを分ける
+唯一の信号になる（内訳は README.md 側）。正常終了なら起動元 pane へ戻して window を閉じる — 残った
+window はユーザーが手で閉じることになり、戻りたい先は元々作業していた pane だから。失敗したときだけ
+pane を残してエラーを読ませる。`bin/claude-worktree` の `--tmux` 経路も終了時に起動元 pane へ戻すが、
+あちらは exit status で分岐せず無条件に戻す（interactive claude の異常終了を読ませる必要が無く、
+起動元が pane なので `$TMUX_PANE` をそのまま渡せる）。
 
-戻り先の pane は `PaneID()` とは別の `CurrentPane()` で取る。picker は `display-popup -E` の中で
-走り、popup は pane ではないので `TMUX_PANE` を継承しない（実測: popup 内では空）。そこで
-`tmux display-message -p "#{pane_id}"` へ落として client の現在 pane を訊く。`PaneID()` 側に
-fallback を足さないのは用途が違うため — あれは hook が「この claude プロセス自身の pane」を
-記録するのに使っており、fallback すると別プロセスの pane を記録してしまう。
+戻り先の pane を取るのに、pane の記録に使っている既存の経路を流用せず別のものを立てた。picker は
+`display-popup -E` の中で走り、popup は pane ではないので `TMUX_PANE` を継承しない（実測: popup 内では
+空）ため、環境変数だけでは足りず multiplexer へ問い合わせる必要がある。一方 hook 側が要るのは
+「この claude プロセス自身の pane」で、そこを問い合わせに落とすと別プロセスの pane を記録してしまう。
+同じ「pane を 1 つ返す」でも答えるべき問いが違うので、分けてある。
 
 flag レベルの詳細（`-d` の要否が経路で逆になる理由、`-t` の `=` 接頭辞・末尾 `:`・`-S` による window
-再利用、上の分岐をコマンドの単一引数 shell 文字列として組む形）は
+再利用、上の分岐をコマンドの単一引数 shell 文字列として組む形とその限界）は
 `internal/multiplexer/tmux.go` のコメントに一本化してあるので、そちらを参照
 （README.md は挙動レベルの説明に留め、flag レベルは書かない）。
 

--- a/docs/design/claude-tmux-worktree.md
+++ b/docs/design/claude-tmux-worktree.md
@@ -140,7 +140,8 @@ roster 名は使わない — interactive では cwd basename + 2 桁 hex にし
 最終形は `<ai-title を 16 桁に切ったもの>-<session id 8 桁>`。id 接尾辞を残すのは、同じ話題の
 window が複数ありうる一方で `new-window -S` の重複畳み込みは session 単位で効いてほしいため。
 採用するのは**最後の** ai-title で、話題が変わって付け直されると `-S` が旧名と一致せず window が
-1 枚増えるが、その window のコマンドが終われば `~exited` へ改名されて自然に解消するので許容する。
+1 枚増えるが、その window は中のコマンドが終われば閉じる（失敗して残る場合は `~exited` へ
+改名される）ので、名前を握り続けることはなく許容する。
 
 名前を張るのは (a) picker の attach / resume 経路（ai-title が取れなければ `attach-<id8>` /
 `resume-<id8>` へフォールバック）と、(b) hook の `UserPromptSubmit` / `Stop`。`Stop` も張るのは
@@ -211,9 +212,22 @@ resume が pane への switch と決定的に違うのは、**元プロセスを
 uuid を `--resume` に渡してもエラーにはならず、その id で空の新規 session が立ってしまうため、
 確認を欠いた resume は「成功したように見えて会話を失う」。
 
+picker が開いた window の終わり方は、コマンドの exit status で分ける。`claude attach` を意図して
+抜ける手段はどれも exit 0 で終わり（外からの `claude stop`、UI で `/exit` してから agent view を
+`Esc` で抜ける、`C-z`）、失敗系だけが非 0 になるので、exit status がこの 2 つを分ける唯一の
+信号になる。正常終了なら起動元 pane へ `switch-client` して window を閉じる — 残った window は
+ユーザーが手で閉じることになり、戻りたい先は元々作業していた pane だから。失敗したときだけ
+shell を残してエラーを読ませ、`-S` の照合名を握り続けないよう window を改名する。`bin/claude-worktree`
+の `--tmux` 経路も同じ「終わったら起動元 pane へ戻す」形で、picker はそれに揃えている。
+
+戻り先の pane は `PaneID()` とは別の `CurrentPane()` で取る。picker は `display-popup -E` の中で
+走り、popup は pane ではないので `TMUX_PANE` を継承しない（実測: popup 内では空）。そこで
+`tmux display-message -p "#{pane_id}"` へ落として client の現在 pane を訊く。`PaneID()` 側に
+fallback を足さないのは用途が違うため — あれは hook が「この claude プロセス自身の pane」を
+記録するのに使っており、fallback すると別プロセスの pane を記録してしまう。
+
 flag レベルの詳細（`-d` の要否が経路で逆になる理由、`-t` の `=` 接頭辞・末尾 `:`・`-S` による window
-再利用、pane を shell へ落とすためコマンドを単一引数の shell 文字列として渡すことと、その shell が
-`-S` の照合名を握り続けないよう終了時に window を改名すること）は
+再利用、上の分岐をコマンドの単一引数 shell 文字列として組む形）は
 `internal/multiplexer/tmux.go` のコメントに一本化してあるので、そちらを参照
 （README.md は挙動レベルの説明に留め、flag レベルは書かない）。
 

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -126,17 +126,24 @@ pane を持つ追跡中の session の window も hook（`UserPromptSubmit` / `S
 [docs/design/claude-tmux-worktree.md](../../docs/design/claude-tmux-worktree.md) を参照。
 
 window を開く attach / resume の経路では、`claude` をそのまま pane のプロセスにせず shell 経由で
-走らせ、終了後は shell へ置き換える。`claude attach` は `C-z` で「shell へ戻る」と言うが、戻る先の
-shell が無ければ pane ごと閉じ、その window しか持たない session は道連れに消える。shell を挟めば
-window も session も残る。起動が即座に失敗したときも、エラーが pane に残って読める
-（`tmux new-window` は中のコマンドの exit status を返さないので、window が閉じると失敗の理由ごと
-消えていた）。
+走らせ、コマンドの exit status で終わり方を分ける。`claude attach` を意図して抜ける手段は
+どれも exit 0 で終わり（外からの `claude stop`、UI で `/exit` してから agent view を `Esc` で
+抜ける、`C-z`）、失敗系だけが非 0 になるので、この 2 つを取り違えずに分けられる。
 
-コマンドが終わった window は shell に置き換わると同時に `<元の名前>~exited` へ改名する。同じ
-対象を選び直したときの window 再利用は名前の一致で決まるので、改名しないと「claude が居ない
-shell だけの window」が名前を握り続け、選び直しても `claude attach` が二度と走らなくなる。改名で
-名前を手放すことで、claude が走っている間の選び直しは同じ window に集約され、抜けたあとの
-選び直しは新しい window で起動し直す。
+- **正常終了（exit 0）**: 起動元 pane へ `switch-client` で戻り、pane が終了して window も閉じる。
+  その window しか持たない session も一緒に消えるが、client は既に起動元へ移っているので影響しない。
+  残った window はユーザーが手で閉じることになるので、閉じるのが既定
+- **失敗（非 0）**: shell へ置き換えて pane を残し、エラーを読ませる。`tmux new-window` は中の
+  コマンドの exit status を返さないので、window を閉じると失敗の理由ごと消える
+
+UI の中で `/exit` しても `claude attach` は終わらず、agent view（`claude agents` と同じ session
+一覧）へ戻る。そこから `Esc` で抜けると exit 0 で終了し、window が閉じて起動元 pane に戻る。
+これは claude 側の挙動で、こちらからは変えられない。
+
+失敗して残った window は `<元の名前>~exited` へ改名する。同じ対象を選び直したときの window
+再利用は名前の一致で決まるので、改名しないと「claude が居ない shell だけの window」が名前を
+握り続け、選び直しても `claude attach` が二度と走らなくなる。正常終了側で改名しないのは window が
+閉じて名前ごと消えるためで、`~exited` window が溜まるのもこれで避けられる。
 
 ### 終了済み session の掘り起こし（`--show-resumable`）
 

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -138,7 +138,9 @@ window を開く attach / resume の経路では、`claude` をそのまま pane
 
 UI の中で `/exit` しても `claude attach` は終わらず、agent view（`claude agents` と同じ session
 一覧）へ戻る。そこから `Esc` で抜けると exit 0 で終了し、window が閉じて起動元 pane に戻る。
-これは claude 側の挙動で、こちらからは変えられない。
+
+戻り先の pane が既に閉じていた場合は戻らず、window と（それしか持たない）session が消えるので
+client は端末へ detach される。
 
 失敗して残った window は `<元の名前>~exited` へ改名する。同じ対象を選び直したときの window
 再利用は名前の一致で決まるので、改名しないと「claude が居ない shell だけの window」が名前を

--- a/src/claude-queue/internal/multiplexer/multiplexer.go
+++ b/src/claude-queue/internal/multiplexer/multiplexer.go
@@ -9,8 +9,15 @@ import (
 // v0.1 implements tmux only; other implementations can be added without
 // touching hook / picker callers.
 type Multiplexer interface {
-	// PaneID returns a stable identifier for the current pane, or "".
+	// PaneID returns a stable identifier for the pane this process runs in, or
+	// "". Callers that want the pane the *client* is looking at want
+	// CurrentPane instead; this one must keep answering only about its own
+	// process, since that is what a hook records as the session's pane.
 	PaneID() string
+	// CurrentPane returns the pane the client currently has focused, or "".
+	// Unlike PaneID this may be answered by asking the multiplexer, so it works
+	// from a context that is not itself a pane -- which is the picker's case.
+	CurrentPane() string
 	// RefreshStatus asks the multiplexer to redraw its status bar.
 	RefreshStatus()
 	// Switch focuses the pane/target identified by the string returned
@@ -21,9 +28,10 @@ type Multiplexer interface {
 	// there. cwd is the window's working directory. window is the name to
 	// give that window, which callers derive from the session's content (see
 	// internal/label) -- the implementation only sanitizes it, it never
-	// invents one. Returns an error when there is no multiplexer to open a
-	// session in.
-	OpenSession(name, cwd, window string, argv []string) error
+	// invents one. originPane is the pane the client is returned to once argv
+	// finishes cleanly, from a prior CurrentPane() call; "" skips the return.
+	// Returns an error when there is no multiplexer to open a session in.
+	OpenSession(name, cwd, window, originPane string, argv []string) error
 	// RenameWindow renames the window holding pane. Used to keep a window's
 	// name following the conversation running in it, so it is best-effort:
 	// callers ignore the error rather than fail the operation they were in.
@@ -72,13 +80,14 @@ func Detect() Multiplexer {
 type noopImpl struct{}
 
 func (noopImpl) PaneID() string             { return "" }
+func (noopImpl) CurrentPane() string        { return "" }
 func (noopImpl) RefreshStatus()             {}
 func (noopImpl) Switch(target string) error { return nil }
 
 // OpenSession cannot succeed without a multiplexer, and callers need to know:
 // unlike Switch, there is no silent degradation that still gets the user to
 // their session. The error is what makes the caller print a manual fallback.
-func (noopImpl) OpenSession(name, cwd, window string, argv []string) error {
+func (noopImpl) OpenSession(name, cwd, window, originPane string, argv []string) error {
 	return errors.New("no multiplexer detected")
 }
 

--- a/src/claude-queue/internal/multiplexer/multiplexer_test.go
+++ b/src/claude-queue/internal/multiplexer/multiplexer_test.go
@@ -12,6 +12,13 @@ func TestDetect_TmuxEnv(t *testing.T) {
 	if got := m.PaneID(); got != "%42" {
 		t.Errorf("PaneID = %q, want %q", got, "%42")
 	}
+	// Inside a pane the two agree, and CurrentPane must take the env var rather
+	// than paying for a subprocess. Where they differ -- the picker's popup, with
+	// no TMUX_PANE to inherit -- there is no tmux server to ask in a unit test,
+	// so that branch is covered through currentPane's injected ask instead.
+	if got := m.CurrentPane(); got != "%42" {
+		t.Errorf("CurrentPane = %q, want %q", got, "%42")
+	}
 }
 
 func TestDetect_NoMultiplexer(t *testing.T) {
@@ -23,6 +30,9 @@ func TestDetect_NoMultiplexer(t *testing.T) {
 	if got := m.PaneID(); got != "" {
 		t.Errorf("PaneID = %q, want empty", got)
 	}
+	if got := m.CurrentPane(); got != "" {
+		t.Errorf("CurrentPane = %q, want empty", got)
+	}
 	// noop methods must not panic.
 	m.RefreshStatus()
 	if err := m.Switch("anything"); err != nil {
@@ -30,7 +40,7 @@ func TestDetect_NoMultiplexer(t *testing.T) {
 	}
 	// Unlike Switch, OpenSession must return an error: the picker's attach path
 	// relies on this to decide whether to print a manual-fallback hint.
-	if err := m.OpenSession("dotrc_wt", "/w/a", "some-window", []string{"claude", "attach", "abc"}); err == nil {
+	if err := m.OpenSession("dotrc_wt", "/w/a", "some-window", "%3", []string{"claude", "attach", "abc"}); err == nil {
 		t.Errorf("noop OpenSession err = nil, want non-nil")
 	}
 	// With no server there is no pane to confirm and no server pid to compare

--- a/src/claude-queue/internal/multiplexer/tmux.go
+++ b/src/claude-queue/internal/multiplexer/tmux.go
@@ -14,6 +14,52 @@ func (tmuxImpl) PaneID() string {
 	return os.Getenv("TMUX_PANE")
 }
 
+// CurrentPane answers "which pane is the client sitting in right now", which is
+// a different question from PaneID's "which pane is this process running in" --
+// and the difference is why this is a separate method rather than a fallback
+// added to PaneID. The hook uses PaneID to record its own claude process's pane;
+// falling back to display-message there would record whichever pane the client
+// happened to have current, i.e. another process's pane.
+//
+// The picker needs this one because it runs inside `display-popup -E`, where
+// TMUX_PANE is empty (observed against tmux 3.6b) -- the popup is not a pane, so
+// there is no pane id to inherit. Asking the server for the client's current
+// pane gets the real pane the popup was opened over, which is the pane the user
+// wants to be returned to.
+func (tmuxImpl) CurrentPane() string {
+	return currentPane(os.Getenv("TMUX_PANE"), displayMessagePane)
+}
+
+// currentPane is the env-then-ask decision, with the ask injected so both
+// branches are testable without a tmux server.
+//
+// The env var wins when set: inside a pane it is exactly the pane in question,
+// and it costs no subprocess. Empty means either "not a pane" (the popup case)
+// or "no tmux at all", and only the server can tell those apart -- so the ask is
+// allowed to fail, and its failure is the "" that makes windowCommand omit the
+// switch-client clause entirely.
+func currentPane(envPane string, ask func() (string, bool)) string {
+	if envPane != "" {
+		return envPane
+	}
+	if out, ok := ask(); ok {
+		return strings.TrimSpace(out)
+	}
+	return ""
+}
+
+func displayMessagePane() (string, bool) {
+	out, err := exec.Command("tmux", currentPaneArgs()...).Output()
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
+}
+
+func currentPaneArgs() []string {
+	return []string{"display-message", "-p", "#{pane_id}"}
+}
+
 func (tmuxImpl) RefreshStatus() {
 	_ = exec.Command("tmux", "refresh-client", "-S").Run()
 }
@@ -27,7 +73,11 @@ func (tmuxImpl) Switch(target string) error {
 // needs the session, not just the window: a background session belongs to a
 // worktree, and opening its window wherever the popup happened to be invoked
 // from would scatter unrelated worktrees across one session.
-func (tmuxImpl) OpenSession(name, cwd, window string, argv []string) error {
+//
+// originPane is where the client is sent back to once argv finishes cleanly;
+// see windowCommand. "" disables the return, which is what happens when there
+// is no client pane to name.
+func (tmuxImpl) OpenSession(name, cwd, window, originPane string, argv []string) error {
 	if name == "" {
 		return errors.New("no session name")
 	}
@@ -47,10 +97,10 @@ func (tmuxImpl) OpenSession(name, cwd, window string, argv []string) error {
 		// over that popup's terminal; switch-client below moves the client
 		// deliberately instead. This is why -d is right here and wrong for
 		// new-window, where it would leave the pick looking like a no-op.
-		if err := exec.Command("tmux", newSessionArgs(name, window, cwd, argv)...).Run(); err != nil {
+		if err := exec.Command("tmux", newSessionArgs(name, window, cwd, originPane, argv)...).Run(); err != nil {
 			return err
 		}
-	} else if err := exec.Command("tmux", newWindowArgs(name, window, cwd, argv)...).Run(); err != nil {
+	} else if err := exec.Command("tmux", newWindowArgs(name, window, cwd, originPane, argv)...).Run(); err != nil {
 		return err
 	}
 	return exec.Command("tmux", "switch-client", "-t="+name).Run()
@@ -66,12 +116,12 @@ func (tmuxImpl) OpenSession(name, cwd, window string, argv []string) error {
 // the same target (a second window would stack instead of -S selecting the
 // first one). Naming it here also disables tmux's automatic-rename for the
 // window, so the name -S depends on cannot drift later.
-func newSessionArgs(name, window, cwd string, argv []string) []string {
+func newSessionArgs(name, window, cwd, originPane string, argv []string) []string {
 	args := []string{"new-session", "-d", "-s", name, "-n", window}
 	if cwd != "" {
 		args = append(args, "-c", cwd)
 	}
-	return append(args, windowCommand(window, argv)...)
+	return append(args, windowCommand(window, originPane, argv)...)
 }
 
 // newWindowArgs builds the tmux argv for adding a window to an existing
@@ -82,50 +132,65 @@ func newSessionArgs(name, window, cwd string, argv []string) []string {
 // unused index -- naming an index instead would error out once it is taken.
 // -S selects an existing window of the same name rather than stacking another,
 // so picking the same session twice is idempotent.
-func newWindowArgs(name, window, cwd string, argv []string) []string {
+func newWindowArgs(name, window, cwd, originPane string, argv []string) []string {
 	args := []string{"new-window", "-S", "-n", window, "-t", "=" + name + ":"}
 	if cwd != "" {
 		args = append(args, "-c", cwd)
 	}
-	return append(args, windowCommand(window, argv)...)
+	return append(args, windowCommand(window, originPane, argv)...)
 }
 
-// exitedSuffix marks a window whose command has finished and which now holds
-// nothing but the fallback shell. sanitizeWindowName never emits "~", so a
-// renamed window can never collide with the name a later pick asks -S for --
-// which is the whole point of the rename, see windowCommand.
+// exitedSuffix marks a window whose command failed and which now holds nothing
+// but the fallback shell. sanitizeWindowName never emits "~", so a renamed
+// window can never collide with the name a later pick asks -S for -- which is
+// the whole point of the rename, see windowCommand.
 const exitedSuffix = "~exited"
 
 // windowCommand renders argv as the one trailing argument tmux runs in the new
-// window. Passing a single argument matters: tmux runs a lone argument through
-// a shell and execs a multi-argument one directly, and only the shell form can
-// keep the pane alive past the command.
+// window, wrapped so that a clean exit returns the client to originPane and a
+// failure leaves the window open to be read.
 //
-// Without it the pane's process is `claude attach` itself, so there is nothing
-// to fall back to. `claude attach --help` promises "Ctrl+Z drops back to your
-// shell", but Ctrl+Z ends the attach, which closes the pane, which closes the
-// window -- and a session the picker just created owns only that window, so the
-// whole session disappears with it. `exec`ing a shell afterwards gives Ctrl+Z
-// somewhere to land. It also makes a command that fails immediately readable:
-// `tmux new-window` does not surface the command's exit status, so before this
-// the error scrolled past with the closing window.
+// Passing a single argument is what makes the wrap possible at all: tmux runs a
+// lone argument through a shell and execs a multi-argument one directly, so only
+// the shell form can put anything after the command.
 //
-// The rename in between is what keeps that surviving window from swallowing the
+// The split is on argv's exit status, because for `claude attach` every way of
+// leaving on purpose exits 0 (observed: an outside `claude stop`, `/exit` then
+// Esc out of the agent view, and Ctrl+Z all exit 0), while the failures -- a
+// short id that matches no job, say -- do not. So:
+//
+//   - exit 0: switch-client moves the attached client back to the pane the
+//     picker was invoked from, and the shell string ends. The pane's process
+//     exits, so the window closes, and the session closes with it when that was
+//     its only window. The client is already elsewhere by then, which is what
+//     makes the vanishing session harmless. Returning the client is the point:
+//     a window left behind is one the user has to close by hand, and the pane
+//     they were working in is where they wanted to end up.
+//   - non-zero: exec a shell so the pane stays open with the error still on it.
+//     `tmux new-window` does not surface the command's exit status, so without
+//     this the reason scrolls past with the closing window.
+//
+// The rename before that exec keeps the surviving window from swallowing the
 // next pick. newWindowArgs' -S selects an existing window of the same name
-// *instead of* running the command, which was harmless while the window died
-// with the command: -S never found a stale one. Once the window outlives the
-// command, picking the same target again would land the user in the leftover
-// shell and never re-run `claude attach`. Renaming on the way out releases the
-// name, so -S still collapses repeat picks while claude is actually running
-// there, and a pick after it exited gets a fresh window. A tmux that cannot be
-// reached here just leaves the name in place; the ";" chain still reaches exec.
+// *instead of* running the command, so a failed window sitting under the name a
+// retry asks for would make the retry a no-op -- the user would land in the
+// leftover shell and claude would never re-run. Renaming releases the name, so
+// -S still collapses repeat picks while claude is actually running there. It is
+// only on the failure branch because the success branch closes the window, and
+// a closed window holds no name; that also stops "~exited" windows from piling
+// up. A tmux that cannot be reached here just leaves the name in place; the ";"
+// chain still reaches exec.
+//
+// An empty originPane omits the switch-client clause rather than emitting an
+// empty -t target, which tmux would reject. The pane still exits and the window
+// still closes; only the return is skipped.
 //
 // Empty argv yields no argument at all, which is how tmux is asked for the
 // default-command (an empty one, the default, starts default-shell as a login
 // shell). The wrapper below is not that: it execs $SHELL without -l, so the
 // fallback is interactive but not a login shell. Nothing here depends on the
 // difference -- the pane only has to stay open and read a shell's rc.
-func windowCommand(window string, argv []string) []string {
+func windowCommand(window, originPane string, argv []string) []string {
 	if len(argv) == 0 {
 		return nil
 	}
@@ -133,11 +198,23 @@ func windowCommand(window string, argv []string) []string {
 	for _, a := range argv {
 		quoted = append(quoted, shellQuote(a))
 	}
-	// -t "$TMUX_PANE" addresses the pane this command runs in, rather than
-	// whichever window the client happens to have current by then.
-	return []string{strings.Join(quoted, " ") +
-		`; tmux rename-window -t "$TMUX_PANE" ` + shellQuote(window+exitedSuffix) +
-		`; exec "${SHELL:-/bin/bash}"`}
+	// rc is captured immediately: every command after this point overwrites $?,
+	// including the `[` test itself.
+	//
+	// -t "$TMUX_PANE" on the rename addresses the pane this command runs in,
+	// rather than whichever window the client happens to have current by then.
+	// The switch-client target is the opposite -- a pane from outside this
+	// window -- so it is spliced in as a quoted literal.
+	cmd := strings.Join(quoted, " ") +
+		`; rc=$?; if [ "$rc" -ne 0 ]; then tmux rename-window -t "$TMUX_PANE" ` +
+		shellQuote(window+exitedSuffix) +
+		`; exec "${SHELL:-/bin/bash}"; fi`
+	if originPane != "" {
+		// 2>/dev/null: with no client attached, or an origin pane that has since
+		// closed, there is nothing to return and nothing to report either.
+		cmd += `; tmux switch-client -t ` + shellQuote(originPane) + ` 2>/dev/null`
+	}
+	return []string{cmd}
 }
 
 // shellQuote renders s as a single literal word for a POSIX shell. argv reaches

--- a/src/claude-queue/internal/multiplexer/tmux.go
+++ b/src/claude-queue/internal/multiplexer/tmux.go
@@ -77,6 +77,13 @@ func (tmuxImpl) Switch(target string) error {
 // originPane is where the client is sent back to once argv finishes cleanly;
 // see windowCommand. "" disables the return, which is what happens when there
 // is no client pane to name.
+//
+// The window's command starts running at new-window/new-session time, so an argv
+// that exits 0 immediately can close the window -- and a just-created session
+// with it -- before the switch-client below runs, making that switch fail and
+// the caller print a fallback hint for a session that did exactly what it was
+// asked. Reaching this needs a clean exit before a single tmux round trip, which
+// the commands the picker opens do not do.
 func (tmuxImpl) OpenSession(name, cwd, window, originPane string, argv []string) error {
 	if name == "" {
 		return errors.New("no session name")
@@ -181,9 +188,20 @@ const exitedSuffix = "~exited"
 // up. A tmux that cannot be reached here just leaves the name in place; the ";"
 // chain still reaches exec.
 //
-// An empty originPane omits the switch-client clause rather than emitting an
-// empty -t target, which tmux would reject. The pane still exits and the window
-// still closes; only the return is skipped.
+// An empty originPane omits the switch-client clause. Not because tmux would
+// reject an empty -t: it resolves one to the *current* target (confirmed against
+// tmux 3.6b -- `list-windows -t ""` lists the current window and exits 0), which
+// here would be the window that is about to close, so the clause would be a
+// meaningless self-switch. There is nothing to return to in this case; the pane
+// still exits and the window still closes, only the return is skipped.
+//
+// Two limits of splicing the pane into the command string, neither of which the
+// switch itself can fix. A window reused by -S keeps the origin pane of the pick
+// that created it, so a later pick from a different pane still returns to the
+// first one. And if the origin pane has closed by the time the command exits,
+// the switch is a no-op and the client is left with no session to be in -- the
+// picker's single-window session goes with the pane, so the client detaches back
+// to the terminal. Both are better than the alternative of not returning at all.
 //
 // Empty argv yields no argument at all, which is how tmux is asked for the
 // default-command (an empty one, the default, starts default-shell as a login
@@ -210,8 +228,15 @@ func windowCommand(window, originPane string, argv []string) []string {
 		shellQuote(window+exitedSuffix) +
 		`; exec "${SHELL:-/bin/bash}"; fi`
 	if originPane != "" {
-		// 2>/dev/null: with no client attached, or an origin pane that has since
-		// closed, there is nothing to return and nothing to report either.
+		// 2>/dev/null: a pane that has since closed, or no client at all, leaves
+		// nothing to return and nothing worth reporting into a closing pane.
+		//
+		// No -c, so tmux picks the client itself. With none attached that is the
+		// no-op above, but tmux falls back to the last active client rather than
+		// only considering ones on this session, so a client that has since moved
+		// elsewhere can be the one pulled back here. claude-worktree's --tmux
+		// wrapper has always had this shape; naming the client would mean
+		// capturing it at pick time.
 		cmd += `; tmux switch-client -t ` + shellQuote(originPane) + ` 2>/dev/null`
 	}
 	return []string{cmd}

--- a/src/claude-queue/internal/multiplexer/tmux_test.go
+++ b/src/claude-queue/internal/multiplexer/tmux_test.go
@@ -305,9 +305,10 @@ func TestWindowCommandBranchesOnExitStatus(t *testing.T) {
 }
 
 // TestWindowCommandWithoutOriginPane covers the case where the picker could not
-// name a pane to go back to. The clause is omitted rather than emitted with an
-// empty target, which tmux rejects -- and a broken trailing command would be
-// run on exactly the path that is supposed to be the clean one.
+// name a pane to go back to. tmux would not reject an empty -t -- it resolves
+// one to the current target, which here is the window about to close -- so the
+// clause has to be left out rather than emitted empty, or the clean path would
+// end in a self-switch that means nothing.
 func TestWindowCommandWithoutOriginPane(t *testing.T) {
 	got := windowCommand("claude-attach-abc", "", []string{"claude", "attach", "abc"})
 	if len(got) != 1 {

--- a/src/claude-queue/internal/multiplexer/tmux_test.go
+++ b/src/claude-queue/internal/multiplexer/tmux_test.go
@@ -8,10 +8,14 @@ import (
 	"github.com/knagiri/dotrc/src/claude-queue/internal/label"
 )
 
-// wantCommand is what `claude attach abc` must reach tmux as: one shell
-// command, so the pane survives the command and drops back to a shell, having
-// first released the window name that -S dedupes on.
-const wantCommand = `'claude' 'attach' 'abc'; tmux rename-window -t "$TMUX_PANE" 'claude-attach-abc~exited'; exec "${SHELL:-/bin/bash}"`
+// originPane stands in for the pane the picker was invoked from, in the shape
+// tmux reports pane ids ("%" plus an index).
+const originPane = "%3"
+
+// wantCommand is what `claude attach abc` must reach tmux as: one shell command
+// that returns the client to the origin pane when the command exits cleanly, and
+// only on failure keeps the pane alive under a released window name.
+const wantCommand = `'claude' 'attach' 'abc'; rc=$?; if [ "$rc" -ne 0 ]; then tmux rename-window -t "$TMUX_PANE" 'claude-attach-abc~exited'; exec "${SHELL:-/bin/bash}"; fi; tmux switch-client -t '%3' 2>/dev/null`
 
 // The argv builders are exercised instead of OpenSession itself so the contract
 // is checked without starting a real tmux server.
@@ -53,7 +57,7 @@ func TestNewSessionArgs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := newSessionArgs(tt.sess, tt.window, tt.cwd, tt.argv)
+			got := newSessionArgs(tt.sess, tt.window, tt.cwd, originPane, tt.argv)
 			if !slices.Equal(got, tt.want) {
 				t.Errorf("newSessionArgs(%q, %q, %q, %v) = %v, want %v", tt.sess, tt.window, tt.cwd, tt.argv, got, tt.want)
 			}
@@ -77,8 +81,8 @@ func TestNewSessionArgsWindowNameMatchesNewWindow(t *testing.T) {
 	argv := []string{"claude", "attach", "abc"}
 	window := "claude-attach-abc"
 
-	sessionArgs := newSessionArgs("dotrc_wt", window, "/w/a", argv)
-	windowArgs := newWindowArgs("dotrc_wt", window, "/w/a", argv)
+	sessionArgs := newSessionArgs("dotrc_wt", window, "/w/a", originPane, argv)
+	windowArgs := newWindowArgs("dotrc_wt", window, "/w/a", originPane, argv)
 
 	sessionWindowName := sessionArgs[slices.Index(sessionArgs, "-n")+1]
 	targetWindowName := windowArgs[slices.Index(windowArgs, "-n")+1]
@@ -132,7 +136,7 @@ func TestNewWindowArgs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := newWindowArgs(tt.sess, tt.window, tt.cwd, tt.argv)
+			got := newWindowArgs(tt.sess, tt.window, tt.cwd, originPane, tt.argv)
 			if !slices.Equal(got, tt.want) {
 				t.Errorf("newWindowArgs(...) = %v, want %v", got, tt.want)
 			}
@@ -196,6 +200,16 @@ func TestShellQuote(t *testing.T) {
 			want: "'a\nb'",
 		},
 		{
+			// The origin pane reaches windowCommand as a switch-client target.
+			// "%" is inert inside single quotes, but the quoting still has to be
+			// there: an unquoted target would be at the mercy of whatever else
+			// the value carried, and the value comes from tmux rather than from
+			// this package.
+			name: "a pane id stays one word",
+			in:   "%3",
+			want: `'%3'`,
+		},
+		{
 			name: "empty stays a word",
 			in:   "",
 			want: `''`,
@@ -211,11 +225,11 @@ func TestShellQuote(t *testing.T) {
 }
 
 func TestWindowCommand(t *testing.T) {
-	t.Run("one argument, ending in an exec of the shell", func(t *testing.T) {
-		got := windowCommand("claude-attach-abc", []string{"claude", "attach", "abc"})
+	t.Run("one argument carrying both branches", func(t *testing.T) {
+		got := windowCommand("claude-attach-abc", originPane, []string{"claude", "attach", "abc"})
 		// A single argument is what makes tmux run the string through a
-		// shell; more than one would be exec'd directly and the exec tail
-		// would be read as a literal argument to claude.
+		// shell; more than one would be exec'd directly and the tail would
+		// be read as literal arguments to claude.
 		if len(got) != 1 {
 			t.Fatalf("windowCommand(...) = %v, want exactly one argument", got)
 		}
@@ -225,27 +239,101 @@ func TestWindowCommand(t *testing.T) {
 	})
 
 	t.Run("every element is quoted", func(t *testing.T) {
-		got := windowCommand("w", []string{"claude", "--resume", "a b'c"})
-		want := `'claude' '--resume' 'a b'\''c'; tmux rename-window -t "$TMUX_PANE" 'w~exited'; exec "${SHELL:-/bin/bash}"`
+		got := windowCommand("w", "%7", []string{"claude", "--resume", "a b'c"})
+		want := `'claude' '--resume' 'a b'\''c'; rc=$?; if [ "$rc" -ne 0 ]; then tmux rename-window -t "$TMUX_PANE" 'w~exited'; exec "${SHELL:-/bin/bash}"; fi; tmux switch-client -t '%7' 2>/dev/null`
 		if len(got) != 1 || got[0] != want {
 			t.Errorf("windowCommand(...) = %v, want [%q]", got, want)
 		}
 	})
 
 	t.Run("empty argv yields no argument", func(t *testing.T) {
-		if got := windowCommand("cmd", nil); len(got) != 0 {
-			t.Errorf("windowCommand(%q, nil) = %v, want no argument so tmux starts its default shell", "cmd", got)
+		if got := windowCommand("cmd", originPane, nil); len(got) != 0 {
+			t.Errorf("windowCommand(%q, %q, nil) = %v, want no argument so tmux starts its default shell", "cmd", originPane, got)
 		}
 	})
 }
 
+// TestWindowCommandBranchesOnExitStatus pins the split this change is about.
+// Every deliberate way of leaving `claude attach` exits 0, so exit status is
+// what separates "the user is done here" from "this never started".
+//
+//   - clean: the client goes back to the origin pane and the shell string ends,
+//     so the pane exits and the window closes with it. This is the requirement --
+//     a window left open is one the user has to close by hand.
+//   - failed: the pane is kept by an exec'd shell so the error stays readable,
+//     under a released window name so a retry is not swallowed by -S.
+func TestWindowCommandBranchesOnExitStatus(t *testing.T) {
+	const window = "claude-attach-abc"
+	got := windowCommand(window, originPane, []string{"claude", "attach", "abc"})
+	if len(got) != 1 {
+		t.Fatalf("windowCommand(...) = %v, want exactly one argument", got)
+	}
+	cmd := got[0]
+
+	// The status has to be captured before anything else can overwrite $?, the
+	// `[` test included.
+	wantCapture := `; rc=$?; if [ "$rc" -ne 0 ]; then `
+	if !strings.Contains(cmd, wantCapture) {
+		t.Errorf("command = %q, must capture the exit status and branch on it via %q", cmd, wantCapture)
+	}
+
+	// The keep-alive belongs to the failure branch only. Were it unconditional
+	// -- as it was before this change -- the clean exit would leave a stranded
+	// window behind and never reach switch-client.
+	execAt := strings.Index(cmd, `exec "${SHELL:-/bin/bash}"`)
+	if execAt < 0 {
+		t.Fatalf("command = %q, must exec a fallback shell so a failure stays readable", cmd)
+	}
+	fiAt := strings.Index(cmd, "; fi")
+	if fiAt < 0 {
+		t.Fatalf("command = %q, must close the failure branch with fi", cmd)
+	}
+	if execAt > fiAt {
+		t.Errorf("command = %q, execs the fallback shell outside the failure branch; a clean exit would keep the window open", cmd)
+	}
+
+	// switch-client is the last thing in the string, and outside the branch: it
+	// is only reached when the command exited 0, because the failure branch
+	// execs and never returns.
+	wantSwitch := `tmux switch-client -t ` + shellQuote(originPane) + ` 2>/dev/null`
+	if !strings.HasSuffix(cmd, wantSwitch) {
+		t.Errorf("command = %q, must end with %q so a clean exit returns the client to the origin pane", cmd, wantSwitch)
+	}
+	if strings.Index(cmd, wantSwitch) < fiAt {
+		t.Errorf("command = %q, returns the client inside the failure branch, where the exec would have consumed the process first", cmd)
+	}
+}
+
+// TestWindowCommandWithoutOriginPane covers the case where the picker could not
+// name a pane to go back to. The clause is omitted rather than emitted with an
+// empty target, which tmux rejects -- and a broken trailing command would be
+// run on exactly the path that is supposed to be the clean one.
+func TestWindowCommandWithoutOriginPane(t *testing.T) {
+	got := windowCommand("claude-attach-abc", "", []string{"claude", "attach", "abc"})
+	if len(got) != 1 {
+		t.Fatalf("windowCommand(...) = %v, want exactly one argument", got)
+	}
+	cmd := got[0]
+	if strings.Contains(cmd, "switch-client") {
+		t.Errorf("command = %q, must not switch-client with no origin pane to name", cmd)
+	}
+	if !strings.HasSuffix(cmd, "; fi") {
+		t.Errorf("command = %q, want it to end at the closed failure branch", cmd)
+	}
+	// The failure branch is unaffected by the missing pane: an error still has
+	// to be readable, and the name still has to be released.
+	if !strings.Contains(cmd, shellQuote("claude-attach-abc"+exitedSuffix)) {
+		t.Errorf("command = %q, must still release the window name on failure", cmd)
+	}
+}
+
 // TestWindowCommandReleasesTheDedupeName pins the repair for the regression the
-// shell wrap would otherwise introduce. -S selects an existing window of the
-// same name *instead of* running the command, so once the window outlives the
-// command, a second pick of the same target would drop the user into the
-// leftover shell and never re-run claude. The command therefore has to rename
-// the window out of the way before it execs the shell, and the name it releases
-// must be exactly the one -S looks for.
+// keep-alive shell would otherwise introduce. -S selects an existing window of
+// the same name *instead of* running the command, so a failed window sitting
+// under that name would make a retry drop the user into the leftover shell and
+// never re-run claude. The command therefore has to rename the window out of the
+// way before it execs the shell, and the name it releases must be exactly the
+// one -S looks for.
 func TestWindowCommandReleasesTheDedupeName(t *testing.T) {
 	argv := []string{"claude", "attach", "abc"}
 	window := "claude-attach-abc"
@@ -254,8 +342,8 @@ func TestWindowCommandReleasesTheDedupeName(t *testing.T) {
 		name string
 		args []string
 	}{
-		{"new-session", newSessionArgs("dotrc_wt", window, "/w/a", argv)},
-		{"new-window", newWindowArgs("dotrc_wt", window, "/w/a", argv)},
+		{"new-session", newSessionArgs("dotrc_wt", window, "/w/a", originPane, argv)},
+		{"new-window", newWindowArgs("dotrc_wt", window, "/w/a", originPane, argv)},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			named := tt.args[slices.Index(tt.args, "-n")+1]
@@ -290,7 +378,7 @@ func TestWindowCommandReleasesTheDedupeName(t *testing.T) {
 func TestWindowCommandUsesTheGivenName(t *testing.T) {
 	const window = "AWS-ログ調査-6773febd"
 
-	got := windowCommand(window, []string{"claude", "attach", "abc"})
+	got := windowCommand(window, originPane, []string{"claude", "attach", "abc"})
 	if len(got) != 1 {
 		t.Fatalf("windowCommand(...) = %v, want exactly one argument", got)
 	}
@@ -298,7 +386,7 @@ func TestWindowCommandUsesTheGivenName(t *testing.T) {
 		t.Errorf("windowCommand(...) = %q, must release exactly %q", got[0], window+exitedSuffix)
 	}
 	// The caller's name is what -n installs, unchanged.
-	args := newWindowArgs("dotrc_wt", window, "/w/a", []string{"claude", "attach", "abc"})
+	args := newWindowArgs("dotrc_wt", window, "/w/a", originPane, []string{"claude", "attach", "abc"})
 	if named := args[slices.Index(args, "-n")+1]; named != window {
 		t.Errorf("newWindowArgs named the window %q, want the caller's %q", named, window)
 	}
@@ -547,6 +635,13 @@ func TestWindowNamingArgs(t *testing.T) {
 		[]string{"setw", "-t", "%5", "automatic-rename", "off"}; !slices.Equal(got, want) {
 		t.Errorf("automaticRenameArgs(off) = %v, want %v", got, want)
 	}
+	// The picker asks for the client's current pane in the one place TMUX_PANE
+	// is empty, so the format has to be the pane id and nothing else -- the
+	// output is trimmed and spliced straight into a switch-client target.
+	if got, want := currentPaneArgs(),
+		[]string{"display-message", "-p", "#{pane_id}"}; !slices.Equal(got, want) {
+		t.Errorf("currentPaneArgs = %v, want %v", got, want)
+	}
 	if got, want := windowNameArgs("%5"),
 		[]string{"display", "-p", "-t", "%5", "#{window_name}"}; !slices.Equal(got, want) {
 		t.Errorf("windowNameArgs = %v, want %v", got, want)
@@ -557,6 +652,42 @@ func TestWindowNamingArgs(t *testing.T) {
 		[]string{"list-panes", "-t", "%5", "-F", "#{pane_id}"}; !slices.Equal(got, want) {
 		t.Errorf("windowPanesArgs = %v, want %v", got, want)
 	}
+}
+
+// currentPane is exercised through its injected ask so both branches are
+// covered without a tmux server. The fallback exists for one situation: the
+// picker runs inside `display-popup -E`, where TMUX_PANE is empty because the
+// popup is not a pane, and only the server knows which pane the client is on.
+func TestCurrentPane(t *testing.T) {
+	never := func() (string, bool) {
+		t.Helper()
+		t.Error("currentPane asked tmux even though TMUX_PANE was set")
+		return "", false
+	}
+
+	t.Run("the env var wins when set", func(t *testing.T) {
+		if got := currentPane("%12", never); got != "%12" {
+			t.Errorf("currentPane = %q, want %q", got, "%12")
+		}
+	})
+
+	t.Run("an empty env var falls back to asking tmux", func(t *testing.T) {
+		// display-message ends its output with a newline, which has to come off
+		// before the value becomes a switch-client target.
+		ask := func() (string, bool) { return "%7\n", true }
+		if got := currentPane("", ask); got != "%7" {
+			t.Errorf("currentPane = %q, want %q", got, "%7")
+		}
+	})
+
+	t.Run("no pane at all is empty, not an error", func(t *testing.T) {
+		// Outside tmux there is no pane and no server. "" is the answer
+		// windowCommand reads as "omit the return", so this must not invent one.
+		ask := func() (string, bool) { return "", false }
+		if got := currentPane("", ask); got != "" {
+			t.Errorf("currentPane = %q, want empty", got)
+		}
+	})
 }
 
 func TestCountLines(t *testing.T) {

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -603,6 +603,14 @@ func Run(args []string) {
 
 	mux := multiplexer.Detect()
 
+	// Read the origin pane before anything below can move the client: the
+	// window openers below end with a switch-client of their own, and a pane
+	// read after that would name the window we just opened instead of the pane
+	// the user came from. Reading it here also keeps it out of the popup's own
+	// lifetime question -- the value is captured while the popup is still up,
+	// and only spliced into a command that runs after it is gone.
+	originPane := mux.CurrentPane()
+
 	switch act := DecideAction(describeTarget(mux, sessionID, sel.Pane, sel.Cwd, transcript)); act.Kind {
 	case "switch":
 		// A failed switch does not terminate the row. Every pane that reaches
@@ -624,7 +632,7 @@ func Run(args []string) {
 		// Do NOT terminate the session on failure the way the pane path does:
 		// a failed window open says nothing about whether the session is alive,
 		// and the manual command still works.
-		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, windowNameFor(transcript, sessionID, "attach"), []string{"claude", "attach", act.Short}); err != nil {
+		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, windowNameFor(transcript, sessionID, "attach"), originPane, []string{"claude", "attach", act.Short}); err != nil {
 			fmt.Fprintf(os.Stderr, "open session failed: %v\nrun: claude attach %s\n", err, act.Short)
 		}
 	case "resume":
@@ -638,7 +646,7 @@ func Run(args []string) {
 				return
 			}
 		}
-		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, windowNameFor(transcript, sessionID, "resume"), []string{"claude", "--resume", act.Resume}); err != nil {
+		if err := mux.OpenSession(names.name(act.Cwd), act.Cwd, windowNameFor(transcript, sessionID, "resume"), originPane, []string{"claude", "--resume", act.Resume}); err != nil {
 			fmt.Fprintf(os.Stderr, "open session failed: %v\nrun: cd %s && claude --resume %s\n", err, act.Cwd, act.Resume)
 		}
 	default:

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -736,10 +736,12 @@ type fakeMux struct {
 	serverPID int             // ServerPID; 0 means "no server"
 }
 
-func (f *fakeMux) PaneID() string                                         { return "" }
-func (f *fakeMux) RefreshStatus()                                         {}
-func (f *fakeMux) Switch(target string) error                             { return nil }
-func (f *fakeMux) OpenSession(name, cwd, window string, a []string) error { return nil }
+func (f *fakeMux) PaneID() string             { return "" }
+func (f *fakeMux) CurrentPane() string        { return "" }
+func (f *fakeMux) RefreshStatus()             {}
+func (f *fakeMux) Switch(target string) error { return nil }
+
+func (f *fakeMux) OpenSession(name, cwd, window, originPane string, a []string) error { return nil }
 
 // The window-naming methods are equally unused here: picker.Run drives them,
 // and Run is the exec boundary these tests stay on the near side of.


### PR DESCRIPTION
picker が開いた tmux window を、中のコマンドが正常終了したら閉じて**起動元の pane へ戻す**。
失敗したときだけ shell を残してエラーを読ませる。

## 背景

PR #63 で「window が中のコマンド終了と同時に消え、picker が作った tmux session ごと落ちる」
問題を直し、コマンドの後に無条件で `exec "${SHELL:-/bin/bash}"` を置いて window を残す形にした。
ただし本来の要望は「session を閉じたら pane も閉じて起動元 pane に戻る」であり、window を残す
形はそれとずれていた。残った window はユーザーが手で閉じることになるし、戻りたい先は元々
作業していた pane である。

`bin/claude-worktree` の `--tmux` 経路が既に終了時に起動元 pane へ戻す形
（`bash -c '...; tmux switch-client -t "$2" 2>/dev/null'`）なので、picker をそちらへ寄せた。ただし
あちらは exit status で分岐せず無条件に戻し、起動元が pane なので `$TMUX_PANE` をそのまま渡す。
picker は popup 内で走るぶん、下記のとおり取得経路と分岐が要る。

## 分岐の根拠

`claude attach` を意図して抜ける手段は 3 通りあり、**いずれも exit 0** で終わる（実測）。

| 抜け方 | exit code |
|---|---|
| 外から `claude stop` / `claude-stop-bg` | 0 |
| attach 中の UI で `/exit` → agent view → `Esc` | 0 |
| attach 中に `C-z` | 0 |

失敗系（存在しない id への attach で `No job matching <id>` 等）だけが非 0 になる。したがって
exit status が「正常に抜けた」と「そもそも起動できなかった」を分ける唯一の信号になる。

## 変更内容

`windowCommand` が組む shell 文字列を exit status で分岐させた。

```
<quoted argv>; rc=$?; if [ "$rc" -ne 0 ]; then tmux rename-window -t "$TMUX_PANE" '<名前>~exited'; exec "${SHELL:-/bin/bash}"; fi; tmux switch-client -t '<起動元pane>' 2>/dev/null
```

- **正常終了（exit 0）**: 起動元 pane へ `switch-client` して shell 文字列が終わる。pane が終了
  するので window も閉じる。その window しか持たない session も消えるが、client は既に起動元へ
  移っているので影響しない
- **失敗（非 0）**: `~exited` へ改名してから `exec` で shell を残す。`tmux new-window` は中の
  コマンドの exit status を返さないので、window を閉じると失敗の理由ごと消える（PR #63 の副次
  効果をここだけ維持する）

改名が失敗時だけになるので `~exited` window は溜まらなくなった。改名自体は残す必要がある —
失敗した window が同名のまま残ると `new-window -S` がそれを掴んで再試行が no-op になる
（PR #63 で実測した回帰と同じ理屈）。起動元 pane が空のときは `switch-client` の節を出さない。
tmux は空の `-t` を拒否するのではなく **current として解決する**（実測: tmux 3.6b で
`list-windows -t ''` は current window を列挙して exit 0）ので、節を残すと「いま閉じようと
している window 自身への自己 switch」という無意味なコマンドになる。

起動元 pane は新設の `Multiplexer.CurrentPane()` で取る。`TMUX_PANE` が非空ならそれ、空なら
`tmux display-message -p "#{pane_id}"` を trim して返し、取れなければ空文字列。picker は
`display-popup -E` の中で走り、popup は pane ではないので `TMUX_PANE` が空になる（実測）。

**既存の `PaneID()` は変更していない。** あれは hook が「この claude プロセス自身の pane」を
記録するのに使っており、`display-message` へ fallback させると別プロセスの pane を記録して
しまう。用途が違うので別メソッドにした。

取得は `OpenSession` を呼ぶ前、かつ自前の `switch-client` が走る前に行う。取得が後になると、
起動元ではなく今開いた window を指してしまう。

## テスト

- builder のテスト: 正常終了節と失敗節の両方が組み立てられること、`switch-client` が末尾に
  あること（= 失敗分岐の `exec` の外）、改名が `exec` より前にあること、起動元 pane が空なら
  `switch-client` 節が出ないこと
- `shellQuote` に pane id（`%3`）のケースを追加
- `currentPane()` を env / fallback / 取得失敗の 3 分岐へ切り出してテスト（tmux server 不要）
- window 名が wrap の影響を受けない既存の不変条件は維持（`TestWindowCommandUsesTheGivenName`、
  `TestSanitizeWindowNameIsAFixedPointOfLabelSanitize`）

### 判別力の確認

新コード側を 11 通りに変異させ、全て既存または新規テストで捕捉されることを確認した
（修正前コードに当てても新シンボルで compile error になるだけで確認にならないため）。

keep-alive を無条件に戻す / `rc=$?` の捕捉を落とす / `switch-client` を落とす / `switch-client` を
失敗分岐の中へ移す / 改名を `exec` の後へ移す / 起動元 pane を unquote で splice / 起動元 pane が
空でも `switch-client` を出す / `currentPane` の fallback を落とす / trim を落とす / env を無視して
常に ask する / `display-message` の format を `#{window_id}` に変える。

## 実機確認

専用 socket（`tmux -L cqprobe` / `-L cqprobe2`）の scratch server 上で行い、既存の live session・
window には一切触れていない。確認後 `kill-server` で撤去済み。

- exit 0 で終わるコマンド → window が閉じる。「消えたこと」を成功条件にするので、先に
  **実行中は window が存在し、出力が pane に見え、`-S` の重複畳み込みも効いている**ことを
  確認してから終了を待った
- 非 0（exit 7）で終わるコマンド → window が残り、`<名前>~exited` へ改名され、コマンドの出力が
  pane に読める

`switch-client` の実際の focus 移動は client が attach していないと確認できないため、scratch
server では未確認。**コマンド文字列に含まれること（構造）までの確認に留めている。**

## 既知の限界

いずれも「起動元 pane をコマンド文字列に焼き込む」設計の帰結で、`switch-client` 自体では直せない。
今回は記録に留め、対処はしていない。

- `new-window -S` で再利用された window は、それを作った pick 時点の起動元 pane を保持し続ける。
  別の pane から選び直しても戻り先は初回の pane になる
- 戻り先の pane が既に閉じていると switch は no-op になり、window と（それしか持たない）session が
  消えるので client は端末へ detach される。旧挙動（無条件 keep-alive）では踏まなかった経路
- `switch-client` に `-c` を渡していないので、tmux が client を自分で推定する。attach 中の client が
  無ければ no-op だが、tmux は「対象 session の client」に限らず最終アクティブ client へ fallback する
  ため、別 session へ移った client が引き戻されうる。`bin/claude-worktree` の `--tmux` 経路も同じ形で、
  厳密にやるなら pick 時に `#{client_name}` を取って `-c` で渡す形になる
- 起動元 pane の取得位置（`OpenSession` より前）を守るテストは無い。`picker.Run` は exec 境界の
  外側でテストされないため、読み取りを後ろへ動かす変異は捕捉されない。現状ガードはコメントのみ

## doc

既存の分担（挙動レベルは README、判断の根拠は design doc、flag / コマンドレベルは
`internal/multiplexer/tmux.go` のコメント）に沿って書き分けた。あわせて「UI 内で `/exit` すると
`claude attach` は終わらず agent view に戻る。そこから `Esc` で抜けると exit 0 で終了し、window が
閉じて起動元 pane に戻る」を挙動として書いた。

## 反映について

`bin/claude-queue` は symlink ではなく `make -C src/claude-queue install` が吐くバイナリなので、
merge / pull しただけでは更新されない。`bin/deploy.sh` を走らせた checkout（通常 main の
working tree）側で再ビルドが必要（`dot/claude/rules/dotrc-deploy.md` §5）。

## 対象外

- `claude attach` 側の挙動（`/exit` で agent view に戻ること）は claude の仕様なので変えていない
- picker のルーティング（switch / attach / resume の分岐）は変更していない

## レビュー

fresh context の判定役 1 体による独立レビューを 1 回受けた（PR が作れず `pr-review-automerge` を
回せないため手動）。must-fix は 1 件で、上記「空の `-t` を tmux が拒否する」というコメントの事実
誤りだった。実測で追認して記述を訂正した（コードの挙動は変更なし。節を落とす判断自体は正しかった）。
nice-to-have は「既知の限界」節と doc の重複整理・先回りの弁明の削除に反映した。
