### PR TITLE
fix(claude-digest): 日報の到達手段を reach 別に書き分ける

### DIFF
--- a/bin/claude-digest
+++ b/bin/claude-digest
@@ -434,7 +434,7 @@ done
 # --- reachability -----------------------------------------------------------
 
 roster="$(claude agents --json 2>/dev/null || echo '[]')"
-declare -A s_reach=() s_state=() s_cwd=()
+declare -A s_reach=() s_state=() s_cwd=() s_kind=()
 
 for uuid in "${session_ids[@]}"; do
   live="$(jq -c --arg id "$uuid" '[.[] | select(.sessionId == $id)] | first // empty' \
@@ -446,9 +446,14 @@ for uuid in "${session_ids[@]}"; do
     if [ -n "$c" ] && [ -d "$c" ]; then alive_cwd="$c"; break; fi
   done <<<"${s_pairs[$uuid]}"
   s_cwd[$uuid]="$alive_cwd"
+  s_kind[$uuid]=""
   if [ -n "$live" ]; then
     s_reach[$uuid]="LIVE"
     s_state[$uuid]="$(jq -r '.state // .status // "-"' <<<"$live")"
+    # background vs. interactive decides how a live session is reached at all:
+    # `claude attach` is background-only and fails with "No job matching" on an
+    # interactive one (see docs/design/claude-digest.md).
+    s_kind[$uuid]="$(jq -r '.kind // ""' <<<"$live")"
   elif [ -n "$alive_cwd" ]; then
     s_reach[$uuid]="RESUMABLE"; s_state[$uuid]="-"
   else
@@ -609,7 +614,21 @@ linked=" "
       # `claude --resume <unknown-uuid>` silently opens an empty new session
       # instead of failing, so an unchecked resume line would be a trap.
       RESUMABLE) printf 'RESUME: claude --resume %s   (cwd: %s)\n' "$uuid" "${s_cwd[$uuid]}" ;;
-      LIVE)      printf 'RESUME: claude-queue picker（C-q q）\n' ;;
+      # `C-q q` is never offered here. That binding passes --repo-scope, so the
+      # picker it opens lists only the repo of the pane it was opened from --
+      # and the digest is a cross-repo index, so following it from any one pane
+      # hides most of what the digest just ranked. `C-q Q` is the unscoped one.
+      # A background session is reached directly instead, by its short id.
+      # Searching by title needs a title: "(no title)" is the placeholder the
+      # collection step substitutes, so it is a search key that matches nothing.
+      LIVE)
+        if [ "${s_kind[$uuid]}" = "background" ]; then
+          printf 'RESUME: claude attach %s\n' "${uuid:0:8}"
+        elif [ "${s_title[$uuid]}" = "(no title)" ]; then
+          printf 'RESUME: claude-queue picker（C-q Q）\n'
+        else
+          printf 'RESUME: C-q Q →「%s」で検索\n' "${s_title[$uuid]}"
+        fi ;;
       CWD_GONE)  printf 'RESUME: 到達不可（cwd 消滅）\n' ;;
     esac
     while IFS=$'\t' read -r r pr subject mine; do
@@ -705,11 +724,19 @@ if { cat <<'EOP'
 ### <SHORT>  <TITLE>        [<REACH>]
 着地  <repo #PR 要約 (commit N)>   ※無ければ「なし」
 残り  <OPEN_BRANCH（repo 付き）と SUMMARY の「残っているもの」を統合した 1〜3 行>   ※無ければ「なし」
-→ <RESUME>   ※REACH が RESUMABLE のときだけ書く
+→ <RESUME>   ※RESUME 行があるときだけ書く（CWD_GONE には無い）
 
 ## 紐付かなかった着地
 ## 片付け（git-reap-gone 対象）
 ## 到達不可（記録のみ）
+
+`→` 行は事実ブロックの `RESUME:` の後ろを**一字一句そのまま**写す。言い換えない。
+到達手段は reach で 3 通りに分かれており、どれもそのまま打てる／検索できる形で既に
+書いてある。書き換えるとコマンドも検索キーも使えなくなる。
+
+- `claude attach <short-id>`         … LIVE な background session
+- `C-q Q →「<title>」で検索`         … LIVE な interactive session
+- `claude --resume <uuid>  (cwd: …)` … RESUMABLE
 
 --- 事実ブロック ---
 EOP

--- a/docs/design/claude-digest.md
+++ b/docs/design/claude-digest.md
@@ -347,18 +347,31 @@ OPEN   6 件  origin/main に未統合 → session の「残り」として出�
 
 | 分類 | 条件 | 日報に書く到達手段 |
 |---|---|---|
-| LIVE | roster に `sessionId` がある | claude-queue picker（`C-q q`） |
+| LIVE / roster の `kind` が `background` | roster に `sessionId` がある | `claude attach <short-id>` |
+| LIVE / それ以外（interactive） | 同上 | `C-q Q →「<title>」で検索` |
 | RESUMABLE | roster に無いが cwd が実在 | `claude --resume <uuid>` |
 | CWD_GONE | cwd が消滅 | 到達不可。記録のみ |
 
 実測（2026-09-08 の cli 30 session）: LIVE 10 / RESUMABLE 17 / CWD_GONE 3。
 
+LIVE を `kind` で割るのは、`claude attach` が background 専用で、interactive に投げると
+`No job matching` で落ちるため（`worktree-scope.md` §6 / §8）。`<short-id>` は `sessionId` の
+先頭 8 文字で、`claude-worktree` が起動時に出すものと同じ。
+
+interactive 側の案内は **`C-q Q`（scope なし）であって `C-q q` ではない。** `C-q q` は
+`--repo-scope` 付きで popup を開いた pane の repo だけを一覧するので、repo 横断で session を
+並べる日報の導線としては、ほとんどの行に到達できない。picker は title 列を持つ fzf なので、
+日報の見出しの title がそのまま絞り込みキーになる（picker の title も日報の title も出所は
+transcript の `ai-title` で同一）。title が `(no title)` の session は検索キーにならないため、
+`C-q Q` の案内だけを書く。
+
 **resume コマンドは transcript の実在を確認してから書く。** `claude --resume <存在しない uuid>`
 はエラーにならず、**その id で空の新規 session を立ててしまう**。日報は transcript を読んで
 uuid を得ているので実在は構造的に保証されるが、この性質のせいで「間違った resume 行」は
 静かに壊れる（起動して、しかし何も残っていない）ため、経路として明示しておく。
-`claude attach` は background 専用で、interactive に投げると `No job matching` で落ちる
-（`worktree-scope.md` §6 / §8）。
+
+`→` 行は段2 の LLM が書くので、prompt 側にも上の分岐を書き、事実ブロックの `RESUME:` 行を
+そのまま写させる。言い換えられるとコマンドも検索キーも使えなくなる。
 
 ラベルは `ai-title` entry（`{"type":"ai-title","aiTitle":"..."}`）の最後の値。実測で 30 session
 中 28 で取れる。取れないものは最初の人間プロンプトの先頭 60 文字で代用する。
@@ -377,6 +390,7 @@ session をキーにした 1 本のリスト。優先度順に並べ、「残り
       eversteel-backend-api #6844 ci(ncs-gateway): bare 名 ECR に multi-arch イメージを push… (13)
 残り  eversteel-backend-api agent/fix/ncs-gateway-rtcp-bye-adr-playbook が ahead=4 で未統合
       委譲先が「ADR は follow-up に分離」と報告、未着手
+→ C-q Q →「mukoyama_kuki ncs-gateway RTSP停止」で検索
 
 ### f2a48cfd  remote assessment access control          [RESUMABLE]
 着地  なし

--- a/test/claude-digest.test.sh
+++ b/test/claude-digest.test.sh
@@ -264,6 +264,17 @@ jq -cn '{type:"user", entrypoint:"cli", isSidechain:false, origin:{kind:"human"}
          message:{role:"user", content:"first prompt of an untitled session"}}' \
   >"$projects/-proj-a/$bare.jsonl"
 
+# UNTITLED: neither an ai-title nor a human prompt, so the title falls all the
+# way through to the "(no title)" placeholder. A live session like this cannot
+# be found in the picker by title, so its reach line must not offer one as a
+# search key.
+untitled=bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+jq -cn --arg cwd "$repo_a" \
+  '{type:"assistant", entrypoint:"cli", isSidechain:false,
+    timestamp:"2026-03-01T03:00:00.700Z", cwd:$cwd, gitBranch:"main",
+    message:{role:"assistant", content:[{type:"text", text:"no human turn here"}]}}' \
+  >"$projects/-proj-a/$untitled.jsonl"
+
 # PLAIN: lives in the repo whose user.email is not a noreply address. Its
 # second entry mentions repo_b's "feature/open", which collides by name with
 # repo_a's -- see the feature/open branch fixture in repo_b above.
@@ -485,6 +496,39 @@ echo '[]' >"$sandbox/roster.json"
 check "a session with a surviving cwd is offered --resume with its own uuid" \
   "$(if grep -qF "RESUME: claude --resume $early   (cwd: $repo_a)" <<<"$d1"
      then echo 0; else echo 1; fi)"
+
+# How a LIVE session is reached depends on its roster `kind`: `claude attach`
+# is background-only, and an interactive one is found in the unscoped picker by
+# title. One roster covers all three live shapes at once.
+jq -cn --arg bg "$plain" --arg ia "$early" --arg nt "$untitled" \
+  '[{sessionId:$bg, kind:"background", status:"idle"},
+    {sessionId:$ia, kind:"interactive", status:"working"},
+    {sessionId:$nt, kind:"interactive", status:"working"}]' >"$sandbox/roster.json"
+dlive="$(run 2026-03-01)"
+
+check "a live background session is reached by claude attach with its short id" \
+  "$(if grep -qF "RESUME: claude attach ${plain:0:8}" \
+       <<<"$(extract_session "$dlive" "$plain")"
+     then echo 0; else echo 1; fi)"
+check "a live interactive session is reached through C-q Q, searched by its title" \
+  "$(if grep -qF 'RESUME: C-q Q →「early session」で検索' \
+       <<<"$(extract_session "$dlive" "$early")"
+     then echo 0; else echo 1; fi)"
+# "(no title)" is the placeholder for a session that has neither an ai-title
+# nor a human prompt. Handing it to the picker's filter matches nothing, so the
+# line must stop at the binding.
+check "a live session with no title is sent to C-q Q without a search key" \
+  "$(if grep -qF 'RESUME: claude-queue picker（C-q Q）' \
+       <<<"$(extract_session "$dlive" "$untitled")" \
+       && ! grep -q 'で検索' <<<"$(extract_session "$dlive" "$untitled")"
+     then echo 0; else echo 1; fi)"
+# `C-q q` opens the picker with --repo-scope, which lists only the repo of the
+# pane it was opened from. The digest ranks sessions across repos, so that
+# binding drops most of them -- it must never be the advice, for any reach.
+check "no reach line ever offers the repo-scoped C-q q binding" \
+  "$(if ! grep -qF 'C-q q' <<<"$dlive" && ! grep -qF 'C-q q' <<<"$d1"
+     then echo 0; else echo 1; fi)"
+echo '[]' >"$sandbox/roster.json"
 
 # --- generate: idempotency and the two stages -------------------------------
 : >"$sandbox/calls"


### PR DESCRIPTION
## Summary

`bin/claude-digest` の日報が LIVE な session に対して一律で出していた到達手段
`→ claude-queue picker（C-q q）` を、reach 別に書き分ける。

| reach | これまで | これから |
|---|---|---|
| LIVE / roster の `kind` が `background` | `claude-queue picker（C-q q）` | `claude attach <short-id>` |
| LIVE / それ以外（interactive） | 同上 | `C-q Q →「<title>」で検索` |
| LIVE / interactive で title が `(no title)` | 同上 | `claude-queue picker（C-q Q）`（検索キー無し） |
| RESUMABLE | `claude --resume <uuid>  (cwd: …)` | 変更なし |
| CWD_GONE | `到達不可（cwd 消滅）` | 変更なし |

- reachability の処理で既に引いている roster entry から `kind` を読み、`s_kind` に持つ
- 段2 prompt にも同じ分岐を書き、事実ブロックの `RESUME:` 行を**一字一句そのまま**写させる
  （`→` 行を書くのは段2 の LLM なので、言い換えられるとコマンドも検索キーも使えなくなる）
- `docs/design/claude-digest.md` の「到達手段」節と出力サンプルを同じ形に揃える

## Why

`C-q q` は `dot/tmux.conf` で `claude-queue picker --repo-scope` に束ねられており、popup を
開いた pane の repo だけを一覧する。日報は repo をまたいで session を優先度順に並べるので、
どの pane から辿っても大半の行に到達できない。導線が repo で切れていた。scope 無しの方は
同ファイル次行の `C-q Q`（`--show-working --show-stale --show-resumable`）。

加えて、案内に session を特定する手掛かりが無く、8 桁の short-id で識別させていた。picker は
title 列を持つ fzf（`src/claude-queue/internal/picker/picker.go` の `FormatLine`）で、その
title と日報の title はどちらも transcript の `ai-title` が出所なので、日報の見出しが
そのまま絞り込みキーになる。`(no title)` は収集側が埋める placeholder で、picker の filter に
渡しても何にもマッチしないため、その場合は binding だけを案内する。

background を `claude attach` に分けるのは、`claude attach` が background 専用で interactive に
投げると `No job matching` で落ちるため（`worktree-scope.md` §6 / §8）。`<short-id>` は
`sessionId` の先頭 8 文字で、`claude-worktree` が起動時に出すものと同じ。

## 判別力の確認（evidence-over-guesswork.md §4）

追加した 4 件のテストについて、新コード側を 1 箇所ずつ変異させて、テストがそれを捕まえる
ことを確認した。変異ごとに `bash test/claude-digest.test.sh` は exit 1。

| 変異した箇所 | 落ちたテスト |
|---|---|
| M1: LIVE 分岐を丸ごと修正前の `printf 'RESUME: claude-queue picker（C-q q）\n'` へ戻す | background の attach / interactive の C-q Q+title / `(no title)` / `C-q q` 不在ガード（4 件すべて） |
| M2: `[ "${s_kind[$uuid]}" = "background" ]` を `false` にして background 分岐を殺す | background の attach |
| M3: `[ "${s_title[$uuid]}" = "(no title)" ]` を `false` にして placeholder ガードを殺す | `(no title)` の案内 |
| M4: interactive 分岐の `C-q Q` を `C-q q` に書き換える | interactive の C-q Q+title / `C-q q` 不在ガード |
| M5: roster から `kind` を読まず `s_kind` を常に空にする | background の attach |

`(no title)` のテストは fixture が空振りしていない：新規に `ai-title` も人間プロンプトも
持たない session（`untitled`）を足しており、title が付いていれば
`RESUME: claude-queue picker（C-q Q）` の存在アサートが落ちる。

## 検証

- `bash test/claude-digest.test.sh` — 57 件 ok / FAIL 0、exit 0
- `test/*.test.sh` 9 本すべて PASS
- `.github/workflows/ci.yml` の shellcheck job と同じファイル一覧で `shellcheck -S warning` — 指摘なし

## Refs

- `dot/tmux.conf:40-41`（`C-q q` = `--repo-scope` / `C-q Q` = scope 無し）
- `src/claude-queue/internal/picker/picker.go` の `FormatLine`（title 列）
- `dot/claude/rules/worktree-scope.md` §6 / §8（`claude attach` は background 専用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
