### PR TITLE
fix(claude-digest): 素材ゼロの session を落とし、claude -p を --restricted で呼ぶ

### DIFF
--- a/bin/claude-digest
+++ b/bin/claude-digest
@@ -229,6 +229,19 @@ while IFS= read -r file; do
   # sdk-py sessions are the security-review skill talking to itself through the
   # SDK, not work anybody did. Only the CLI entrypoint is a real session.
   [ "$(jq -r '.entrypoint // ""' <<<"$rec")" = "cli" ] || continue
+  # A session whose transcript carries no human prompt and no assistant text
+  # has nothing to triage, so it is dropped here rather than listed with a
+  # placeholder -- nine such sessions once took twenty-seven lines of a digest.
+  # The test is the stage 1 material itself, extracted here and reused there,
+  # never a proxy like "has a title" or "has a first prompt": a session that
+  # only ever got assistant text has neither and would be wrongly dropped.
+  #
+  # The extract goes to the mktemp scratch dir, never $digest_dir, so --dry-run
+  # keeps its promise to write nothing.
+  mat="$work/$uuid.txt"
+  jq -rn --arg day "$day" -f "$work/material.jq" "$file" 2>/dev/null \
+    | head -c 400000 >"$mat" || true
+  [ -s "$mat" ] || continue
 
   seen_uuid="$seen_uuid$uuid "
   session_ids+=("$uuid")
@@ -504,13 +517,11 @@ for uuid in "${session_ids[@]}"; do
 
   out="$digest_dir/$day/$uuid.md"
   if [ ! -s "$out" ]; then
+    # Written during collection, and non-empty for every session that got this
+    # far -- an empty one is what dropped the session from session_ids.
     mat="$work/$uuid.txt"
-    jq -rn --arg day "$day" -f "$work/material.jq" "${s_file[$uuid]}" 2>/dev/null \
-      | head -c 400000 >"$mat" || true
-    if [ ! -s "$mat" ]; then
-      printf -- '---\nends_with_question: no\ndelegate_incomplete: no\n---\n## 着地したもの\nなし\n## 残っているもの\nなし\n## 一言\n本文素材のないセッション。\n' >"$out"
-    elif { stage1_prompt; printf '\n### セッション: %s\n\n' "${s_title[$uuid]}"; cat "$mat"; } \
-           | claude -p --tools "" >"$out.part" 2>"$work/$uuid.err"; then
+    if { stage1_prompt; printf '\n### セッション: %s\n\n' "${s_title[$uuid]}"; cat "$mat"; } \
+         | claude -p --tools "" >"$out.part" 2>"$work/$uuid.err"; then
       mv "$out.part" "$out"
     else
       echo "claude-digest: summarising $uuid failed; see $work/$uuid.err" >&2

--- a/bin/claude-digest
+++ b/bin/claude-digest
@@ -38,6 +38,16 @@ set -euo pipefail
 # both are pure text-in, text-out summarisation -- so removing the entire tool
 # surface is strictly safer than trying to deny-list it.
 #
+# Both also pass --restricted, which is what keeps the digest's own LLM calls
+# out of claude-queue's resumable list. Each -p call is a child session that
+# the hooks in ~/.claude/settings.json record, and it closes with reason
+# "other", so a morning's run leaves dozens of entries reading as sessions cut
+# short (41 of 43 on 2026-09-11). --restricted ignores the user, project and
+# local settings files, so claude-queue's own hooks are not loaded for these
+# calls and the digest stops filing them. (--bare has the same effect but
+# forces ANTHROPIC_API_KEY-only authentication, which this login does not
+# have.) The tools --restricted drops are already gone via --tools "".
+#
 # Usage:
 #   claude-digest                       show the most recent digest
 #   claude-digest <YYYY-MM-DD>          show that day's digest
@@ -521,7 +531,7 @@ for uuid in "${session_ids[@]}"; do
     # far -- an empty one is what dropped the session from session_ids.
     mat="$work/$uuid.txt"
     if { stage1_prompt; printf '\n### セッション: %s\n\n' "${s_title[$uuid]}"; cat "$mat"; } \
-         | claude -p --tools "" >"$out.part" 2>"$work/$uuid.err"; then
+         | claude -p --tools "" --restricted >"$out.part" 2>"$work/$uuid.err"; then
       mv "$out.part" "$out"
     else
       echo "claude-digest: summarising $uuid failed; see $work/$uuid.err" >&2
@@ -725,7 +735,7 @@ if { cat <<'EOP'
 --- 事実ブロック ---
 EOP
      cat "$facts"
-   } | claude -p --tools "" >"$out.part" 2>"$work/reduce.err"; then
+   } | claude -p --tools "" --restricted >"$out.part" 2>"$work/reduce.err"; then
   mv "$out.part" "$out"
 else
   echo "claude-digest: reduce failed; see stderr below" >&2

--- a/docs/design/claude-digest.md
+++ b/docs/design/claude-digest.md
@@ -124,6 +124,19 @@ origin == null                     238   tool_result 等
 **jq の落とし穴**: `.message.content[]?` の中へ入ると `.sessionId` などトップレベルの
 フィールドは null になる。必要なら `.sessionId as $s |` で先に束縛する。
 
+### 素材ゼロの session は一覧に載せない
+
+上の表で 1 件も採れなかった session は、`session_ids` を確定する段階で落とす。事実ブロックにも
+日報にも一切現れない。`system` / `attachment` / `last-prompt` しか持たない 10 行程度の
+transcript が実際に生まれ、確認すべきことが何も無いのに「確認すべき session」として並ぶため。
+
+判定は**段1 が使う `material.jq` そのもの**で、その出力が空なら落とす。`title` の有無や
+`first_prompt` の有無で代用しない — assistant の発話だけを持つ session はそのどちらも欠くが
+素材はあるので、代用すると誤って落ちる。
+
+抽出は収集ループの中で作業用 `mktemp -d` へ 1 度だけ行い、段1 はその結果を読み直す。書き出し先が
+`$CLAUDE_DIGEST_DIR` の外なので、`--dry-run` の「何も書かない」は保たれる。
+
 ### 素材量（2026-09-08、cli セッションのみ）
 
 ```
@@ -500,7 +513,7 @@ command not found になるだけで判別にならない）。
 | `author_pattern` から数値 ID 導出を外す | a noreply address yields the numeric-id author pattern |
 | `blocked` の +4 を外す | a blocked session sorts to the top |
 | 着地 ∩ 言及の交差をやめる | a landed PR nobody mentioned goes to the unlinked list, named with its repo |
-| 段1 の中間サマリ再利用をやめる | re-running a day reuses the intermediates and only redoes the reduce |
+| 段1 の中間サマリ再利用をやめる | re-running a day reuses the intermediates and only redoes the reduce || 素材ゼロ session の除外を外す | a session with no summarisable material is dropped from the facts block（対照の「…while a session of the same day that has material is still listed」と「a session with only assistant text, and no human prompt, is kept」は通り続ける） |
 
 `-F` の判別には BRE 前提の fixture が要る。手元の git は `grep.patternType` 未設定で
 `--author` が BRE 既定になるため、`+` はリテラルであり、ERE 前提の偽 author

--- a/docs/design/claude-digest.md
+++ b/docs/design/claude-digest.md
@@ -54,6 +54,15 @@ claude-digest --generate --dry-run [<date>]
 （選択理由は `bin/claude-digest` の `show()` 内コメントを参照）。ページャの選択は
 claude-digest 側に一本化しており、`dot/tmux.conf` の binding はページャを指定しない。
 
+### LLM 呼び出しは `--restricted`
+
+段1・段2 とも `claude -p --tools "" --restricted` で呼ぶ。`--tools ""` は要約が純粋な
+text-in / text-out であり、読ませる transcript に第三者由来のテキストが混ざるためで、
+`--restricted` は user / project / local の settings を読ませないためである。読ませると
+claude-queue の hook が子 session を 1 本ずつ登録し、終了理由が `other` になるので、
+resumable 一覧（`C-q Q`）が「途中で切られた session」で埋まる（2026-09-11 朝は 43 本中 41 本）。
+`--bare` も hook を止めるが認証を `ANTHROPIC_API_KEY` のみに強制するため使えない。
+
 ## 日の境界は JST 05:00
 
 深夜作業を前日側に落とすため、日は 05:00 JST から 05:00 JST までとする。
@@ -513,7 +522,9 @@ command not found になるだけで判別にならない）。
 | `author_pattern` から数値 ID 導出を外す | a noreply address yields the numeric-id author pattern |
 | `blocked` の +4 を外す | a blocked session sorts to the top |
 | 着地 ∩ 言及の交差をやめる | a landed PR nobody mentioned goes to the unlinked list, named with its repo |
-| 段1 の中間サマリ再利用をやめる | re-running a day reuses the intermediates and only redoes the reduce || 素材ゼロ session の除外を外す | a session with no summarisable material is dropped from the facts block（対照の「…while a session of the same day that has material is still listed」と「a session with only assistant text, and no human prompt, is kept」は通り続ける） |
+| 段1 の中間サマリ再利用をやめる | re-running a day reuses the intermediates and only redoes the reduce |
+| `claude -p` から `--restricted` を外す | every -p call the digest makes carries --restricted |
+| 素材ゼロ session の除外を外す | a session with no summarisable material is dropped from the facts block（対照の「…while a session of the same day that has material is still listed」と「a session with only assistant text, and no human prompt, is kept」は通り続ける） |
 
 `-F` の判別には BRE 前提の fixture が要る。手元の git は `grep.patternType` 未設定で
 `--author` が BRE 既定になるため、`+` はリテラルであり、ERE 前提の偽 author

--- a/test/claude-digest.test.sh
+++ b/test/claude-digest.test.sh
@@ -279,6 +279,37 @@ nobase=88888888-8888-8888-8888-888888888888
   entry '2026-03-01T05:00:00.200Z' "$repo_c" 'feature/nobase'
 } >"$projects/-proj-b/$nobase.jsonl"
 
+# NOMATERIAL: a real cli session whose transcript holds nothing summarisable --
+# only system/attachment bookkeeping, no human prompt and no assistant text.
+# There is nothing to triage in it, so it must not reach the facts block at
+# all. Its cwd and branch are repo_a's, so it would certainly be listed if the
+# filter were absent.
+nomaterial=bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+{ jq -cn --arg cwd "$repo_a" \
+    '{type:"system", subtype:"local_command_output", entrypoint:"cli",
+      isSidechain:false, timestamp:"2026-03-01T03:00:00.100Z", cwd:$cwd,
+      gitBranch:"main", content:"<local-command-stdout></local-command-stdout>"}'
+  jq -cn --arg cwd "$repo_a" \
+    '{type:"attachment", entrypoint:"cli", isSidechain:false,
+      timestamp:"2026-03-01T03:00:01.100Z", cwd:$cwd, gitBranch:"main",
+      attachment:{type:"new_directory", path:"/tmp"}}'
+} >"$projects/-proj-a/$nomaterial.jsonl"
+
+# ASSISTANT_ONLY: no human turn at all, so it has neither an ai-title nor a
+# first prompt -- but it does carry assistant text, which is material. It is
+# the reason the drop above keys on material.jq rather than on the title or
+# the first prompt: either of those proxies would take this session with it.
+assistant_only=cccccccc-cccc-cccc-cccc-cccccccccccc
+{ jq -cn --arg cwd "$repo_a" \
+    '{type:"system", subtype:"local_command_output", entrypoint:"cli",
+      isSidechain:false, timestamp:"2026-03-01T03:10:00.100Z", cwd:$cwd,
+      gitBranch:"main", content:"<local-command-stdout></local-command-stdout>"}'
+  jq -cn --arg cwd "$repo_a" \
+    '{type:"assistant", entrypoint:"cli", isSidechain:false,
+      timestamp:"2026-03-01T03:11:00.100Z", cwd:$cwd, gitBranch:"main",
+      message:{role:"assistant", content:[{type:"text", text:"resumed and summarised the branch"}]}}'
+} >"$projects/-proj-a/$assistant_only.jsonl"
+
 # --------------------------------------------------------------------------
 run() {  # run <day>; prints the facts block
   env CLAUDE_PROJECTS_DIR="$projects" CLAUDE_DIGEST_DIR="$digests" \
@@ -458,6 +489,21 @@ check "a session with no surviving cwd is reported unreachable" \
 check "an entry with no gitBranch produces no branch line" \
   "$(if ! grep -qE '^OPEN_BRANCH: [^ ]+ +$' <<<"$d1"; then echo 0; else echo 1; fi)"
 
+# --- sessions with no summarisable material ---------------------------------
+# A session holding only system/attachment bookkeeping has nothing to triage,
+# so it is dropped before the facts block is built rather than listed with a
+# placeholder summary.
+check "a session with no summarisable material is dropped from the facts block" \
+  "$(if ! grep -q "SESSION $nomaterial" <<<"$d1"; then echo 0; else echo 1; fi)"
+# The control for the check above: without it, dropping every session would
+# pass just as well. "early" is in the same facts block and does carry material.
+check "...while a session of the same day that has material is still listed" \
+  "$(if grep -q "SESSION $early" <<<"$d1"; then echo 0; else echo 1; fi)"
+# The drop keys on material.jq, never on the title or the first prompt: this
+# session has neither (no ai-title, no human turn) and yet is full of material.
+check "a session with only assistant text, and no human prompt, is kept" \
+  "$(if grep -q "SESSION $assistant_only" <<<"$d1"; then echo 0; else echo 1; fi)"
+
 d0="$(run 2026-01-01)"; rc0=$?
 check "a day with no sessions still produces a facts block" \
   "$(if [ "$rc0" -eq 0 ] && grep -q '^# 2026-01-01' <<<"$d0" && grep -q '^- なし' <<<"$d0"
@@ -505,13 +551,16 @@ check "generate writes the day's digest" \
 check "stage 1 writes one intermediate per session" \
   "$(if [ -s "$digests/2026-03-01/$early.md" ] && [ -s "$digests/2026-03-01/$dup.md" ]
      then echo 0; else echo 1; fi)"
+# The dropped session never reaches stage 1 either, so no placeholder
+# intermediate is written for it.
+check "no intermediate is written for a session with no material" \
+  "$(if [ ! -e "$digests/2026-03-01/$nomaterial.md" ]; then echo 0; else echo 1; fi)"
 # The second run reuses every intermediate, so it costs exactly one more -p
 # call than the first: the reduce.
 check "re-running a day reuses the intermediates and only redoes the reduce" \
   "$(if [ "$g2" -eq 0 ] && [ "$(( calls2 - calls1 ))" -eq 1 ]; then echo 0; else echo 1; fi)"
 check "the reduce is handed the facts, not the raw transcripts" \
   "$(if grep -q "SHORT: ${early:0:8}" "$digests/2026-03-01.md"; then echo 0; else echo 1; fi)"
-
 # --- show mode --------------------------------------------------------------
 out="$(env CLAUDE_DIGEST_DIR="$digests" PATH="$stubdir:$PATH" "$bin" 2026-03-01 2>&1)"
 check "show prints the requested day" \

--- a/test/claude-digest.test.sh
+++ b/test/claude-digest.test.sh
@@ -22,7 +22,8 @@ mkdir -p "$projects/-proj-a" "$projects/-proj-b" "$digests"
 
 # --------------------------------------------------------------------------
 # The `claude` stub: serves the roster, and answers -p from stdin. It records
-# one line per -p call so the idempotency test can count them.
+# one line per -p call, carrying that call's whole argument list, so the tests
+# can both count the calls and assert which flags they carried.
 # --------------------------------------------------------------------------
 stubdir="$sandbox/stub"; mkdir -p "$stubdir"
 cat >"$stubdir/claude" <<'STUB'
@@ -31,7 +32,7 @@ case "${1:-}" in
   agents) cat "${CD_ROSTER:-/dev/null}"; exit 0 ;;
   -p)
     body="$(cat)"
-    printf '%s\n' "-p" >>"${CD_CALLS:-/dev/null}"
+    printf '%s\n' "$*" >>"${CD_CALLS:-/dev/null}"
     if printf '%s' "$body" | grep -q '事実ブロック'; then
       printf 'STUB-DIGEST\n'
       printf '%s\n' "$body" | grep -E '^(SHORT|LANDED_PR|OPEN_BRANCH):' || true
@@ -561,6 +562,13 @@ check "re-running a day reuses the intermediates and only redoes the reduce" \
   "$(if [ "$g2" -eq 0 ] && [ "$(( calls2 - calls1 ))" -eq 1 ]; then echo 0; else echo 1; fi)"
 check "the reduce is handed the facts, not the raw transcripts" \
   "$(if grep -q "SHORT: ${early:0:8}" "$digests/2026-03-01.md"; then echo 0; else echo 1; fi)"
+# Every -p call -- stage 1 and the reduce alike -- must carry --restricted, or
+# the user settings files load for it and each call is filed as a session that
+# ended for reason "other", silting up claude-queue's resumable list.
+restricted="$(grep -c -- '--restricted' "$sandbox/calls")"
+check "every -p call the digest makes carries --restricted" \
+  "$(if [ "$calls2" -gt 0 ] && [ "$restricted" -eq "$calls2" ]; then echo 0; else echo 1; fi)"
+
 # --- show mode --------------------------------------------------------------
 out="$(env CLAUDE_DIGEST_DIR="$digests" PATH="$stubdir:$PATH" "$bin" 2026-03-01 2>&1)"
 check "show prints the requested day" \


### PR DESCRIPTION
## Summary

`bin/claude-digest` に 2 つの修正を入れる。どちらも日報が「確認すべきもの」以外で
埋まるのを止めるもの。

### 1. 素材ゼロの session を日報から落とす（f22fc8d）

transcript に人間のプロンプトも assistant のテキストも無い session が、確認すべきことが
何も無いのに「確認すべき session」として並んでいた。2026-09-10 の日報では 9 件が末尾に
並び、27 行を占めた（いずれも `entrypoint == "cli"` の正規の session だが、中身は
`system` / `attachment` / `last-prompt` / `cost-state` だけの 10 行程度）。

判定は段1 が使う `material.jq` が既に持っていた（出力が空なら `claude -p` を呼ばず
`本文素材のないセッション。` というプレースホルダを書いていた）。判定を session 一覧が
確定する前へ前倒しし、空のものを `session_ids` から外す。到達不能になった段1 の
プレースホルダ分岐は削除した。

- **判定基準は既存のものをそのまま使う。** `title` の有無や `first_prompt` の有無で
  代用しない — assistant の発話だけを持つ session はそのどちらも欠くが素材はあるので、
  代用すると誤って落ちる
- **`--dry-run` の「何も書かない」は保たれる。** 抽出先は `mktemp -d` の作業ディレクトリで、
  `$digest_dir` 配下には触れない
- **中間サマリの再利用も変わらない。** 段1 は収集時に書かれた同じファイルを読み直すだけ

`claude -p` の呼び出し回数は変わらない（落とした分岐は元から LLM を呼んでいない）。

### 2. `claude -p` に `--restricted` を付ける（5e7976b）

日報は session 1 本につき `claude -p` を 1 回呼ぶが、その子 session が
`~/.claude/settings.json` の hook に登録され、終了理由が `other` になるため、
claude-queue の resumable 一覧（`C-q Q`）に「途中で切られた session」として積み上がって
いた。2026-09-11 朝の実行では 43 本中 41 本がこの形で載った。

同じ prompt（`printf 'reply with OK only' | claude -p --tools "" <flag>`）で `sessions`
テーブルの行数増分を測った実測:

| flag | 行の増分 | 出力 |
|---|---|---|
| （なし） | +1 | OK |
| `--no-session-persistence` | +1 | OK |
| `--settings '{"hooks":{}}'` | +1 | OK |
| `--bare` | +0 | 失敗（`Not logged in · Please run /login`） |
| `--restricted` | **+0** | OK |

`--restricted` は user / project / local の settings ファイルを無視するので claude-queue の
hook がロードされない。同時に落とすコマンド実行系ツールと WebFetch は、この呼び出しが
既に `--tools ""` なので影響しない。`--bare` は認証を `ANTHROPIC_API_KEY` のみに強制する
ため使えない。

## 検証

`test/claude-digest.test.sh` 58 件、`test/*.test.sh` 9 本すべて pass。CI の shellcheck job と
同じファイル一覧で `shellcheck -S warning` も clean。

追加したテスト（`--generate --dry-run` の出力に対して assert）:

- 素材ゼロの session（`system` / `attachment` だけを持つ）が事実ブロックに出ないこと
- **対照**: 同じ日の、素材を持つ session（`early`）は従来どおり出ること
- assistant のテキストだけを持ち人間のプロンプトが無い session は落ちないこと
- その session に段1 の中間サマリが書かれないこと
- `claude -p` の全呼び出しが `--restricted` を carry すること（stub が引数全体を記録する形へ変更）

既存の `--dry-run` が何も書かないことのガード、および中間サマリ再利用の冪等性テストは
そのまま pass している。

### 変異した箇所 → 落ちたテスト

`dot/claude/rules/evidence-over-guesswork.md` §4 に従い、新しいコード側を変異させて判別力を
確認した。

| 変異 | 落ちたテスト |
|---|---|
| `[ -s "$mat" ] \|\| continue` を外す | `a session with no summarisable material is dropped from the facts block` / `no intermediate is written for a session with no material` |
| `claude -p` から `--restricted` を外す | `every -p call the digest makes carries --restricted` |

1 つ目の変異では、対照である
`...while a session of the same day that has material is still listed` と
`a session with only assistant text, and no human prompt, is kept` は通り続けた
（フィルタが効きすぎていないことの確認）。

## Refs

- `docs/design/claude-digest.md` に「素材ゼロの session は一覧に載せない」と
  「LLM 呼び出しは `--restricted`」を追記した

🤖 Generated with [Claude Code](https://claude.com/claude-code)
