### PR TITLE
harness: gofmt gate と CI の新設、委譲成果物の置き場所 .delegate/ の規約化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          # Track the toolchain the module declares instead of pinning a second
+          # version here that would drift from go.mod.
+          go-version-file: src/claude-queue/go.mod
+      - run: make -C src/claude-queue test vet fmt-check
+
+  bash:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: run bin/ script tests
+        run: |
+          for t in test/*.test.sh; do bash "$t" || exit 1; done
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Files are listed one by one rather than globbed, for two reasons.
+      # `bin/claude-queue` is a build artifact (a gitignored Go binary), so
+      # `bin/*` would hand shellcheck something it cannot parse. And three legacy
+      # scripts -- bin/deploy.sh, bin/list-install.sh, bin/ghq-tmux-session --
+      # still carry warnings; cleaning those up is separate work, so the gate
+      # covers only what is already at zero. Adding a script means adding a line
+      # here.
+      - name: shellcheck
+        run: |
+          shellcheck -S warning \
+            bin/claude-reap-bg \
+            bin/claude-review \
+            bin/claude-stop-bg \
+            bin/claude-worktree \
+            bin/gh-automerge \
+            bin/gh-await-reviews \
+            bin/gh-list-threads \
+            bin/gh-pr-checks \
+            bin/gh-pr-comments \
+            bin/gh-resolve-thread \
+            bin/git-reap-gone \
+            bin/git-set-commit-sign \
+            test/claude-reap-bg.test.sh \
+            test/claude-review.test.sh \
+            test/claude-stop-bg.test.sh \
+            test/claude-worktree.test.sh \
+            test/gh-wrappers.test.sh \
+            test/git-reap-gone.test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches: [main]
 
+# Every job here only checks out and runs read-only test/lint commands, so pin
+# GITHUB_TOKEN to read-only rather than inheriting the repo/org default (which
+# can be write).
+permissions:
+  contents: read
+
 jobs:
   go:
     runs-on: ubuntu-latest

--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -65,6 +65,11 @@ set -euo pipefail
 # getting an answer promptly). `--seed` copies such files in, so the delegated
 # prompt can reference them relatively.
 #
+# The reverse direction has a reserved spot: `.delegate/` inside the worktree,
+# added to the repo's exclude at creation. A delegate that stops short leaves
+# what it wants to hand back there, where the delegator reads it by relative
+# path and `git-reap-gone` still sees a clean worktree.
+#
 # Usage:
 #   claude-worktree [--self] [--tmux] [--model <alias>] [--seed <path>]... <name> [-b <branch>] [-- <prompt...>]
 #
@@ -279,6 +284,48 @@ elif git -C "$repo_dir" show-ref --verify --quiet "refs/remotes/origin/${branch}
   git -C "$repo_dir" worktree add --track -b "$branch" "$wt_path" "origin/${branch}" >&2 # remote-only branch
 else
   git -C "$repo_dir" worktree add -b "$branch" "$wt_path" >&2 # new branch
+fi
+
+# Reserve `.delegate/` as the delegate's return channel: where it drops files it
+# wants to hand back (a PR body draft, findings, a generated artifact) when it
+# stops short and reports instead of finishing. It has to be somewhere the
+# delegator can read WITHOUT a permission prompt -- i.e. inside the worktree --
+# and it must not block cleanup, since a delegate that stopped short leaves the
+# directory behind for `git-reap-gone`.
+#
+# An exclude entry is what reconciles those two. `git-reap-gone` refuses a
+# worktree whose `git status --porcelain` is non-empty, so an untracked
+# `.delegate/` would make the branch un-reapable; excluded, status stays empty
+# and `git worktree remove` succeeds without --force. Doing it here rather than
+# in .gitignore keeps the convention out of every branch's committed tree -- it
+# is a property of delegation, not of the code.
+#
+# The entry lands in the REPO-WIDE exclude, not a per-worktree one. `git
+# rev-parse --git-path info/exclude` resolves to the common dir's
+# `.git/info/exclude` even when asked from inside a linked worktree, and that is
+# the only location git reads: writing the same pattern to
+# `.git/worktrees/<name>/info/exclude` leaves `check-ignore` reporting the path
+# as not ignored (measured on git 2.43.0). So the pattern is shared by every
+# checkout of the repo -- harmless, since `.delegate/` is a delegation-only
+# directory the delegator wants ignored on its side too.
+#
+# The path is still asked of git rather than assembled by hand: a linked
+# worktree's `.git` is a FILE, so a hand-built path does not resolve and would
+# fail while looking merely absent.
+#
+# Best-effort throughout: appending only when the entry is absent keeps a repeat
+# run from duplicating it (it accumulates in shared repo state otherwise), and
+# any failure here degrades to a warning rather than losing an otherwise-good
+# worktree.
+if exclude_path="$(git -C "$wt_path" rev-parse --path-format=absolute --git-path info/exclude 2>/dev/null)" \
+   && [ -n "$exclude_path" ] \
+   && mkdir -p "$(dirname "$exclude_path")" 2>/dev/null; then
+  if ! { [ -f "$exclude_path" ] && grep -qxF '/.delegate/' "$exclude_path"; }; then
+    printf '/.delegate/\n' >>"$exclude_path" \
+      || echo "claude-worktree: could not add /.delegate/ to $exclude_path" >&2
+  fi
+else
+  echo "claude-worktree: could not resolve the repo exclude; /.delegate/ not ignored" >&2
 fi
 
 # Seed the worktree. Copies stay untracked when the source is gitignored, so they

--- a/bin/claude-worktree
+++ b/bin/claude-worktree
@@ -321,6 +321,15 @@ if exclude_path="$(git -C "$wt_path" rev-parse --path-format=absolute --git-path
    && [ -n "$exclude_path" ] \
    && mkdir -p "$(dirname "$exclude_path")" 2>/dev/null; then
   if ! { [ -f "$exclude_path" ] && grep -qxF '/.delegate/' "$exclude_path"; }; then
+    # If the file already has content and its last byte isn't a newline,
+    # appending directly would glue our pattern onto the existing last line
+    # (e.g. an existing `/scratch/` with no trailing newline becomes
+    # `/scratch//.delegate/`), silently corrupting that entry and never
+    # registering ours. Insert the missing newline first so the append always
+    # lands as its own line.
+    if [ -s "$exclude_path" ] && [ "$(tail -c1 "$exclude_path" | wc -l)" -eq 0 ]; then
+      printf '\n' >>"$exclude_path"
+    fi
     printf '/.delegate/\n' >>"$exclude_path" \
       || echo "claude-worktree: could not add /.delegate/ to $exclude_path" >&2
   fi

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env sh
+#!/usr/bin/env bash
 
 # path/to/repo
 REPO_DIR=$(realpath $(dirname $(dirname $0)))

--- a/dot/claude/rules/worktree-scope.md
+++ b/dot/claude/rules/worktree-scope.md
@@ -179,9 +179,27 @@ claude-worktree [--self] [--tmux] [--model <alias>] [--seed <path>]... <name> [-
 
 seed したファイルは gitignore 済みなら worktree 内でも untracked のままなので、委譲先の commit には載らない。
 
+##### 戻り方向も同じ — 委譲先が返す成果物は `.delegate/` に置く
+
+上の 2 つの理由（伝播しない・承認で固まる）は、委譲先が**返す**ファイルにもそのまま当てはまる。委譲元が読めるのは worktree 内のファイルだけで、外に置かれたものは絶対パス Read の承認で固まるか、そもそも到達できない。
+
+したがって委譲先が中断・完了報告に添えるファイル（PR 本文ドラフト、調査結果、生成物）は、**worktree 内の `.delegate/` に置き、報告には相対パスで書く**。
+
+- `$CLAUDE_JOB_DIR` に置かない。job の削除で消えるので、報告を読む頃には無いことがある
+- `/tmp` に置かない。寿命が不定で、並行する別 job と名前が衝突しうる
+- `.delegate/` は `claude-worktree` が worktree 作成時に repo の exclude（`git rev-parse --git-path info/exclude` が返す `.git/info/exclude`）へ登録するので、置いたままでも `git status --porcelain` は空のままになる。§7 の `git-reap-gone` は worktree が clean であることを reap の条件にしており、`git worktree remove` も `--force` 無しで通る。つまり成果物を残したまま後片付けできる
+
+`.delegate/` を untracked のまま worktree 内に置く（exclude に入れない）と、この clean 判定が塞がって reap が skip される。逆に worktree の外へ出すと委譲元が読めない。exclude 済みの worktree 内、というのがその両方を同時に満たす唯一の場所である。
+
 <!-- 文脈: main checkout の gitignore 済み spec を絶対パスで参照する委譲プロンプトを渡したところ、
      委譲先が worktree 外 Read の permission prompt で最初の一歩から動けなくなった incident。
-     根本: 委譲先が承認なしに読めるのは新 worktree 内のファイルだけ。 -->
+     根本: 委譲先が承認なしに読めるのは新 worktree 内のファイルだけ。
+     戻り方向の節の由来: 同じ「置き場所」の問題が返す側で 2 回別々に事故になった。1 回目は
+     $CLAUDE_JOB_DIR/tmp に PR 本文ドラフトを置き、job 削除で消えるうえ委譲元からは worktree 外
+     Read の承認になった。2 回目は worktree 内に untracked で置き、git-reap-gone が
+     「worktree not clean」で skip した。exclude 登録を claude-worktree 側へ入れて両方を塞いだ。
+     なお per-worktree の exclude（.git/worktrees/<name>/info/exclude）は git 2.43.0 では
+     読まれない（check-ignore が not ignored を返す）ので、登録先は repo 共通の方になる。 -->
 
 連携の全体像（git worktree を土台に、既定の background 起動（`claude --bg`）と `--tmux` の tmux セッションへ分岐し、どちらも claude-queue が追跡するという層構成と、`claude-worktree` の位置づけ）は `docs/design/claude-tmux-worktree.md` を参照。
 

--- a/dot/claude/skills/implement-and-review/SKILL.md
+++ b/dot/claude/skills/implement-and-review/SKILL.md
@@ -51,6 +51,26 @@ description: worktree に委譲されたタスクを実装→merge で完遂す�
    自身が起こす headless pane の stdout を tee するだけで、委譲先の interactive セッションから
    呼ばれた skill の出力は載らない）。
 
+   **外部ツールの予約文字・エスケープ・quoting も同じ扱いにする**: 裏取りの対象は repo 内の
+   実装に限らない。plan が外部ツールへ渡す文字列の仕様に踏み込んでいたら（「この文字を
+   置換すればよい」「この形で quote する」等）、そのツールの一次情報（man / 公式リファレンス）を
+   引いてから書く。
+
+   ただし**範囲は限定する**。「外部ツールの挙動全般」まで広げると毎回 man を引くことになり、
+   コストが釣り合わない。絞る先は**間違えると黙って壊れるクラス** — エラーにならず、別のものと
+   して解釈されて通ってしまうものである。具体的には予約文字・エスケープ・quoting 規則・format
+   展開がこれに当たる。存在しない flag を渡すような誤りは即座にエラーで返ってくるので、この
+   裏取りの対象ではない（実行すれば分かる）。黙って別解釈されるものだけが、テストも gate も
+   すり抜けて後から発覚するため、書く前の確認に見合う。
+
+   由来: PR #67 のレビューで発覚した tmux window 名の実バグ。委譲プロンプトが置換対象として
+   挙げていた `.` `:` `~` をそのまま書き写し、tmux の FORMATS を一次情報で確認しなかった。
+   実際には `#` も予約されていて、`rename-window` / `new-window -n` に渡した名前は format 展開
+   される。結果 `#S` `#T` `#D` `#W` が session / pane / window に置換され、閉じない `#{` は
+   以降を丸ごと飲み込む。表示崩れに留まらず、`new-window -S` の dedupe が名前の不一致で破れ、
+   automatic-rename が永久に off になった。どれもエラーは出ず、名前が「通って」しまうのが
+   このクラスの怖さである。
+
    **委譲の上限**: Opus 5 は放っておくと過剰に委譲する（促進する指示が要ったのは 4.8 までで、
    5 では逆に上限が要る。出典: Anthropic 公式 Prompting Claude Opus 5「Controlling subagent
    spawning」節 <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5#controlling-subagent-spawning>）。

--- a/src/claude-queue/Makefile
+++ b/src/claude-queue/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install test clean fmt vet
+.PHONY: build install test clean fmt fmt-check vet
 
 REPO_ROOT := $(shell git rev-parse --show-toplevel)
 BIN := $(REPO_ROOT)/bin/claude-queue
@@ -20,6 +20,17 @@ clean:
 
 fmt:
 	go fmt ./...
+
+# `gofmt -l` exits 0 even when it lists unformatted files, so the gate is the
+# emptiness of its output, not its exit status. Names the offending files so the
+# fix is `gofmt -w` on exactly those.
+fmt-check:
+	@out="$$(gofmt -l .)"; \
+	if [ -n "$$out" ]; then \
+		echo "gofmt would rewrite these files:" >&2; \
+		echo "$$out" >&2; \
+		exit 1; \
+	fi
 
 vet:
 	go vet ./...

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -244,7 +244,18 @@ prefix (`C-q`) のあと `q` で popup → fzf → Enter でジャンプ。`Q` �
 
 ## Manual verification checklist
 
-PR 作成時に description に貼って確認：
+自動で回る gate は `.github/workflows/ci.yml` の 3 job（go / bash / shellcheck）。
+Go 側は手元でも同じものを回せる：
+
+```
+make -C src/claude-queue test vet fmt-check
+```
+
+`fmt-check` は `gofmt -l .` の出力が非空なら落ちる。`go vet` は整形崩れを見ないので、
+これが無いと未整形の Go が全 gate を通る。崩れたファイル名が出るので `gofmt -w` を当てる。
+残る 2 job は repo root の `test/*.test.sh` と `bin/` の shellcheck で、対象は workflow が持つ。
+
+以下は自動化できない、手で確かめる項目。PR 作成時に description に貼って確認：
 
 - [ ] `make install` で `bin/claude-queue` 生成、`claude-queue --version` が期待値
 - [ ] `claude-queue reset --force` で DB 削除、次 hook で再生成

--- a/src/claude-queue/README.md
+++ b/src/claude-queue/README.md
@@ -62,14 +62,16 @@ make install
 | 2 | ai-title（transcript 由来） | 40 桁 padding + truncate |
 | 3 | worktree 名 | 56 桁 padding + truncate |
 | 4 | age | 可変（短い） |
-| 5 | summary（何で止まっているか） | padding なし。行末まで |
+| 5 | summary（何で止まっているか） | padding なし。payload 由来は 150 桁で truncate |
 | 6〜9 | session_id / tmux_pane / cwd / transcript_path | 非表示 |
 
 ai-title を worktree 名より前に置くのは、同じ repo に複数 session が並ぶと worktree 名は全部
 同じで summary も全部 `working` になり、「何の作業か」を言えるのが title だけになるため。
 padding と truncate は表示幅（全角 2 桁）で数える — 日本語タイトルが多数派なので、バイト数
-基準の `%-40s` では列が揃わない。popup は client 幅の 80%（実測 ~290 桁）あり、前半 3 列で
-100 桁弱しか使わないので、残りは summary が使う。
+基準の `%-40s` では列が揃わない。行は tab 区切りのまま fzf に渡り、fzf 既定の `--tabstop=8` で
+展開されるので、2〜4 列目は 8 / 56 / 120 桁から始まる（padding 幅の 1+40+56 ではなく、各列の
+末尾で次の 8 の倍数まで送られるため）。popup は client 幅の 80%（実測 ~290 桁）あるので、
+summary が 150 桁使ってもなお収まる。
 
 ai-title は window 名と同じ transcript から取るが、**別関数**（`label.DisplayTitle`）で作る。
 window 名側の 16 桁切りと `-<id8>` 付与、`.` `:` `~` `#` の置換は tmux の `-t` target 構文と

--- a/test/claude-worktree.test.sh
+++ b/test/claude-worktree.test.sh
@@ -168,6 +168,26 @@ if grep -qxF '/scratch/' "$ex" && [ "$(grep -cxF '/.delegate/' "$ex")" -eq 1 ]; 
   echo "ok: an existing exclude entry is preserved"
 else echo "FAIL: existing exclude entry clobbered"; fail=1; fi
 
+# A pre-existing exclude with NO trailing newline is a distinct case from the one
+# above (that file already ends in "\n" from the earlier append). A hand-written
+# `.git/info/exclude` commonly lacks a final newline, and appending straight onto
+# that glues our pattern onto the last line -- e.g. `/scratch/` becomes
+# `/scratch//.delegate/`, which is neither the original entry nor a working
+# `/.delegate/` line. Use a dedicated repo so the accumulated exclude state from
+# the tests above (which already has a trailing newline) can't mask this.
+noeolrepo="$tmp/noeolrepo"
+mkdir -p "$noeolrepo"
+git -C "$noeolrepo" init -q
+git -C "$noeolrepo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+mkdir -p "$noeolrepo/.git/info"
+printf '/scratch/' >"$noeolrepo/.git/info/exclude" # deliberately no trailing newline
+
+(cd "$noeolrepo" && "$wt" noeolwt) >/dev/null 2>&1; rc=$?
+ex2="$noeolrepo/.git/info/exclude"
+if [ "$rc" -eq 0 ] && [ "$(grep -cxF '/scratch/' "$ex2")" -eq 1 ] && grep -qxF '/.delegate/' "$ex2"; then
+  echo "ok: appending to a non-newline-terminated exclude preserves the existing entry"
+else echo "FAIL: exclude corrupted: $(cat "$ex2" 2>/dev/null)"; fail=1; fi
+
 # --- default seeds declared in .claude/worktree-seed ---------------------------
 # A repo names the gitignored files a delegate cannot work without (the config
 # supplying its GitHub token, a local .env) in .claude/worktree-seed, and they

--- a/test/claude-worktree.test.sh
+++ b/test/claude-worktree.test.sh
@@ -115,6 +115,59 @@ if [ "$rc" -eq 0 ] && [ "$rc2" -eq 0 ] \
   echo "ok: repeated --seed and directory seeds replace rather than nest on reseed"
 else echo "FAIL: multi/dir seed rc=$rc rc2=$rc2 nested?=$([ -e "${cwdrepo}_multiseed/docs/specs/specs" ] && echo yes || echo no)"; fail=1; fi
 
+# --- .delegate/ return channel -------------------------------------------------
+# `.delegate/` is where a delegate leaves files it wants to hand back. It has to
+# be readable from the worktree by relative path AND invisible to git, or an
+# untracked directory would make `git-reap-gone` skip the worktree as unclean.
+# The exclude entry is what buys the second half.
+#
+# The entry belongs in the repo-wide `.git/info/exclude` (the common dir's),
+# which is what --git-path returns from inside a linked worktree AND the only
+# copy git reads: the same pattern in `.git/worktrees/<name>/info/exclude`
+# leaves the path un-ignored (git 2.43.0). Asserting the resolved location, not
+# just the entry, is what would catch a "fix" that moves the write to the
+# per-worktree path -- where it would stop working without failing.
+(cd "$cwdrepo" && "$wt" delegatewt) >/dev/null 2>&1; rc=$?
+ex="$(git -C "${cwdrepo}_delegatewt" rev-parse --path-format=absolute --git-path info/exclude 2>/dev/null)"
+if [ "$rc" -eq 0 ] && [ "$ex" = "$cwdrepo/.git/info/exclude" ] && grep -qxF '/.delegate/' "$ex"; then
+  echo "ok: worktree creation adds /.delegate/ to the repo-wide exclude"
+else echo "FAIL: exclude entry missing rc=$rc path=${ex:-<unresolved>}"; fail=1; fi
+
+# The point of the entry: a file dropped in .delegate/ leaves `status --porcelain`
+# empty, which is exactly the predicate git-reap-gone gates on. Guard on the file
+# existing so this cannot pass vacuously.
+mkdir -p "${cwdrepo}_delegatewt/.delegate"
+echo "pr body draft" >"${cwdrepo}_delegatewt/.delegate/pr-body.md"
+st="$(git -C "${cwdrepo}_delegatewt" status --porcelain 2>/dev/null)"
+if [ -f "${cwdrepo}_delegatewt/.delegate/pr-body.md" ] && [ -z "$st" ]; then
+  echo "ok: files under .delegate/ stay invisible to git status"
+else echo "FAIL: .delegate/ is visible to git: ${st:-<file missing>}"; fail=1; fi
+
+# ...and the worktree is still removable without --force, which is the other half
+# of what git-reap-gone needs.
+git -C "$cwdrepo" worktree remove "${cwdrepo}_delegatewt" >/dev/null 2>&1; rc=$?
+if [ "$rc" -eq 0 ]; then
+  echo "ok: a worktree holding .delegate/ files is removable without --force"
+else echo "FAIL: worktree remove refused a .delegate/-holding worktree rc=$rc"; fail=1; fi
+
+# Re-running over an existing worktree dir must not append a second copy of the
+# entry (the script reuses the dir rather than recreating it).
+(cd "$cwdrepo" && "$wt" dupwt) >/dev/null 2>&1
+(cd "$cwdrepo" && "$wt" dupwt) >/dev/null 2>&1; rc=$?
+ex="$(git -C "${cwdrepo}_dupwt" rev-parse --path-format=absolute --git-path info/exclude 2>/dev/null)"
+n="$(grep -cxF '/.delegate/' "$ex" 2>/dev/null || echo 0)"
+if [ "$rc" -eq 0 ] && [ "$n" -eq 1 ]; then
+  echo "ok: a repeat run leaves exactly one /.delegate/ entry"
+else echo "FAIL: exclude entry count=$n rc=$rc"; fail=1; fi
+
+# An exclude the repo already wrote must survive: the script appends, never
+# rewrites. Losing a user's pattern would be a silent regression.
+printf '/scratch/\n' >>"$ex"
+(cd "$cwdrepo" && "$wt" dupwt) >/dev/null 2>&1
+if grep -qxF '/scratch/' "$ex" && [ "$(grep -cxF '/.delegate/' "$ex")" -eq 1 ]; then
+  echo "ok: an existing exclude entry is preserved"
+else echo "FAIL: existing exclude entry clobbered"; fail=1; fi
+
 # --- default seeds declared in .claude/worktree-seed ---------------------------
 # A repo names the gitignored files a delegate cannot work without (the config
 # supplying its GitHub token, a local .env) in .claude/worktree-seed, and they


### PR DESCRIPTION

## Summary

ハーネス整備 4 件。Go の実装コード（`src/claude-queue/**/*.go`）は変更していない。

### A. format gate と CI（`c58a705`）

この repo には CI が無く、gate は手元の `make test vet` だけだった。`go vet` は gofmt 崩れを
見ないので、未整形の Go が全 gate を green で通る（実際に `picker_test.go` が崩れたまま通った）。

- `src/claude-queue/Makefile` に `fmt-check` を追加。`gofmt -l .` は崩れたファイルを列挙しても
  exit 0 なので、出力の非空を判定して落とす
- `.github/workflows/ci.yml` を新設。`pull_request` と `push: branches: [main]` で go / bash /
  shellcheck の 3 job
- `src/claude-queue/README.md` の verification checklist 冒頭に、自動 gate と手元での回し方を追記

shellcheck の対象は glob ではなく明示列挙にした。`bin/claude-queue` は gitignore 済みのビルド
成果物（Go バイナリ）で glob が拾うと parse に失敗し、legacy 3 本（`bin/deploy.sh` /
`bin/list-install.sh` / `bin/ghq-tmux-session`）には既存の warning が残っているため。legacy の
整理は別作業として本 PR では触れていない。列挙対象は warning 0 のもののみ。

### B. 委譲先が返す成果物の置き場所（`1e2e06c`）

`worktree-scope.md` §6 の「委譲プロンプトはファイルシステム的に自己完結させる」は**入力**方向
しか定めておらず、委譲先が blocked になったときに**返す**成果物の置き場所が未定義だった。実際に
2 回別々の形で事故になっている。`$CLAUDE_JOB_DIR/tmp` に置くと job 削除で消えるうえ委譲元からは
worktree 外 Read の承認になり、worktree 内に untracked で置くと `git-reap-gone` が
「worktree not clean」で skip する。

`bin/claude-worktree` が worktree 作成時に `/.delegate/` を exclude へ登録することで、worktree 内
に置いたまま `git status --porcelain` が空に保たれ、reap の clean 判定も `git worktree remove`
（`--force` 無し）も通る。rule 側にも戻り方向の規約として追記した。

### C. 外部ツールの挙動の裏取り（`460c20a`）

`implement-and-review` 手順 2 の「plan 内の事実主張は書き写す前に裏を取る」を、外部ツールの
予約文字・エスケープ・quoting・format 展開まで広げた。範囲は「間違えると黙って壊れる」クラスに
限定している（存在しない flag のような誤りは実行すれば即エラーで返るので対象外）。

### D. doc の訂正と shebang の実バグ（`2adfba4`）

- `bin/deploy.sh` の 1 行目 `#/usr/bin/env sh` は `#!` になっておらず shebang として機能して
  いなかった。`declare -A`（2 箇所）と `function`（1 箇所）を使うので `#!/usr/bin/env bash` に
  修正。bash から呼ぶと bash 自身が拾うため露見していなかった。この 1 行以外の deploy.sh の
  warning（SC2045 / SC2046 / SC2034 等）は別作業として触れていない
- README picker 節の 2 箇所を訂正。行は tab 区切りのまま fzf に渡り既定の `--tabstop=8` で
  展開されるので、列開始位置は padding 幅の和（`1+40+56`）ではなく 8 / 56 / 120 桁になる。
  summary も「行末まで」ではなく `summaryWidth = 150` 桁で truncate される

## 委譲時の設計からの逸脱 1 件

委譲プロンプトは exclude の登録先を「その worktree 専用の exclude」と書いていたが、これは
成立しない。git 2.43.0 で実測したところ、`.git/worktrees/<name>/info/exclude` に同じ pattern を
書いても `git check-ignore` は not ignored を返す（git が読むのは common dir の
`.git/info/exclude` のみ）。

委譲プロンプトの根拠として添えられていた実測は、ignore の出所を切り分けていなかった。probe
repo は直前の手順で `.gitignore` に `.delegate/` を commit しており、`wt2` はそれを checkout
しているので、per-worktree の exclude を書かなくても `git status --porcelain` は空になる。
`.delegate/` 配下のファイル自体は作られていたが、空だった理由が exclude なのか commit 済みの
`.gitignore` なのかを区別できない形だった。

一方、プロンプトが名指ししていたコマンド `git rev-parse --git-path info/exclude` は linked
worktree から問うても common dir 側を返すため、そのコマンドを使う実装自体は正しく動く。実装は
プロンプトどおり（コマンド指定・パスを文字列で組み立てない・best-effort）で、記述だけを実測に
合わせて「repo 共通の exclude」に直した。効果の差は scope のみで、`.delegate/` が repo 全体で
ignore される（委譲元側でも ignore されるので実害は無い）。

## 検証

```
make -C src/claude-queue test vet fmt-check        # 全 package ok / vet 無出力 / fmt-check 通過
for t in test/*.test.sh; do bash "$t"; done        # 6 本すべて PASS
shellcheck -S warning <CI の列挙対象 18 ファイル>   # warning 0
```

`fmt-check` の判別力も確認済み。`internal/picker/picker.go` に整形崩れを入れると
`gofmt would rewrite these files: internal/picker/picker.go` を出して exit 1、戻すと通る
（同じ崩れで `go vet` は通る＝この gate が塞いだ穴）。

`.delegate/` の 5 test も同様に、`claude-worktree` の exclude 追加を無効化すると全部落ちる
ことを確認した（うち `git worktree remove` は rc=128 で拒否され、exclude が無い場合の実害を
実測で裏付けている）。

## Notes

レビュー時の参考として、本 PR のスコープ外で気づいた点を報告に回している（この PR では直して
いない）。
