### PR TITLE
fix(claude-queue): picker が background session の pane を祖先辿りで誤解決するのを直す

### DIFF
--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -84,7 +84,11 @@ transcript を掴む。tab を含む Bash コマンド（`awk -F'<tab>'`）は�
 
 1. **到達できる pane があれば `tmux switch-client`**。roster に該当 session があれば
    `claude agents --json` の pid からプロセス祖先を辿って pane を解決する（identity 込みの
-   確認）。ledger の `tmux_pane` を最後の手段として見るのは **roster を読めなかったときだけ**
+   確認）。ただしこの祖先辿りは interactive な roster entry にだけ適用する。background agent は
+   ホスト共有の `claude daemon run` が fork するため、daemon が pane の中から起きていると配下の
+   全 background が無関係なその pane に解決されてしまう。よって background は pane を解決せず、
+   必ず手順 2 の `claude attach` に落とす。ledger の `tmux_pane` を最後の手段として見るのは
+   **roster を読めなかったときだけ**
    （roster は読めたが該当 session が無い場合は含まない — それはプロセス終了の証拠なので
    使わない）。pane id は server 単位のカウンタで新しい server は `%0` から振り直すため、
    実在するだけでは同一 session の pane だと確認したことにならない。switch が失敗しても row は

--- a/src/claude-queue/internal/picker/origin.go
+++ b/src/claude-queue/internal/picker/origin.go
@@ -31,9 +31,16 @@ const (
 	// started outside a multiplexer altogether. Not an orphan -- there is a
 	// terminal somewhere that owns it.
 	originOutside
-	// originCurrent means the process belongs to this very tmux server. Its
-	// pane should have been found by FindPane; seeing this alongside an
-	// unreachable pane means the pane closed while the process lived on.
+	// originCurrent means the process belongs to this very tmux server. For an
+	// interactive session, its pane should have been found by FindPane, so
+	// seeing this alongside an unreachable pane means the pane closed while
+	// the process lived on. That implication does not hold for a background
+	// session: paneForSession skips background entries outright (see its
+	// comment), so an unreachable pane there proves nothing about the pane
+	// ever having closed -- it was never looked up. describeTarget calls
+	// originOf regardless of kind, but DecideAction routes background
+	// sessions to `claude attach` before origin is ever consulted, so this
+	// gap is inert in practice.
 	originCurrent
 	// originOrphan means the process belongs to a tmux server that no longer
 	// owns the socket it was started on: either the socket is gone, or another

--- a/src/claude-queue/internal/picker/origin_test.go
+++ b/src/claude-queue/internal/picker/origin_test.go
@@ -3,6 +3,8 @@ package picker
 import (
 	"strings"
 	"testing"
+
+	"github.com/knagiri/dotrc/src/claude-queue/internal/roster"
 )
 
 // environ builds the NUL-separated block /proc/<pid>/environ hands back.
@@ -144,7 +146,7 @@ func TestClassifyOrigin(t *testing.T) {
 func TestOnlyOrphanIsKillable(t *testing.T) {
 	for _, o := range []serverOrigin{originUnknown, originOutside, originCurrent, originForeignLive} {
 		tgt := resumable()
-		tgt.InRoster, tgt.Kind, tgt.PID, tgt.Origin = true, "interactive", 4242, o
+		tgt.InRoster, tgt.Kind, tgt.PID, tgt.Origin = true, roster.KindInteractive, 4242, o
 		if act := DecideAction(tgt); act.KillPID != 0 {
 			t.Errorf("origin %v: KillPID = %d, want 0", o, act.KillPID)
 		}

--- a/src/claude-queue/internal/picker/picker.go
+++ b/src/claude-queue/internal/picker/picker.go
@@ -265,7 +265,7 @@ type Target struct {
 	// one transcript.
 	RosterOK bool
 	InRoster bool
-	Kind     string // roster kind: "interactive" | "background"
+	Kind     string // roster kind: roster.KindInteractive | roster.KindBackground
 	PID      int
 	Origin   serverOrigin
 
@@ -340,7 +340,7 @@ func DecideAction(t Target) Action {
 			shortID(t.SessionID), t.RosterMatches, t.DuplicatePIDs)}
 	}
 	if t.InRoster {
-		if t.Kind == "background" {
+		if t.Kind == roster.KindBackground {
 			return Action{Kind: "attach", Short: shortID(t.SessionID), Cwd: t.Cwd}
 		}
 		if t.Origin != originOrphan {
@@ -443,16 +443,29 @@ func reachablePane(mux multiplexer.Multiplexer, agents []roster.Agent, sessionID
 // agents --json` has been observed to list the same session id twice (see
 // Target.RosterMatches), and stopping at the first entry risks missing the
 // one pid that actually resolves to a pane.
+//
+// Background agents are skipped rather than looked up, because the ancestry
+// walk is only meaningful for a process that was started inside a pane. A
+// background agent is not: it is forked by the host-shared `claude daemon run`
+// singleton, and that daemon is itself a descendant of whichever process first
+// needed it. When that happened to be inside a pane, every background agent
+// under the daemon walks up into that pane -- and since the daemon is shared
+// across worktrees, unrelated sessions resolve to the same one. Selecting such
+// a row would switch to a third session's window with no error. Skipping keeps
+// DecideAction's premise that a background session has no pane.
 func paneForSession(agents []roster.Agent, sessionID string, find func(int) (string, bool)) string {
 	for _, a := range agentsFor(agents, sessionID) {
+		if a.Kind == roster.KindBackground {
+			continue
+		}
 		if pane, found := find(a.PID); found {
 			return pane
 		}
 	}
-	// The session is live but outside this tmux server (a session that
-	// outlived the server it started in, or a background agent that never had
-	// a pane). Which of the two it is decides whether the session may be
-	// killed and resumed, and that is originOf's question, not this one's.
+	// The session is live but has no pane of ours: an interactive session that
+	// outlived the server it started in, or a background agent, which never had
+	// one. Which of the two it is decides whether the session may be killed and
+	// resumed, and that is originOf's question, not this one's.
 	return ""
 }
 

--- a/src/claude-queue/internal/picker/picker_test.go
+++ b/src/claude-queue/internal/picker/picker_test.go
@@ -463,12 +463,12 @@ func TestResumableRowCarriesNoPaneForTheRosterFallback(t *testing.T) {
 // -- falls back to the existing routing instead of resuming onto a live
 // process. Resumable rows add no branch of their own to DecideAction.
 func TestResumableRowInRosterFallsBackToExistingRouting(t *testing.T) {
-	agents := []roster.Agent{{SessionID: testUUID, PID: 100, Kind: "background"}}
+	agents := []roster.Agent{{SessionID: testUUID, PID: 100, Kind: roster.KindBackground}}
 	mux := &fakeMux{}
 
 	tgt := resumable()
 	tgt.Pane = reachablePane(mux, agents, testUUID, "%1", true)
-	tgt.InRoster, tgt.Kind, tgt.PID = true, "background", 100
+	tgt.InRoster, tgt.Kind, tgt.PID = true, roster.KindBackground, 100
 
 	if act := DecideAction(tgt); act.Kind != "attach" || act.Short != "61c846eb" {
 		t.Errorf("DecideAction = %+v, want attach by short id", act)
@@ -539,7 +539,7 @@ func TestDecideAction(t *testing.T) {
 		// back reachable, nothing may be killed.
 		name: "reachable pane beats an orphan process",
 		target: withPane(func(tg *Target) {
-			tg.Pane, tg.InRoster, tg.Kind, tg.PID, tg.Origin = "%12", true, "interactive", 4242, originOrphan
+			tg.Pane, tg.InRoster, tg.Kind, tg.PID, tg.Origin = "%12", true, roster.KindInteractive, 4242, originOrphan
 		}),
 		kind: "switch",
 		pane: "%12",
@@ -558,7 +558,7 @@ func TestDecideAction(t *testing.T) {
 		// fails with "No job matching".
 		name: "background session attaches by short id",
 		target: withPane(func(tg *Target) {
-			tg.InRoster, tg.Kind, tg.PID = true, "background", 100
+			tg.InRoster, tg.Kind, tg.PID = true, roster.KindBackground, 100
 		}),
 		kind:  "attach",
 		short: "61c846eb",
@@ -566,7 +566,7 @@ func TestDecideAction(t *testing.T) {
 		// Short ids that are already <= 8 chars must not be sliced out of range.
 		name: "short session id is not truncated",
 		target: withPane(func(tg *Target) {
-			tg.SessionID, tg.InRoster, tg.Kind, tg.PID = "abc", true, "background", 100
+			tg.SessionID, tg.InRoster, tg.Kind, tg.PID = "abc", true, roster.KindBackground, 100
 		}),
 		kind:  "attach",
 		short: "abc",
@@ -577,7 +577,7 @@ func TestDecideAction(t *testing.T) {
 		// so this refuses rather than kill one of the two arbitrarily.
 		name: "duplicate roster entries are not touched",
 		target: withPane(func(tg *Target) {
-			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originOrphan
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, roster.KindInteractive, 4242, originOrphan
 			tg.RosterMatches, tg.DuplicatePIDs = 2, []int{4242, 5252}
 		}),
 		kind: "none",
@@ -586,7 +586,7 @@ func TestDecideAction(t *testing.T) {
 		// server no client of ours can reach.
 		name: "orphan interactive session is ended then resumed",
 		target: withPane(func(tg *Target) {
-			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originOrphan
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, roster.KindInteractive, 4242, originOrphan
 		}),
 		kind:    "resume",
 		resume:  testUUID,
@@ -594,7 +594,7 @@ func TestDecideAction(t *testing.T) {
 	}, {
 		name: "session started outside tmux is left alone",
 		target: withPane(func(tg *Target) {
-			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originOutside
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, roster.KindInteractive, 4242, originOutside
 		}),
 		kind: "none",
 	}, {
@@ -603,7 +603,7 @@ func TestDecideAction(t *testing.T) {
 		// terminal (a different socket entirely), so it must not be killed.
 		name: "interactive session on a still-running foreign server is left alone",
 		target: withPane(func(tg *Target) {
-			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originForeignLive
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, roster.KindInteractive, 4242, originForeignLive
 		}),
 		kind: "none",
 	}, {
@@ -611,19 +611,19 @@ func TestDecideAction(t *testing.T) {
 		// safe answer is the same as for a session in use elsewhere.
 		name: "unknown origin is left alone",
 		target: withPane(func(tg *Target) {
-			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originUnknown
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, roster.KindInteractive, 4242, originUnknown
 		}),
 		kind: "none",
 	}, {
 		name: "same-server session with a closed pane is left alone",
 		target: withPane(func(tg *Target) {
-			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originCurrent
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, roster.KindInteractive, 4242, originCurrent
 		}),
 		kind: "none",
 	}, {
 		name: "orphan with no pid cannot be ended, so is left alone",
 		target: withPane(func(tg *Target) {
-			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 0, originOrphan
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, roster.KindInteractive, 0, originOrphan
 		}),
 		kind: "none",
 	}, {
@@ -657,7 +657,7 @@ func TestDecideAction(t *testing.T) {
 		// is gone must not be killed for a resume that cannot happen.
 		name: "orphan with no transcript is not killed",
 		target: withPane(func(tg *Target) {
-			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, "interactive", 4242, originOrphan
+			tg.InRoster, tg.Kind, tg.PID, tg.Origin = true, roster.KindInteractive, 4242, originOrphan
 			tg.TranscriptExists = false
 		}),
 		kind: "none",
@@ -699,12 +699,19 @@ func TestDecideAction(t *testing.T) {
 // jobs and would silently close a fresh window for an interactive session.
 func TestPaneForSession(t *testing.T) {
 	agents := []roster.Agent{
-		{SessionID: "bg", PID: 100, Kind: "background"},
-		{SessionID: "live", PID: 200, Kind: "interactive"},
+		{SessionID: "bg", PID: 100, Kind: roster.KindBackground},
+		{SessionID: "live", PID: 200, Kind: roster.KindInteractive},
 	}
-	// Only pid 200 sits under a pane; 100 is a background agent with none.
+	// The background pid resolves to a pane, because in the field it does: a
+	// background agent is forked by the host-shared `claude daemon run`
+	// singleton, and when that daemon was itself started from inside a pane the
+	// ancestry walk reaches it. The pane is not the session's, so the lookup
+	// must not be attempted at all.
 	find := func(pid int) (string, bool) {
-		if pid == 200 {
+		switch pid {
+		case 100:
+			return "%320", true
+		case 200:
 			return "%7", true
 		}
 		return "", false
@@ -713,8 +720,9 @@ func TestPaneForSession(t *testing.T) {
 	if got := paneForSession(agents, "live", find); got != "%7" {
 		t.Errorf("paneForSession(live) = %q, want %%7", got)
 	}
-	// A live agent with no pane must stay empty so DecideAction routes it to
-	// attach, which is the correct path for a background session.
+	// A background session must stay empty so DecideAction routes it to attach,
+	// which is the only path that reaches it -- switching would land on the
+	// daemon's ancestor pane, an unrelated session's window.
 	if got := paneForSession(agents, "bg", find); got != "" {
 		t.Errorf("paneForSession(bg) = %q, want empty", got)
 	}
@@ -724,6 +732,26 @@ func TestPaneForSession(t *testing.T) {
 	}
 	if got := paneForSession(nil, "live", find); got != "" {
 		t.Errorf("paneForSession over an empty roster = %q, want empty", got)
+	}
+}
+
+// The observed symptom, in the shape it was measured: two unrelated background
+// sessions in different worktrees, both under one shared daemon, resolved to
+// the same pane %320 -- which belonged to a third session's `claude attach`
+// window. Both rows would have switched there instead of attaching, with no
+// error. Neither may resolve to a pane.
+func TestPaneForSessionSharedDaemonPane(t *testing.T) {
+	agents := []roster.Agent{
+		{SessionID: "6f3093ad", PID: 3843635, Kind: roster.KindBackground},
+		{SessionID: "b1baa690", PID: 3118555, Kind: roster.KindBackground},
+	}
+	// Both pids walk up into the one pane the shared daemon was started from.
+	find := func(int) (string, bool) { return "%320", true }
+
+	for _, id := range []string{"6f3093ad", "b1baa690"} {
+		if got := paneForSession(agents, id, find); got != "" {
+			t.Errorf("paneForSession(%s) = %q, want empty: that pane belongs to the daemon's ancestor, not this session", id, got)
+		}
 	}
 }
 
@@ -768,11 +796,12 @@ func (f *fakeMux) ServerPID() (int, bool)        { return f.serverPID, f.serverP
 // the session: that absence is evidence the process ended, not a reason to
 // trust a stale id.
 func TestReachablePane(t *testing.T) {
-	live := []roster.Agent{{SessionID: "live", PID: 200, Kind: "interactive"}}
+	live := []roster.Agent{{SessionID: "live", PID: 200, Kind: roster.KindInteractive}}
 	dup := []roster.Agent{
-		{SessionID: "dup", PID: 200, Kind: "interactive"},
-		{SessionID: "dup", PID: 201, Kind: "interactive"},
+		{SessionID: "dup", PID: 200, Kind: roster.KindInteractive},
+		{SessionID: "dup", PID: 201, Kind: roster.KindInteractive},
 	}
+	bg := []roster.Agent{{SessionID: "bg", PID: 100, Kind: roster.KindBackground}}
 
 	cases := []struct {
 		name       string
@@ -863,6 +892,17 @@ func TestReachablePane(t *testing.T) {
 		rosterOK:  true,
 		want:      "%8",
 	}, {
+		// A background agent's ancestry does reach a pane -- the shared `claude
+		// daemon run` that forked it was started from one -- but that pane is
+		// not the session's. It must be reported unreachable so the pick
+		// attaches instead of switching into an unrelated window.
+		name:      "background agent's ancestor pane is not its own",
+		agents:    bg,
+		mux:       &fakeMux{find: map[int]string{100: "%320"}},
+		sessionID: "bg",
+		rosterOK:  true,
+		want:      "",
+	}, {
 		// Nothing to look the process up by, and an empty pane column: the row
 		// is not reachable by any pane.
 		name:       "no session id and no ledger pane",
@@ -886,11 +926,11 @@ func TestReachablePane(t *testing.T) {
 // ledger, so the pick lands on the switch path rather than on a resume that
 // would kill a session whose pane is right here.
 func TestReachablePaneRoutesToSwitch(t *testing.T) {
-	agents := []roster.Agent{{SessionID: testUUID, PID: 200, Kind: "interactive"}}
+	agents := []roster.Agent{{SessionID: testUUID, PID: 200, Kind: roster.KindInteractive}}
 	mux := &fakeMux{find: map[int]string{200: "%7"}}
 
 	tgt := resumable()
-	tgt.InRoster, tgt.Kind, tgt.PID, tgt.Origin = true, "interactive", 200, originOrphan
+	tgt.InRoster, tgt.Kind, tgt.PID, tgt.Origin = true, roster.KindInteractive, 200, originOrphan
 	tgt.Pane = reachablePane(mux, agents, testUUID, "%stale", true)
 
 	if act := DecideAction(tgt); act.Kind != "switch" || act.Pane != "%7" {

--- a/src/claude-queue/internal/roster/roster.go
+++ b/src/claude-queue/internal/roster/roster.go
@@ -13,12 +13,21 @@ import (
 	"os/exec"
 )
 
+// The two values Agent.Kind takes. They are named because the distinction
+// decides how a session is reached -- an interactive session runs in a tmux
+// pane, a background one does not -- so callers branch on it rather than just
+// display it.
+const (
+	KindInteractive = "interactive"
+	KindBackground  = "background"
+)
+
 // Agent is one entry of the roster. The json tags are the contract with
 // `claude agents --json`; fields the callers do not use are left out.
 type Agent struct {
 	SessionID string `json:"sessionId"`
 	PID       int    `json:"pid"`
-	Kind      string `json:"kind"` // "interactive" | "background"
+	Kind      string `json:"kind"` // KindInteractive | KindBackground
 	Cwd       string `json:"cwd"`
 }
 


### PR DESCRIPTION
## Summary

picker（tmux `C-q q`）で、無関係な複数の background session が同じ tmux pane に解決され、
選ぶと別 session の window へ飛ばされる不具合を直す。

`picker.paneForSession` → `multiplexer.FindPane` は roster の pid から親を最大 10 段
（`maxPaneWalk`）さかのぼり、tmux の `pane_pid` に一致した pane を返す。この逆算が正しいのは
「そのプロセスが pane の中で起動された」ときだけで、background agent はそうではない。
ホスト共有の `claude daemon run` シングルトンが fork して作り、その daemon 自身は最初に
それを必要としたプロセスの子孫なので、たまたま pane の中から起きていると配下の全
background agent がその pane に解決される。daemon は worktree をまたいで共有されるため、
無関係な session 同士が同じ pane を指す。

`DecideAction` は `t.Pane != ""` を最初に見て `switch` を返すため、こうした行を選ぶと
`claude attach` が走らず無関係な window へ移動する。エラーが出ない silent failure。

変更は 2 点。

- **祖先辿りから background を除外する**: `paneForSession` が `roster.KindBackground` の
  roster entry を `FindPane` に渡さずスキップする。`DecideAction` の前提
  「a background session has no pane」を、ledger 経路（`$TMUX_PANE` を記録する hook）だけでなく
  roster 経路でも成り立たせる。
- **kind の定数化**: `roster.KindInteractive` / `roster.KindBackground` を切り、`DecideAction`
  の文字列リテラル比較と各テストの kind をそれに寄せた。

## 症状（実測）

picker の全 46 行について pane 解決を再現したところ、default view の最上位 2 行
（どちらも awaiting_approval / background）が同じ pane `%320` を指していた。

| session | cwd | 解決された pane |
|---|---|---|
| 6f3093ad | `eversteel-backend-api_ncs-gw-rtp-watchdog/apps/go/ncs-gateway` | `%320` |
| b1baa690 | `ncs-recorder_media-archive-key-fix` | `%320` |

`%320` はこのどちらでもない第三の session（9e0e7d81 の attach window）の pane。
ppid の連鎖は 4 段で `%320` に到達しており（`bg-spare` → `bg-pty-host` →
`claude daemon run` → `claude attach 9e0e7d81` → pane）、`maxPaneWalk` の 10 には
まったく届いていない。b1baa690 も同じ daemon 配下なので同じ経路をたどる。

参考実測: 生きている interactive session 34 件のさかのぼり段数は depth 0 が 7 件、
depth 1 が 27 件。上限 10 は通常使われていない。

## 判別力の確認

修正前のコード（`paneForSession` から background スキップだけを外した状態）に対して、
追加・変更したテストを掛けて実際に落ちることを確認した。

```
=== RUN   TestPaneForSession
    picker_test.go:727: paneForSession(bg) = "%320", want empty
--- FAIL: TestPaneForSession (0.00s)
=== RUN   TestPaneForSessionSharedDaemonPane
    picker_test.go:753: paneForSession(6f3093ad) = "%320", want empty: that pane belongs to the daemon's ancestor, not this session
    picker_test.go:753: paneForSession(b1baa690) = "%320", want empty: that pane belongs to the daemon's ancestor, not this session
--- FAIL: TestPaneForSessionSharedDaemonPane (0.00s)
=== RUN   TestReachablePane/background_agent's_ancestor_pane_is_not_its_own
    picker_test.go:919: reachablePane = "%320", want ""
    --- FAIL: TestReachablePane/background_agent's_ancestor_pane_is_not_its_own (0.00s)
```

3 つとも `""` を期待するところで `%320` を返して落ちた。修正後は全件 pass する。
既存の他ケース（`duplicate roster entries try every pid for a pane` 等）は前後どちらでも pass。

既存の `TestPaneForSession` は background ケースを持っていたが、fake の `find` が
background pid に対して `false` を返す形で、**今回破れた前提をテスト側でも仮定していた**。
実測どおり pane を返すよう改めたのが回帰テストの本体で、そこに同一 daemon 配下の
2 session が同じ pane を返す `TestPaneForSessionSharedDaemonPane` を足した。

## Why

**なぜテストで検証したか**: 調査中に `claude attach 9e0e7d81` が終了して daemon の ppid が
1 に変わったため、この症状は現在手元で再現しない。間欠的な不具合であり直ってはおらず、
次に daemon が pane の中から起こされた時点で再発する。実環境での再現待ちはせず、
上記のユニットテストで裏取りした。

**採用しなかった案**:

- `maxPaneWalk` を縮める: 段数はたまたまの値。wrapper（`bash -c`, `mise exec` 等）経由の
  正当な深さを切る一方、daemon がもっと浅い位置から起きれば再発する。
- 祖先辿り中に `claude daemon run` を検出して打ち切る: 段ごとに `ps -o args=` が要り、
  `multiplexer` が claude の内部プロセス名に依存する。kind 判定が正確かつ無料なので不要。
- 見つけた pane が本当にその session のものか検証する: 今回の原因に対して過剰。

**スコープ外と確定させた点**: ledger（`sessions.tmux_pane`）経由の同種汚染も疑って確認したが、
対象外だった。hook は `os.Getenv("TMUX_PANE")` を記録するところ（`internal/hook/run.go`）、
実測で daemon の env には `TMUX_PANE=%320` が残っているが background agent の子プロセスには
渡っていない。DB 上の background 行 12 件もすべて pane が空だった。`reachablePane` の
ledger fallback（`!rosterOK` の分岐）と hook 側は変更していない。

## 検証

```
cd src/claude-queue && make test && go vet ./...   # 全 pass
make build                                          # bin/claude-queue 再生成
gofmt -l ./internal ./cmd                           # 出力なし
```

`bin/claude-queue` は `.gitignore` の `/bin/claude-queue` に載るローカルビルド成果物なので
commit しない（既存の扱いを踏襲）。したがって merge 後、ホームの PATH に乗る checkout 側で
`make -C src/claude-queue install` の再ビルドが必要。
