### PR TITLE
fix(pr-review-automerge): 終端確認に存在しない merged フィールドを使わない

### DIFF
--- a/dot/claude/skills/pr-review-automerge/SKILL.md
+++ b/dot/claude/skills/pr-review-automerge/SKILL.md
@@ -108,9 +108,9 @@ fresh subagent に委譲**する。これが「修正適用後にコンテキス
       ので、required check の充足判定は auto-merge（branch protection）に委ねる。
    c. `has_failure` が `false` なら `gh-automerge <PR>` を実行する（内部で `gh pr merge --auto --merge`。
       clean 拒否のときだけ `gh pr merge --merge` へ fallback する）。
-   d. `gh pr view <PR> --json autoMergeRequest,merged` の `autoMergeRequest` が **非 null**、
-      **または `merged` が true**（c の fallback で直接 merge された場合）であることを確認する。
-      これがこの skill の終端状態。**auto-merge を有効化できたなら `merged` は確認しない。**
+   d. `gh pr view <PR> --json autoMergeRequest,state` の `autoMergeRequest` が **非 null**、
+      **または `state` が `MERGED`**（c の fallback で直接 merge された場合）であることを確認する。
+      これがこの skill の終端状態。**auto-merge を有効化できたなら merge 済みかは確認しない。**
       PR が実際に merge されるかは repo の branch protection が決めるので、merge されて
       いなくても正常である。
    e. **最終サマリ出力**: 全イテレーションの「指摘→対応」（判定役の仕分けと修正役の変更）、最後の検出


### PR DESCRIPTION
## Summary

`pr-review-automerge` 手順 3.d の終端確認コマンドを `gh pr view <PR> --json autoMergeRequest,merged`
から `--json autoMergeRequest,state` に直し、判定を `state == "MERGED"` にする。

## Why

`gh pr view --json` に `merged` というフィールドは存在せず、実行すると
`Unknown JSON field: "merged"` で失敗する（PR #73 の作業中に実測）。#73 で clean fallback 経路の
終端状態（`autoMergeRequest` が null のまま merge 済みになる）を確認できるよう 3.d を拡張した際に、
存在しないフィールド名を書いてしまっていた。

利用可能なフィールドのうち merge 済みを表すのは `state`（`MERGED`）と `mergedAt`（非 null）。
既に他所で `state` を参照している箇所は無いが、真偽が一目で分かる `state == "MERGED"` を採る。

## Refs

- #73 — clean fallback を入れた PR（この誤りの出所）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nygJ2Yixd73LC7VTUsZmB
