### PR TITLE
feat(claude-worktree): background 起動を acceptEdits から auto mode へ

### DIFF
--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -11,9 +11,23 @@ set -euo pipefail
 # inside another worktree.
 #
 # When a prompt is given, the default is a BACKGROUND agent (`claude --bg`,
-# acceptEdits) started with the worktree as its cwd. Tool calls that need
-# approval block and wait rather than degrading silently. Reach it with
+# permission mode `auto`) started with the worktree as its cwd. Reach it with
 # `claude attach <short-id>` (the id is printed at launch).
+#
+# The two modes deliberately run different permission modes: background is
+# `auto`, --tmux is `acceptEdits`. A background delegation is fire-and-forget
+# with nobody watching, so under acceptEdits every command outside the allowlist
+# (compound commands with variable expansion or loops, `git -c`, a tool's
+# unfamiliar subcommand) raised a prompt no one could approve and the session sat
+# frozen -- observed 10+ times. In `auto` mode a classifier vets those instead,
+# so the delegate keeps moving without the allowlist having to grow a hole per
+# incident. Existing allow/deny rules still win: the classifier only judges what
+# no rule matched, and it blocks work that widens permissions beyond the request,
+# targets unfamiliar infrastructure, or is driven by adversarial content; three
+# consecutive (or twenty total) blocks drop the session back to normal prompts.
+# --tmux keeps acceptEdits because a human is sitting with that session: their
+# judgment is the one wanted there, and the prompts are no obstacle when someone
+# is present to answer them.
 #
 # A delegate does NOT exit when its task completes: it stays at `status: idle`
 # waiting for further input (a different state from `status: waiting` /
@@ -52,6 +66,9 @@ set -euo pipefail
 #                  INTERACTIVE claude instead of a background agent. Use when a
 #                  human is meant to sit with it (working a design out together);
 #                  the session stays at the REPL and is reached with `gts`.
+#                  Runs with `acceptEdits`, not the background mode's `auto`:
+#                  someone is present to answer prompts, and their judgment
+#                  beats a classifier's in that setting.
 #   --model <alias>
 #                  pass --model <alias> to the launched claude (e.g. opus), so the
 #                  caller picks the model for the role it is delegating. Omitted
@@ -73,10 +90,11 @@ set -euo pipefail
 #                  local branch, else origin/<branch> (tracked, no fetch), else
 #                  created fresh from the current HEAD.
 #   -- <prompt>    everything after `--` is the initial prompt. By default the
-#                  delegate is started with `claude --bg` (acceptEdits) and is
-#                  reached with `claude attach <short-id>`; it stays alive once
-#                  the task completes, so the delegator closes it with
-#                  `claude-stop-bg`. With --tmux, see above.
+#                  delegate is started with `claude --bg` (permission mode
+#                  `auto`, since nobody is there to approve prompts -- see the
+#                  header) and is reached with `claude attach <short-id>`; it
+#                  stays alive once the task completes, so the delegator closes
+#                  it with `claude-stop-bg`. With --tmux, see above.
 
 usage() {
   # Print the first contiguous "# " comment block (the description), skipping the
@@ -313,8 +331,10 @@ fi
 if [ "$use_tmux" = 0 ]; then
   # Background agent (default). It does NOT exit on its own when the task
   # completes -- see the header for that. It's preferred over an interactive
-  # session because it doesn't occupy a tmux session/pane and blocks on
-  # approval-requiring tool calls instead of degrading silently. The id is
+  # session because it doesn't occupy a tmux session/pane. Permission mode is
+  # `auto` (NOT acceptEdits, which --tmux keeps): nobody is attached to answer a
+  # prompt, so a classifier vets what the allowlist doesn't cover -- see the
+  # header for why and for what the classifier still refuses. The id is
   # assigned by --bg (it ignores --session-id), so the only way to learn it is
   # to read the launch banner back.
   #
@@ -330,7 +350,7 @@ if [ "$use_tmux" = 0 ]; then
   # would read back 0 even though claude failed. Falling through to `else`
   # keeps `$?` as claude's real exit code.
   if [ -n "$model" ]; then
-    if launch_out="$(cd "$wt_path" && claude --bg --permission-mode acceptEdits --model "$model" "$prompt" 2>&1)"; then
+    if launch_out="$(cd "$wt_path" && claude --bg --permission-mode auto --model "$model" "$prompt" 2>&1)"; then
       :
     else
       rc=$?
@@ -339,7 +359,7 @@ if [ "$use_tmux" = 0 ]; then
       exit "$rc"
     fi
   else
-    if launch_out="$(cd "$wt_path" && claude --bg --permission-mode acceptEdits "$prompt" 2>&1)"; then
+    if launch_out="$(cd "$wt_path" && claude --bg --permission-mode auto "$prompt" 2>&1)"; then
       :
     else
       rc=$?
@@ -357,7 +377,7 @@ if [ "$use_tmux" = 0 ]; then
   echo "worktree : $wt_path"
   echo "branch   : $branch"
   if [ -n "$short" ]; then
-    echo "session  : $short (background; acceptEdits)"
+    echo "session  : $short (background; auto)"
   else
     # The session IS running -- only the id is unknown. Surfacing the raw banner
     # beats printing a report with a silently empty field.
@@ -384,6 +404,11 @@ fi
 # Start claude INSIDE a fresh detached tmux session in the worktree. Passing the
 # prompt as a separate argv element keeps spaces/quotes intact (tmux preserves
 # argv). Interactive (no -p) so it stays at the REPL after the first prompt.
+#
+# Permission mode stays `acceptEdits` here -- the background launch above uses
+# `auto`, and that difference is intentional: this mode exists for a human to sit
+# with the session, so approval prompts cost nothing and their judgment is
+# preferred over the classifier's (see the header).
 #
 # When launched from inside tmux, wrap the launch in `bash -c` so that when
 # claude exits we chain `switch-client -t <origin_pane>`, returning the attached

--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -60,9 +60,10 @@ set -euo pipefail
 # attached / origin pane gone both degrade to a silent no-op.
 #
 # A new worktree only checks out the branch: gitignored / uncommitted files of the
-# invoking checkout do NOT propagate, and a delegated session cannot read outside
-# its worktree without a permission prompt nobody is there to approve. `--seed`
-# copies such files in, so the delegated prompt can reference them relatively.
+# invoking checkout do NOT propagate, and reading outside the worktree still has
+# no guarantee of passing the classifier described above (or, under --tmux, of
+# getting an answer promptly). `--seed` copies such files in, so the delegated
+# prompt can reference them relatively.
 #
 # Usage:
 #   claude-worktree [--self] [--tmux] [--model <alias>] [--seed <path>]... <name> [-b <branch>] [-- <prompt...>]

--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -25,6 +25,13 @@ set -euo pipefail
 # no rule matched, and it blocks work that widens permissions beyond the request,
 # targets unfamiliar infrastructure, or is driven by adversarial content; three
 # consecutive (or twenty total) blocks drop the session back to normal prompts.
+# That escalation is not a fix -- it reintroduces the frozen-prompt problem
+# `auto` mode exists to avoid: once escalated, an unattended delegate again
+# needs a human to run `claude attach <short-id>` and answer the prompt before
+# it can continue. Escalation only lowers how often that happens, and exactly
+# how a detached, unattended session behaves while sitting on a post-escalation
+# prompt is unverified against docs or a real run, so this is stated narrowly
+# rather than assumed safe.
 # --tmux keeps acceptEdits because a human is sitting with that session: their
 # judgment is the one wanted there, and the prompts are no obstacle when someone
 # is present to answer them.

--- a/test/claude-worktree.test.sh
+++ b/test/claude-worktree.test.sh
@@ -529,7 +529,7 @@ if [ "$rc" -eq 0 ] \
    && grep -A1 -Fx -- '--permission-mode' "$log" | grep -Fxq 'auto' \
    && ! grep -Fxq -- 'acceptEdits' "$log" \
    && grep -Fxq "$prompt" "$log" \
-   && grep -q 'session  : abcd1234 (background' <<<"$out" \
+   && grep -Fq 'session  : abcd1234 (background; auto)' <<<"$out" \
    && grep -q 'attach   : claude attach abcd1234' <<<"$out"; then
   echo "ok: default launch uses claude --bg in auto mode and reports the short id"
 else

--- a/test/claude-worktree.test.sh
+++ b/test/claude-worktree.test.sh
@@ -287,6 +287,12 @@ prompt='say "hi" it'\''s here'
 # Inside tmux ($TMUX set): launch is wrapped in `bash -c` so claude's exit is
 # chained to `switch-client -t <origin_pane>`, returning the client to the pane
 # we launched from. Assert the chain is wired and quoting is intact.
+#
+# --tmux keeps `acceptEdits` while the background launch moved to `auto`: a human
+# sits with this session, so their judgment is preferred over the classifier's.
+# Here the flag lives inside the `bash -c` command STRING (one log line, several
+# tokens), so the mode is matched as the `--permission-mode <mode>` phrase rather
+# than as a whole line.
 log="$tmp/ns-in"
 out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
   export PATH="$stubbin:$PATH" TMUX_STUB_LOG="$log" TMUX=fake TMUX_PANE=%9
@@ -294,15 +300,19 @@ out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
 if [ "$rc" -eq 0 ] \
    && grep -q 'switch-client' "$log" \
    && grep -Fxq '%9' "$log" \
+   && grep -Fq -- '--permission-mode acceptEdits' "$log" \
+   && ! grep -Fq -- '--permission-mode auto' "$log" \
    && grep -Fxq "$prompt" "$log" \
    && grep -q 'attach   : gts' <<<"$out"; then
-  echo "ok: \$TMUX set wires switch-client back to origin pane, prompt intact"
+  echo "ok: \$TMUX set wires switch-client back to origin pane, prompt intact, acceptEdits kept"
 else
   echo "FAIL: in-tmux launch rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; fail=1
 fi
 
 # Outside tmux ($TMUX unset): no client to return, so claude runs directly (no
 # wrapper, no switch-client) and the attach hint falls back to `tmux attach`.
+# claude is exec'd directly here, so the mode is its own argv element (one per
+# log line) -- assert acceptEdits present and the background mode's auto absent.
 log="$tmp/ns-out"
 out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
   export PATH="$stubbin:$PATH" TMUX_STUB_LOG="$log"
@@ -310,9 +320,11 @@ out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
 if [ "$rc" -eq 0 ] \
    && ! grep -q 'switch-client' "$log" \
    && grep -Fxq 'claude' "$log" \
+   && grep -A1 -Fx -- '--permission-mode' "$log" | grep -Fxq 'acceptEdits' \
+   && ! grep -Fxq -- 'auto' "$log" \
    && grep -Fxq "$prompt" "$log" \
    && grep -q 'attach   : tmux attach -t' <<<"$out"; then
-  echo "ok: no \$TMUX launches claude directly, no pane-return chain"
+  echo "ok: no \$TMUX launches claude directly, no pane-return chain, acceptEdits kept"
 else
   echo "FAIL: out-of-tmux launch rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; fail=1
 fi
@@ -367,9 +379,11 @@ out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
   "$wt" --tmux --model sonnet modelout -- "$prompt"; } 2>/dev/null)"; rc=$?
 if [ "$rc" -eq 0 ] \
    && grep -A1 -Fx -- '--model' "$log" | grep -Fxq 'sonnet' \
+   && grep -A1 -Fx -- '--permission-mode' "$log" | grep -Fxq 'acceptEdits' \
+   && ! grep -Fxq -- 'auto' "$log" \
    && grep -Fxq "$prompt" "$log" \
    && grep -q 'model    : sonnet' <<<"$out"; then
-  echo "ok: --model reaches the out-of-tmux launch and is reported"
+  echo "ok: --model reaches the out-of-tmux launch, which keeps acceptEdits, and is reported"
 else
   echo "FAIL: out-of-tmux --model rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; fail=1
 fi
@@ -501,19 +515,23 @@ chmod +x "$stubbin/claude"
 emptyroster="$tmp/roster-empty.json"
 echo '[]' >"$emptyroster"
 
-# Default (no --tmux): claude --bg is launched with acceptEdits, the short id is
-# lifted out of the banner, and the report tells the user how to attach.
+# Default (no --tmux): claude --bg is launched in permission mode `auto` (NOT
+# acceptEdits -- nobody is attached to answer a prompt; see the script header),
+# the short id is lifted out of the banner, and the report tells the user how to
+# attach. The mode is asserted as the element right after --permission-mode, and
+# acceptEdits asserted absent, so a partial rename can't pass.
 log="$tmp/bg-default"
 out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
   export PATH="$stubbin:$PATH" CLAUDE_STUB_LOG="$log" CLAUDE_STUB_ROSTER="$emptyroster"
   "$wt" bgdefault -- "$prompt"; } 2>/dev/null)"; rc=$?
 if [ "$rc" -eq 0 ] \
    && grep -Fxq -- '--bg' "$log" \
-   && grep -Fxq -- 'acceptEdits' "$log" \
+   && grep -A1 -Fx -- '--permission-mode' "$log" | grep -Fxq 'auto' \
+   && ! grep -Fxq -- 'acceptEdits' "$log" \
    && grep -Fxq "$prompt" "$log" \
    && grep -q 'session  : abcd1234 (background' <<<"$out" \
    && grep -q 'attach   : claude attach abcd1234' <<<"$out"; then
-  echo "ok: default launch uses claude --bg and reports the short id"
+  echo "ok: default launch uses claude --bg in auto mode and reports the short id"
 else
   echo "FAIL: bg default rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; echo "$out"; fail=1
 fi
@@ -537,7 +555,9 @@ if [ "$rc" -eq 0 ] && [ "$(cat "$cwdlog" 2>/dev/null)" = "${cwdrepo}_bgcwd" ]; t
   echo "ok: bg launch runs with the worktree as cwd"
 else echo "FAIL: bg cwd rc=$rc got=$(cat "$cwdlog" 2>/dev/null) want=${cwdrepo}_bgcwd"; fail=1; fi
 
-# --model rides through to the bg launch as two adjacent argv elements.
+# --model rides through to the bg launch as two adjacent argv elements. The
+# launch has a separate branch per --model, so the mode is re-asserted here:
+# otherwise one branch could keep acceptEdits unnoticed.
 log="$tmp/bg-model"
 out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
   export PATH="$stubbin:$PATH" CLAUDE_STUB_LOG="$log" CLAUDE_STUB_CWDLOG="$tmp/x" \
@@ -545,8 +565,10 @@ out="$(cd "$cwdrepo" && { unset TMUX TMUX_PANE
   "$wt" --model opus bgmodel -- "$prompt"; } 2>/dev/null)"; rc=$?
 if [ "$rc" -eq 0 ] \
    && grep -A1 -Fx -- '--model' "$log" | grep -Fxq 'opus' \
+   && grep -A1 -Fx -- '--permission-mode' "$log" | grep -Fxq 'auto' \
+   && ! grep -Fxq -- 'acceptEdits' "$log" \
    && grep -q 'model    : opus' <<<"$out"; then
-  echo "ok: --model reaches the bg launch and is reported"
+  echo "ok: --model reaches the bg launch, which stays in auto mode, and is reported"
 else echo "FAIL: bg --model rc=$rc"; sed 's/^/  argv| /' "$log" 2>/dev/null; fail=1; fi
 
 # Omitting --model must not synthesise `--model ""` (claude rejects it).


### PR DESCRIPTION
## Summary

`bin/claude-worktree` の background 起動（既定モード、`--tmux` 無し）の permission mode を
`acceptEdits` から `auto` へ変更する。`--tmux` 経路は `acceptEdits` のまま維持する。

- bg 起動の 2 分岐（`--model` の有無）をどちらも `--permission-mode auto` に変更
- 起動レポートの表示を `(background; acceptEdits)` → `(background; auto)` に追随
- ヘッダコメント / Usage 節に「bg は `auto`、`--tmux` は `acceptEdits`」という差と、その理由を明記
- `--tmux` の launch 直前コメントに、`acceptEdits` 維持が意図的である旨を追記

## Why

fire-and-forget の background 委譲は人間不在で走る。`acceptEdits` では allowlist に無いコマンド
（変数展開やループを含む複合コマンド、`git -c`、他ツールの新規サブコマンド）が permission prompt に
落ち、誰も承認できないまま session が固まる。実測で 10 回以上発生した。`auto` mode なら classifier が
審査するため、穴を都度 allowlist へ足さなくても委譲先が自走できる。

安全性は <https://code.claude.com/docs/en/permission-modes> で裏取り済み:

- 既存の allow/deny rule は `auto` でも先に効く（classifier は rule にマッチしないものだけを審査する）
- classifier は「依頼を超えて権限を広げる」「見知らぬインフラを対象にする」「敵対的コンテンツに
  駆動された」行為をブロックする
- 連続 3 回または通算 20 回のブロックで `auto` は一時停止し、通常の承認プロンプトへ戻る
  （このフォールバックが無いのは `-p` の非対話セッションで、`--bg` は該当しない）

`--tmux` を変えないのは、人間が同席して協同する委譲（HOW をその場で詰める等）に使うモードだから。
承認プロンプトは支障にならず、classifier の自動判断より人間の判断を優先すべき文脈にあたる。

## Tests

`test/claude-worktree.test.sh` の argv 記録スタブに assertion を足した。

- bg 起動 2 形（`--model` 有無）: argv に `auto` が入り `acceptEdits` が入らないこと
- `--tmux` 起動 3 形（in-tmux / out-of-tmux ± `--model`）: 逆に `acceptEdits` が入り `auto` が入らないこと

判別力の確認として、修正前の `bin/claude-worktree`（`git show HEAD:` で取得）に新テストを掛けると
bg 側の 2 ケースが FAIL することを確認済み。全 42 ケース pass。

## Refs

- <https://code.claude.com/docs/en/permission-modes>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZ2pmGiD4RZDbAi8ccAA8n
